### PR TITLE
fix: Restore Exposed DAO workshop dependencies

### DIFF
--- a/exposed/dao-web-transaction/build.gradle.kts
+++ b/exposed/dao-web-transaction/build.gradle.kts
@@ -35,6 +35,7 @@ dependencies {
 
     // Exposed
     implementation(libs.bluetape4k.exposed.core)
+    implementation(libs.bluetape4k.exposed.dao)
     implementation(libs.exposed.core)
     implementation(libs.exposed.dao)
     implementation(libs.exposed.kotlin.datetime)

--- a/exposed/domain/build.gradle.kts
+++ b/exposed/domain/build.gradle.kts
@@ -12,6 +12,7 @@ dependencies {
     testImplementation(project(":shared"))
 
     implementation(libs.bluetape4k.exposed.core)
+    implementation(libs.bluetape4k.exposed.dao)
     implementation(libs.bluetape4k.exposed.jackson3)
     testImplementation(libs.bluetape4k.exposed.jdbc.tests)
 

--- a/exposed/sql-web-virtualthread/build.gradle.kts
+++ b/exposed/sql-web-virtualthread/build.gradle.kts
@@ -36,6 +36,7 @@ dependencies {
 
     // Exposed
     implementation(libs.bluetape4k.exposed.core)
+    implementation(libs.bluetape4k.exposed.dao)
     implementation(libs.exposed.core)
     implementation(libs.exposed.jdbc)
     implementation(libs.exposed.dao)

--- a/exposed/sql-webflux-coroutines/build.gradle.kts
+++ b/exposed/sql-webflux-coroutines/build.gradle.kts
@@ -31,6 +31,7 @@ dependencies {
 
     // Exposed
     implementation(libs.bluetape4k.exposed.core)
+    implementation(libs.bluetape4k.exposed.dao)
     implementation(libs.exposed.core)
     implementation(libs.exposed.dao)
     implementation(libs.exposed.jdbc)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -195,6 +195,7 @@ bluetape4k-retrofit2 = { module = "io.github.bluetape4k:bluetape4k-retrofit2" , 
 bluetape4k-vertx = { module = "io.github.bluetape4k:bluetape4k-vertx" , version.ref = "bluetape4k" }
 bluetape4k-cassandra = { module = "io.github.bluetape4k:bluetape4k-cassandra" , version.ref = "bluetape4k" }
 bluetape4k-exposed-core = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-core" , version.ref = "bluetape4k" }
+bluetape4k-exposed-dao = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-dao" , version.ref = "bluetape4k" }
 bluetape4k-exposed-jackson3 = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-jackson3" , version.ref = "bluetape4k" }
 bluetape4k-exposed-jdbc-tests = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-jdbc-tests" , version.ref = "bluetape4k" }
 bluetape4k-exposed-r2dbc = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-r2dbc" , version.ref = "bluetape4k" }


### PR DESCRIPTION
## Summary
- add the `bluetape4k-exposed-dao` catalog alias
- wire the DAO helper dependency into workshop modules that import `io.bluetape4k.exposed.dao.*` helpers

## Root cause
The Nightly governance PR surfaced an existing CI compile failure: several Exposed workshop modules used DAO helper functions such as `idEquals`, `idHashCode`, and `entityToStringBuilder` without declaring the artifact that provides them.

## Validation
- `./gradlew :exposed-domain:compileKotlin :exposed-dao-web-transaction:compileKotlin :exposed-sql-web-virtualthread:compileKotlin :exposed-sql-webflux-coroutines:compileKotlin --no-daemon --no-configuration-cache`
- `git diff --check origin/develop...HEAD`