### PR TITLE
[codex] Use version catalogs for bluetape4k dependencies

### DIFF
--- a/exposed/dao-web-transaction/build.gradle.kts
+++ b/exposed/dao-web-transaction/build.gradle.kts
@@ -34,7 +34,7 @@ dependencies {
     implementation(libs.bluetape4k.jdbc)
 
     // Exposed
-    implementation(libs.bluetape4k.exposed.lib)
+    implementation(libs.bluetape4k.exposed.core)
     implementation(libs.exposed.core)
     implementation(libs.exposed.dao)
     implementation(libs.exposed.kotlin.datetime)

--- a/exposed/domain/build.gradle.kts
+++ b/exposed/domain/build.gradle.kts
@@ -11,7 +11,7 @@ dependencies {
 
     testImplementation(project(":shared"))
 
-    implementation(libs.bluetape4k.exposed.lib)
+    implementation(libs.bluetape4k.exposed.core)
     implementation(libs.bluetape4k.exposed.jackson3)
     testImplementation(libs.bluetape4k.exposed.jdbc.tests)
 

--- a/exposed/spring-transaction/build.gradle.kts
+++ b/exposed/spring-transaction/build.gradle.kts
@@ -13,7 +13,7 @@ dependencies {
     implementation(project(":exposed-domain"))
 
     // Exposed
-    implementation(libs.bluetape4k.exposed.lib)
+    implementation(libs.bluetape4k.exposed.core)
     implementation(libs.exposed.core)
     implementation(libs.exposed.dao)
     implementation(libs.exposed.jdbc)

--- a/exposed/sql-web-virtualthread/build.gradle.kts
+++ b/exposed/sql-web-virtualthread/build.gradle.kts
@@ -35,7 +35,7 @@ dependencies {
     implementation(libs.bluetape4k.jdbc)
 
     // Exposed
-    implementation(libs.bluetape4k.exposed.lib)
+    implementation(libs.bluetape4k.exposed.core)
     implementation(libs.exposed.core)
     implementation(libs.exposed.jdbc)
     implementation(libs.exposed.dao)

--- a/exposed/sql-webflux-coroutines/build.gradle.kts
+++ b/exposed/sql-webflux-coroutines/build.gradle.kts
@@ -30,7 +30,7 @@ dependencies {
     implementation(libs.bluetape4k.jdbc)
 
     // Exposed
-    implementation(libs.bluetape4k.exposed.lib)
+    implementation(libs.bluetape4k.exposed.core)
     implementation(libs.exposed.core)
     implementation(libs.exposed.dao)
     implementation(libs.exposed.jdbc)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -194,10 +194,10 @@ bluetape4k-protobuf = { module = "io.github.bluetape4k:bluetape4k-protobuf" , ve
 bluetape4k-retrofit2 = { module = "io.github.bluetape4k:bluetape4k-retrofit2" , version.ref = "bluetape4k" }
 bluetape4k-vertx = { module = "io.github.bluetape4k:bluetape4k-vertx" , version.ref = "bluetape4k" }
 bluetape4k-cassandra = { module = "io.github.bluetape4k:bluetape4k-cassandra" , version.ref = "bluetape4k" }
-bluetape4k-exposed-lib = { module = "io.github.bluetape4k:bluetape4k-exposed" , version.ref = "bluetape4k" }
-bluetape4k-exposed-jackson3 = { module = "io.github.bluetape4k:bluetape4k-exposed-jackson3" , version.ref = "bluetape4k" }
-bluetape4k-exposed-jdbc-tests = { module = "io.github.bluetape4k:bluetape4k-exposed-jdbc-tests" , version.ref = "bluetape4k" }
-bluetape4k-exposed-r2dbc = { module = "io.github.bluetape4k:bluetape4k-exposed-r2dbc" , version.ref = "bluetape4k" }
+bluetape4k-exposed-core = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-core" , version.ref = "bluetape4k" }
+bluetape4k-exposed-jackson3 = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-jackson3" , version.ref = "bluetape4k" }
+bluetape4k-exposed-jdbc-tests = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-jdbc-tests" , version.ref = "bluetape4k" }
+bluetape4k-exposed-r2dbc = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-r2dbc" , version.ref = "bluetape4k" }
 bluetape4k-hibernate = { module = "io.github.bluetape4k:bluetape4k-hibernate" , version.ref = "bluetape4k" }
 bluetape4k-jdbc = { module = "io.github.bluetape4k:bluetape4k-jdbc" , version.ref = "bluetape4k" }
 bluetape4k-mongodb = { module = "io.github.bluetape4k:bluetape4k-mongodb" , version.ref = "bluetape4k" }


### PR DESCRIPTION
## What changed

- Renamed the workshop exposed core catalog alias to `bluetape4k-exposed-core`.
- Updated bluetape4k-exposed artifact aliases to the `io.github.bluetape4k.exposed:*` group.
- Replaced exposed module references with `libs.bluetape4k.exposed.core`.

## Why

This keeps workshop Exposed dependencies aligned with the bluetape4k-exposed artifact layout and avoids stale legacy coordinates.

## Validation

- `./gradlew help --no-daemon`
- `rg` scan for direct bluetape4k build-script coordinates
- `git diff --check`

## Notes

Full module test suites were not run.