### PR TITLE
fix: Ignite 2 compatibility alias 복구

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -86,7 +86,7 @@ opentelemetry-instrumentation-alpha = "2.27.0-alpha"  # https://mvnrepository.co
 caffeine = "3.2.4"  # https://mvnrepository.com/artifact/com.github.ben-manes.caffeine/caffeine
 ehcache = "3.12.0"  # https://mvnrepository.com/artifact/org.ehcache/ehcache
 cache2k = "2.6.1.Final"  # https://mvnrepository.com/artifact/org.cache2k/cache2k-api
-ignite = "3.1.0"  # https://mvnrepository.com/artifact/org.apache.ignite/ignite-core
+ignite = "2.18.0"  # https://mvnrepository.com/artifact/org.apache.ignite/ignite-core
 hazelcast = "5.6.0"  # https://mvnrepository.com/artifact/com.hazelcast/hazelcast
 
 cassandra = "4.19.2"  # https://mvnrepository.com/artifact/org.apache.cassandra/java-driver-core


### PR DESCRIPTION
## 요약
- `ignite` alias를 Apache Ignite 2.x 라인인 `2.18.0`으로 복구
- Dependabot의 Apache Ignite 3.x 교차 라인 업그레이드를 되돌림

## 검증
- `./gradlew help --no-daemon`

## 참고
- Full repository test suite는 실행하지 않음