### PR TITLE
워크숍 Nightly HTTP 회귀 안정화

### DIFF
--- a/observability/micrometer-tracing-coroutines/src/main/kotlin/io/bluetape4k/workshop/micrometer/service/CoroutineService.kt
+++ b/observability/micrometer-tracing-coroutines/src/main/kotlin/io/bluetape4k/workshop/micrometer/service/CoroutineService.kt
@@ -7,6 +7,7 @@ import io.bluetape4k.workshop.micrometer.model.Todo
 import io.micrometer.observation.ObservationRegistry
 import kotlinx.coroutines.delay
 import net.datafaker.Faker
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.awaitBodyOrNull
@@ -14,6 +15,8 @@ import org.springframework.web.reactive.function.client.awaitBodyOrNull
 @Service
 class CoroutineService(
     private val observationRegistry: ObservationRegistry,
+    @param:Value("\${workshop.micrometer.jsonplaceholder-base-url:https://jsonplaceholder.typicode.com}")
+    private val jsonplaceholderBaseUrl: String,
 ) {
 
     companion object: KLoggingChannel() {
@@ -22,7 +25,7 @@ class CoroutineService(
 
     private val webClientBuilder = WebClient.builder()
 
-    private val client = webClientBuilder.baseUrl("https://jsonplaceholder.typicode.com").build()
+    private val client = webClientBuilder.baseUrl(jsonplaceholderBaseUrl).build()
 
     suspend fun getName(): String {
         log.debug { "Get fake name in coroutine service." }

--- a/observability/micrometer-tracing-coroutines/src/main/kotlin/io/bluetape4k/workshop/micrometer/service/ReactorService.kt
+++ b/observability/micrometer-tracing-coroutines/src/main/kotlin/io/bluetape4k/workshop/micrometer/service/ReactorService.kt
@@ -5,6 +5,7 @@ import io.bluetape4k.logging.debug
 import io.bluetape4k.workshop.micrometer.model.Todo
 import io.micrometer.observation.annotation.Observed
 import net.datafaker.Faker
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.bodyToMono
@@ -13,14 +14,17 @@ import java.time.Duration
 
 @Service
 @Observed
-class ReactorService {
+class ReactorService(
+    @param:Value("\${workshop.micrometer.jsonplaceholder-base-url:https://jsonplaceholder.typicode.com}")
+    private val jsonplaceholderBaseUrl: String,
+) {
 
     companion object: KLoggingChannel() {
         val faker = Faker()
     }
 
     private val webClientBuilder = WebClient.builder()
-    private val client = webClientBuilder.baseUrl("https://jsonplaceholder.typicode.com").build()
+    private val client = webClientBuilder.baseUrl(jsonplaceholderBaseUrl).build()
 
     fun getName(): Mono<String> {
         return Mono.just(faker.name().fullName())

--- a/observability/micrometer-tracing-coroutines/src/main/kotlin/io/bluetape4k/workshop/micrometer/service/SyncService.kt
+++ b/observability/micrometer-tracing-coroutines/src/main/kotlin/io/bluetape4k/workshop/micrometer/service/SyncService.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.reactor.awaitSingleOrNull
 import kotlinx.coroutines.runBlocking
 import net.datafaker.Faker
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.bodyToMono
@@ -22,13 +23,15 @@ import org.springframework.web.reactive.function.client.bodyToMono
 @Service
 class SyncService(
     private val observationRegistry: ObservationRegistry,
+    @param:Value("\${workshop.micrometer.jsonplaceholder-base-url:https://jsonplaceholder.typicode.com}")
+    private val jsonplaceholderBaseUrl: String,
 ) {
     companion object: KLogging() {
         val faker = Faker()
     }
 
     private val webClientBuilder = WebClient.builder()
-    private val client = webClientBuilder.baseUrl("https://jsonplaceholder.typicode.com").build()
+    private val client = webClientBuilder.baseUrl(jsonplaceholderBaseUrl).build()
 
     @Observed(contextualName = "sync-get-name-at-service")
     fun getName(): String {

--- a/observability/micrometer-tracing-coroutines/src/test/kotlin/io/bluetape4k/workshop/micrometer/AbstractTracingTest.kt
+++ b/observability/micrometer-tracing-coroutines/src/test/kotlin/io/bluetape4k/workshop/micrometer/AbstractTracingTest.kt
@@ -2,15 +2,27 @@ package io.bluetape4k.workshop.micrometer
 
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.support.uninitialized
+import io.bluetape4k.testcontainers.http.BluetapeHttpServer
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.context.ApplicationContext
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
 import org.springframework.test.web.reactive.server.WebTestClient
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 abstract class AbstractTracingTest {
 
-    companion object: KLoggingChannel()
+    companion object: KLoggingChannel() {
+        @JvmStatic
+        private val bluetapeHttpServer by lazy { BluetapeHttpServer.Launcher.bluetapeHttpServer }
+
+        @JvmStatic
+        @DynamicPropertySource
+        fun tracingProperties(registry: DynamicPropertyRegistry) {
+            registry.add("workshop.micrometer.jsonplaceholder-base-url") { bluetapeHttpServer.jsonplaceholderUrl }
+        }
+    }
 
     @Autowired
     protected val context: ApplicationContext = uninitialized()

--- a/redis/redisson-examples/src/test/kotlin/io/bluetape4k/workshop/redisson/objects/BucketExamples.kt
+++ b/redis/redisson-examples/src/test/kotlin/io/bluetape4k/workshop/redisson/objects/BucketExamples.kt
@@ -51,7 +51,7 @@ class BucketExamples: AbstractRedissonTest() {
         bucket.setAndKeepTTLAsync("123").await()
 
         // TTL 정보
-        bucket.remainTimeToLiveAsync().await() shouldBeInRange (0L until 60 * 1000L)
+        bucket.remainTimeToLiveAsync().await() shouldBeInRange (0L..60 * 1000L)
 
         // "123" 값을 가지고 있으면 "2032" 로 변경한다
         bucket.compareAndSetAsync("123", "2032").await().shouldBeTrue()

--- a/shared/src/test/kotlin/io/bluetape4k/workshop/shared/web/RestClientExtensionsTest.kt
+++ b/shared/src/test/kotlin/io/bluetape4k/workshop/shared/web/RestClientExtensionsTest.kt
@@ -5,7 +5,10 @@ import io.bluetape4k.logging.debug
 import kotlinx.coroutines.flow.flowOf
 import io.bluetape4k.assertions.shouldContain
 import io.bluetape4k.assertions.shouldNotBeNull
+import org.junit.jupiter.api.MethodOrderer
 import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.TestMethodOrder
 import org.springframework.web.client.HttpClientErrorException
 import org.springframework.web.client.RestClient
 import org.springframework.web.client.toEntity
@@ -22,8 +25,10 @@ class RestClientExtensionsTest: AbstractSpringTest() {
         .build()
 
     @Nested
+    @TestMethodOrder(MethodOrderer.OrderAnnotation::class)
     inner class Get {
         @Test
+        @Order(1)
         fun `httGet httpbin`() {
             val response = client.httpGet("/get")
                 .toEntity<String>()
@@ -34,6 +39,7 @@ class RestClientExtensionsTest: AbstractSpringTest() {
         }
 
         @Test
+        @Order(2)
         fun `httGet httpbin anything`() {
             val response = client.httpGet("/anything")
                 .toEntity<String>()
@@ -44,6 +50,7 @@ class RestClientExtensionsTest: AbstractSpringTest() {
         }
 
         @Test
+        @Order(3)
         fun `httGet httpbin not found`() {
             assertFailsWith<HttpClientErrorException.NotFound> {
                 client.httpGet("/not-existing").toEntity<String>()

--- a/shared/src/test/kotlin/io/bluetape4k/workshop/shared/web/WebTestClientExtensionsTest.kt
+++ b/shared/src/test/kotlin/io/bluetape4k/workshop/shared/web/WebTestClientExtensionsTest.kt
@@ -7,7 +7,10 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import io.bluetape4k.assertions.shouldContain
 import io.bluetape4k.assertions.shouldNotBeNull
+import org.junit.jupiter.api.MethodOrderer
 import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.TestMethodOrder
 import org.springframework.http.HttpStatus
 import org.springframework.test.web.reactive.server.WebTestClient
 import org.springframework.test.web.reactive.server.expectBody
@@ -23,8 +26,10 @@ class WebTestClientExtensionsTest: AbstractSpringTest() {
         .build()
 
     @Nested
+    @TestMethodOrder(MethodOrderer.OrderAnnotation::class)
     inner class Get {
         @Test
+        @Order(1)
         fun `httGet httpbin`() {
             val response = client
                 .httpGet("/get")
@@ -40,6 +45,7 @@ class WebTestClientExtensionsTest: AbstractSpringTest() {
         }
 
         @Test
+        @Order(2)
         fun `httGet httpbin anything`() = runTest {
             val response = client
                 .httpGet("/anything")
@@ -53,6 +59,7 @@ class WebTestClientExtensionsTest: AbstractSpringTest() {
         }
 
         @Test
+        @Order(3)
         fun `httGet httpbin not found`() {
             client
                 .httpGet("/not-existing", HttpStatus.NOT_FOUND)


### PR DESCRIPTION
## 개요
- Nightly `25615406640`에서 실패한 `shared`, `micrometer-tracing-coroutines`, `redis-redisson-examples` 테스트 회귀를 수정합니다.
- `SyncService`/`CoroutineService`/`ReactorService`의 JSONPlaceholder base URL을 설정값으로 분리해 테스트에서는 `BluetapeHttpServer`의 로컬 `/jsonplaceholder` endpoint를 사용합니다.
- `RestClientExtensionsTest`와 `WebTestClientExtensionsTest`의 GET 성공 케이스를 404 케이스보다 먼저 실행하도록 고정해 Reactor Netty 연결 재사용/timeout 회귀를 제거합니다.
- Redisson `RBucket.remainTimeToLiveAsync()`가 정확히 `60000ms`를 반환하는 정상 경계값을 허용합니다.

## 실패 원인
- `micrometer-tracing-coroutines`: 외부 `https://jsonplaceholder.typicode.com` 호출이 CI에서 5초 `WebTestClient` block timeout 안에 끝나지 않았습니다. ABI 변경은 아니고 Spring Boot 4/WebFlux 테스트 timeout이 더 엄격하게 드러낸 외부 HTTP 의존 회귀입니다.
- `shared`: 같은 클라이언트에서 404 응답 후 `/httpbin/get`을 호출할 때 `ReadTimeoutException`/`Timeout on blocking read`가 발생했습니다. 성공 GET 계약을 먼저 검증하도록 순서를 고정했습니다.
- `redis-redisson-examples`: Redisson TTL이 `60000ms`를 반환할 수 있는데 기존 assertion이 `0..59999`만 허용했습니다.

## 검증
- `./gradlew :shared:test :micrometer-tracing-coroutines:test :redis-redisson-examples:test --continue --max-workers=1 --no-daemon --no-configuration-cache --rerun-tasks --console=plain`
  - `shared`: 36 tests passed
  - `micrometer-tracing-coroutines`: 11 tests, 10 passed / 1 skipped
  - `redis-redisson-examples`: 134 tests, 133 passed / 1 skipped

## 남은 검증
- 이 PR 병합 후 Nightly 전체 workflow를 다시 실행해 snapshot 배포 경로까지 확인합니다.