### PR TITLE
docs: Document Kover coverage policy

### DIFF
--- a/docs/governance/kover-coverage-policy.md
+++ b/docs/governance/kover-coverage-policy.md
@@ -1,0 +1,25 @@
+# Kover Coverage Policy
+
+## Current Status
+
+`bluetape4k-workshop` is a workshop/demo repository and does not enforce Kover
+coverage thresholds.
+
+## Policy
+
+Status: documented workshop/demo exception.
+
+The repository demonstrates bluetape4k integrations across many frameworks and
+runtime combinations. Build and test health are the primary signals; coverage is
+not a production release gate.
+
+## Threshold Plan
+
+- Keep examples compiling and tests passing.
+- Add local coverage checks only for examples that become reusable production
+  templates.
+
+## CI/Nightly Contract
+
+CI/Nightly run build/test signals. No `koverVerify` task is required unless a
+module is promoted from demo code to a maintained template.


### PR DESCRIPTION
## 요약
- repo-local Kover coverage policy를 추가했습니다.
- 현재 상태를 enforced/report-only/exception으로 명시했습니다.
- failing `koverVerify` gate는 baseline 측정 후 module-level로 추가한다는 threshold plan을 남겼습니다.

## 검증
- `git diff --check`

Related to bluetape4k/.github#1.