### PR TITLE
chore: Kover 강제 게이트 정책 제거

### DIFF
--- a/docs/governance/kover-coverage-policy.md
+++ b/docs/governance/kover-coverage-policy.md
@@ -16,10 +16,10 @@ not a production release gate.
 ## Threshold Plan
 
 - Keep examples compiling and tests passing.
-- Add local coverage checks only for examples that become reusable production
-  templates.
+- Use coverage reports only as an informational signal when an example becomes a
+  reusable production template.
 
 ## CI/Nightly Contract
 
-CI/Nightly run build/test signals. No `koverVerify` task is required unless a
-module is promoted from demo code to a maintained template.
+CI/Nightly run build/test signals. Coverage reports, if added, must remain
+informational and must not introduce a failing threshold by default.


### PR DESCRIPTION
## Summary
- workshop coverage 정책을 report-only로 정리
- demo/template coverage가 fixed threshold gate로 CI/Nightly를 실패시키지 않도록 문서화

## Verification
- git diff --check
- workspace rg: non-leader active workflows contain no koverVerify/minBound/Verify Kover threshold steps

Not-tested: 문서 전용 변경이라 Gradle build는 실행하지 않았습니다.

Co-authored-by: OmX <omx@oh-my-codex.dev>