### PR TITLE
docs: Normalize lessons capture guidance

### DIFF
--- a/docs/lessons/2026-05-11-nightly-exposed-dao-dependencies.md
+++ b/docs/lessons/2026-05-11-nightly-exposed-dao-dependencies.md
@@ -1,0 +1,32 @@
+# Nightly Changes Can Surface Existing Compile Drift
+
+## Context
+
+The bluetape4k-workshop Nightly workflow was split into smoke and full lanes.
+The PR exposed a pre-existing CI compile failure in Exposed workshop modules.
+
+## Decision or Finding
+
+When a workflow-only PR fails compile, inspect the failing source before
+assuming the workflow change caused the failure. CI may reveal dependency drift
+that local incremental builds have hidden.
+
+## Outcome
+
+Modules importing `io.bluetape4k.exposed.dao.*` helper functions now declare the
+`bluetape4k-exposed-dao` dependency explicitly.
+
+## Verification
+
+- Local compile succeeded for:
+  - `:exposed-domain:compileKotlin`
+  - `:exposed-dao-web-transaction:compileKotlin`
+  - `:exposed-sql-web-virtualthread:compileKotlin`
+  - `:exposed-sql-webflux-coroutines:compileKotlin`
+- PR #29 CI succeeded.
+
+## Future Guidance
+
+- Treat workflow PR failures as real repository signals.
+- Check imported helper packages against declared module dependencies.
+- Keep dependency aliases catalog-managed so module builds stay explicit.

--- a/docs/lessons/README.md
+++ b/docs/lessons/README.md
@@ -1,0 +1,15 @@
+# Lessons
+
+Store durable bluetape4k-workshop lessons in this directory.
+
+Use this structure for each lesson:
+
+- Context
+- Decision or Finding
+- Outcome
+- Verification
+- Future Guidance
+
+Name files as `YYYY-MM-DD-{slug}.md`. Promote repeated rules to `AGENTS.md`,
+workflow docs, or a narrower skill. Keep transient `.omx` notes out of this
+directory unless they have been deliberately promoted.


### PR DESCRIPTION
## 요약
- `docs/lessons/README.md`를 추가해 repo-local Lessons 작성 기준을 명시했습니다.
- 중요한 작업/실패/검증 결과는 `docs/lessons/YYYY-MM-DD-{slug}.md`로 남기고, 반복 규칙은 `AGENTS.md`나 workflow 문서로 승격하도록 정리했습니다.

## 검증
- `git diff --check`

Related to bluetape4k/.github#4.