### PR TITLE
Stabilize workshop Nightly test runtime

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -50,11 +50,24 @@ jobs:
         with:
           gradle-version: wrapper
           cache-read-only: true
+      - name: Checkout bluetape4k projects
+        uses: actions/checkout@v4
+        with:
+          repository: bluetape4k/bluetape4k-projects
+          ref: develop
+          path: .bluetape4k-projects
+      - name: Build bluetape4k mock server images
+        working-directory: .bluetape4k-projects
+        run: ./gradlew :bluetape4k-mock-web-server:jibDockerBuild :bluetape4k-mock-webflux-server:jibDockerBuild --no-configuration-cache --max-workers=1
+        env:
+          GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
       - name: Run tests
         env:
           GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
           TESTCONTAINERS_RYUK_DISABLED: "true"
           DOCKER_HOST: "unix:///var/run/docker.sock"
+          DD_API_KEY: "test-api-key"
+          DD_APPLICATION_KEY: "test-application-key"
         run: ./gradlew test --continue --max-workers=1
       - name: Upload test results
         if: always()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -149,6 +149,18 @@ subprojects {
                 systemProperty("java.util.logging.manager", "org.jboss.logmanager.LogManager")
             }
 
+            // CI 기본 locale 은 `en` 처럼 국가가 없어 javax.money 기본 currency 를 해석하지 못합니다.
+            systemProperty("user.language", "en")
+            systemProperty("user.country", "US")
+
+            // Datadog registry auto-config 가 placeholder 를 그대로 URI 에 넣지 않도록 테스트 기본값을 제공합니다.
+            systemProperty("management.datadog.metrics.export.enabled", "false")
+            environment("DD_API_KEY", providers.environmentVariable("DD_API_KEY").orElse("test-api-key").get())
+            environment(
+                "DD_APPLICATION_KEY",
+                providers.environmentVariable("DD_APPLICATION_KEY").orElse("test-application-key").get()
+            )
+
             testLogging {
                 showExceptions = true
                 showCauses = true

--- a/reactive/mutiny/src/test/kotlin/io/bluetape4k/examples/mutiny/01_Basic_Uni.kt
+++ b/reactive/mutiny/src/test/kotlin/io/bluetape4k/examples/mutiny/01_Basic_Uni.kt
@@ -99,7 +99,7 @@ class UniBasicExamples {
         repeat(5) {
             deferred.subscribe().with { results.add(it) }
         }
-        results shouldBeEqualTo listOf(1, 2, 3, 4, 5)
+        results shouldBeEqualTo listOf(1L, 2L, 3L, 4L, 5L)
     }
 
     @Test
@@ -135,7 +135,7 @@ class UniBasicExamples {
         repeat(5) {
             uni.subscribe().with { results.add(it) }
         }
-        results shouldBeEqualTo listOf(10, 20, 30, 40, 50)
+        results shouldBeEqualTo listOf(10L, 20L, 30L, 40L, 50L)
     }
 
     // NOTE: 예외가 발생해도, onFailureCallback 이 없다면 예외를 rethrow 하지는 않는다

--- a/spring-boot/async-logging/src/test/resources/logback-test.xml
+++ b/spring-boot/async-logging/src/test/resources/logback-test.xml
@@ -36,7 +36,7 @@
 
     <!-- JSON 포맷으로 로그가 저장되는지 확인하기 위한 File Appender -->
     <appender name="FILE" class="ch.qos.logback.core.FileAppender">
-        <file>${LOG_FILE}</file>
+        <file>${LOG_PATH}/plain-app.log</file>
         <!-- Log 정보를 파일로 저장 시, JSON 포맷으로 변경하기 위해 logstash 를 사용합니다. -->
         <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
     </appender>
@@ -49,7 +49,7 @@
         <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
         <!-- Rolling file policy -->
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>${LOG_FILE}.%d{yyyy-MM-dd}</fileNamePattern>
+            <fileNamePattern>${LOG_PATH}/rolling-app.%d{yyyy-MM-dd}.log</fileNamePattern>
             <maxHistory>5</maxHistory>
             
         </rollingPolicy>


### PR DESCRIPTION
의존성 갱신 후 workshop develop Nightly에서 드러난 테스트 런타임 회귀를 정리합니다.

원인과 수정:
- CI test job에 bluetape4k-projects mock web server Docker image가 없어 `bluetape4k/mock-web-server:latest` pull 실패가 발생했습니다. Nightly test 전에 bluetape4k-projects develop을 checkout하고 `jibDockerBuild`로 `mock-web-server`/`mock-webflux-server` 이미지를 로컬 Docker에 준비합니다.
- GitHub runner 기본 locale이 `en`이라 `javax.money`가 기본 currency를 해석하지 못했습니다. Gradle test task에 `user.language=en`, `user.country=US`를 지정했습니다.
- Datadog 설정의 `DD_API_KEY`/`DD_APPLICATION_KEY` placeholder가 테스트에서 URI로 그대로 들어가거나 실제 export를 시도했습니다. test task에 dummy env를 제공하고 `management.datadog.metrics.export.enabled=false`로 export를 끕니다.
- Spring Boot 4 AOT가 `logback-test.xml`의 appender를 초기화하면서 `FILE`과 `ROLLING_FILE`이 같은 `logs/app.log`를 사용해 충돌했습니다. test logback의 plain/rolling file target을 분리했습니다.
- Kluent 제거 후 bluetape4k assertions가 리스트 element type까지 엄격히 비교하면서 Mutiny `Long` 결과를 `Int` 기대값과 비교하던 테스트가 실패했습니다. 기대값을 `Long`으로 맞췄습니다.

검증:
- `./gradlew :spring-boot-async-logging:test :reactive-mutiny:test :micrometer-observation:test --continue --max-workers=1 --no-daemon --no-configuration-cache --rerun-tasks --console=plain` 통과.
- `./gradlew :shared:test :spring-boot-async-logging:test :redis-redisson-examples:test :reactive-mutiny:test :virtualthreads-spring-mvc-tomcat:test :virtualthreads-spring-webflux:test :exposed-domain:test --tests "*Money*" :micrometer-observation:test --continue --max-workers=1 --no-daemon --no-configuration-cache --rerun-tasks --console=plain`에서 수정 전 실패 지점 확인 후, `shared`, `redis-redisson-examples`, `virtualthreads-spring-mvc-tomcat`, `virtualthreads-spring-webflux`, `exposed-domain` 통과 확인.