### PR TITLE
chore: Redis client major 업데이트 guard 추가

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -52,6 +52,13 @@ updates:
       - dependency-name: "org.springframework.boot:*"
         update-types:
           - "version-update:semver-major"
+      # Redis client major baselines follow bluetape4k-projects after validation.
+      - dependency-name: "io.lettuce:lettuce-core"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "org.redisson:*"
+        update-types:
+          - "version-update:semver-major"
       - dependency-name: "org.apache.kafka:*"
         update-types:
           - "version-update:semver-major"


### PR DESCRIPTION
## 요약
- Redis client(Lettuce/Redisson) semver-major Dependabot PR을 자동 생성하지 않도록 설정했습니다.
- Redis client major baseline은 `bluetape4k-projects`에서 먼저 검증한 뒤 다른 repo로 정렬하는 정책을 따릅니다.

## 검증
- Ruby YAML parse 통과
- 중앙 version drift report에서 Lettuce/Redisson 정렬 확인