### PR TITLE
docs: align workshop baseline guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,10 +2,10 @@
 
 Backend examples using bluetape4k libraries.
 
-- Kotlin 2.3.20
-- Java 25
-- Spring Boot 4.0.3
-- bluetape4k 1.5.0-Beta2
+- Kotlin 2.3.21
+- Java 21
+- Spring Boot 4.0.6
+- bluetape4k 1.7.0
 
 ## Commands
 
@@ -48,10 +48,10 @@ names.
 
 ## Rules
 
-- Dependency versions live in `buildSrc/src/main/kotlin/Libs.kt`.
+- Dependency versions live in `gradle/libs.versions.toml`.
 - Package prefix: `io.bluetape4k.workshop.{module}.*`.
 - Tests are serialized by `TestMutexService` to avoid DB conflicts.
-- JVM uses ZGC, 2-4 GB heap, and preview features.
+- JVM uses the Java 21 toolchain, ZGC, 2-4 GB heap, and preview features.
 - Spring Boot modules use `springBoot { mainClass.set(...) }` and extend test
   dependencies from `compileOnly`/`runtimeOnly` where the repo already does so.
 - Common bluetape4k modules include logging, JUnit5, coroutines, Exposed, and

--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ Bluetape4k 라이브러리를 활용한 백엔드 예제 모음입니다.
 
 | 항목          | 버전               |
 |-------------|------------------|
-| Kotlin      | 2.3.20           |
-| Java        | 25               |
-| Spring Boot | 4.0.3            |
-| bluetape4k  | 1.5.0-SNAPSHOT   |
+| Kotlin      | 2.3.21           |
+| Java        | 21               |
+| Spring Boot | 4.0.6            |
+| bluetape4k  | 1.7.0            |
 | Gradle      | Kotlin DSL, 멀티모듈 |
 
 ## 빌드
@@ -80,6 +80,6 @@ flowchart LR
 
 ## 테스트
 
-- JUnit 5 + Kluent + MockK
+- JUnit 5 + bluetape4k-assertions + MockK
 - Testcontainers (MariaDB, MySQL, PostgreSQL, CockroachDB)
 - JVM: ZGC, `-Xms2G -Xmx4G`, `--enable-preview`


### PR DESCRIPTION
## DoD Completion Report - Daily bug scan workshop baseline docs

### Related Issue

N/A - daily automation scan of recent `develop` changes.

### Work Done

- Updated README baseline table to Kotlin 2.3.21, Java 21, Spring Boot 4.0.6, and bluetape4k 1.7.0.
- Replaced stale Kluent testing text with `bluetape4k-assertions`.
- Updated AGENTS.md so future agents follow the current version catalog and Java 21 baseline.

### Test Results

Repository: `bluetape4k-workshop`
Result: Gradle project loading passed.
Date: 2026-05-10

### Pre-PR Required Checks

| Item | Status |
|------|--------|
| Worktree used | PASS |
| 6-R Tier 1 security review | PASS |
| 6-R Tier 2 Ops/SRE review | PASS |
| 6-R Tier 3 structural review | PASS |
| 6-R Tier 4 Kotlin/code quality review | PASS |
| 6-R Tier 5 tests/types/silent failure review | PASS |
| 6-R Tier 6 performance/stability review | PASS |
| README.md updated | PASS |
| AGENTS.md updated | PASS |
| `git diff --check` | PASS |

### Verification

- `./gradlew help --no-daemon`
- `git diff --check`

### Commits

- `8c5ee1f1 Keep workshop docs aligned with current baselines`
