### PR TITLE
[codex] Ignore local OMX project memory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ build/
 .omx/metrics.json
 .omx/state/
 .omx/context/
+.omx/project-memory.json
 .omx/tmux-hook.json
 
 # IntelliJ IDEA


### PR DESCRIPTION
## Summary
- ignore .omx/project-memory.json as local Codex runtime memory

## Validation
- git diff --cached --check
- project-memory JSON validation