### PR TITLE
Nightly를 smoke/full lane으로 분리

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2,8 +2,18 @@ name: Nightly
 
 on:
   schedule:
-    - cron: '0 19 * * *'  # 매일 UTC 19:00 (KST 04:00)
+    - cron: '0 19 * * 1-6'  # Daily smoke, UTC 19:00 (KST 04:00) Mon-Sat
+    - cron: '0 19 * * 0'    # Weekly full, UTC 19:00 (KST 04:00) Sunday
   workflow_dispatch:
+    inputs:
+      scope:
+        description: 'Nightly scope to run'
+        required: true
+        type: choice
+        default: full
+        options:
+          - smoke
+          - full
 
 env:
   JAVA_VERSION: '21'
@@ -38,6 +48,8 @@ jobs:
 
   test:
     name: Test (Testcontainers)
+    if: ${{ (github.event_name == 'schedule' && github.event.schedule == '0 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
+
     runs-on: ubuntu-latest
     needs: build
     steps:


### PR DESCRIPTION
## 변경 사항

- Nightly schedule을 daily smoke와 weekly full로 분리했습니다.
- workflow_dispatch에 scope 입력을 추가했습니다.
- 고비용 컨테이너/외부 런타임/예제/coverage 집계 job은 scope=full에서만 실행되도록 gate를 추가했습니다.

## 검증

- actionlint .github/workflows/nightly.yml
- git diff --check

Refs bluetape4k/.github#2