### PR TITLE
[fix] Exposed 테스트 helper 의존성 복구

### DIFF
--- a/docs/lessons/2026-05-12-exposed-jdbc-helper-dependency.md
+++ b/docs/lessons/2026-05-12-exposed-jdbc-helper-dependency.md
@@ -1,0 +1,24 @@
+# Exposed JDBC Helper Dependency Lessons
+
+## Context
+
+daily bug scan에서 `bluetape4k-workshop` develop 변경을 6-Tier로 재검토했다. 최근 dependency alignment는 `exposed/domain`에 `bluetape4k-exposed-dao`를 추가했지만, 기존 test source는 `io.bluetape4k.exposed.jdbc.selectImplicitAll` extension을 계속 사용하고 있었다.
+
+## Decision or Finding
+
+`exposed/domain:compileTestKotlin`은 `io.bluetape4k.exposed.jdbc.selectImplicitAll` import를 해석하지 못해 실패했다. `bluetape4k-exposed-jdbc-tests`는 test fixture 계약을 제공하지만, main JDBC helper extension artifact를 대신하지 않는다.
+
+## Outcome
+
+- `gradle/libs.versions.toml`에 `bluetape4k-exposed-jdbc` alias를 추가했다.
+- `exposed/domain` test dependency에 `libs.bluetape4k.exposed.jdbc`를 추가해 `selectImplicitAll` helper를 명시적으로 가져오도록 했다.
+
+## Verification
+
+- 실패 재현: `./gradlew :exposed-domain:compileTestKotlin --no-configuration-cache --stacktrace`
+- 수정 후 통과: `repo-test-summary -- ./gradlew :exposed-domain:compileTestKotlin :exposed-sql-web-virtualthread:testClasses --continue`
+
+## Future Guidance
+
+- `bluetape4k-exposed-dao`를 추가해도 JDBC DSL helper까지 자동으로 들어온다고 가정하지 않는다.
+- `bluetape4k-exposed-jdbc-tests`와 `bluetape4k-exposed-jdbc`는 역할이 다르다. test source가 `io.bluetape4k.exposed.jdbc.*` main helper를 import하면 `bluetape4k-exposed-jdbc` dependency를 명시한다.

--- a/exposed/domain/build.gradle.kts
+++ b/exposed/domain/build.gradle.kts
@@ -13,6 +13,7 @@ dependencies {
 
     implementation(libs.bluetape4k.exposed.core)
     implementation(libs.bluetape4k.exposed.dao)
+    testImplementation(libs.bluetape4k.exposed.jdbc)
     implementation(libs.bluetape4k.exposed.jackson3)
     testImplementation(libs.bluetape4k.exposed.jdbc.tests)
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -196,6 +196,7 @@ bluetape4k-vertx = { module = "io.github.bluetape4k:bluetape4k-vertx" , version.
 bluetape4k-cassandra = { module = "io.github.bluetape4k:bluetape4k-cassandra" , version.ref = "bluetape4k" }
 bluetape4k-exposed-core = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-core" , version.ref = "bluetape4k" }
 bluetape4k-exposed-dao = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-dao" , version.ref = "bluetape4k" }
+bluetape4k-exposed-jdbc = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-jdbc" , version.ref = "bluetape4k" }
 bluetape4k-exposed-jackson3 = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-jackson3" , version.ref = "bluetape4k" }
 bluetape4k-exposed-jdbc-tests = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-jdbc-tests" , version.ref = "bluetape4k" }
 bluetape4k-exposed-r2dbc = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-r2dbc" , version.ref = "bluetape4k" }


### PR DESCRIPTION
## 요약
- `exposed-domain` test source가 사용하는 `io.bluetape4k.exposed.jdbc.selectImplicitAll` helper 의존성을 명시했습니다.
- `bluetape4k-exposed-jdbc` catalog alias를 추가하고 `exposed/domain` test dependency로 연결했습니다.
- daily bug scan lesson을 추가했습니다.

## 6-Tier Review
- Security: dependency 추가는 test scope이며 secret/권한 변경 없음. P0/P1=0.
- Ops/SRE: `compileTestKotlin` 실패를 직접 재현하고 복구. P0/P1=0.
- Structural: `exposed-jdbc-tests`와 `exposed-jdbc` 역할을 분리해 dependency boundary를 명시. P0/P1=0.
- Kotlin/Code Quality: source import는 유지하고 classpath만 복구. P0/P1=0.
- Tests/Types/Silent Failure: 실패 재현 후 targeted compile 통과. P0/P1=0.
- Performance/Stability: runtime path 변경 없음. P0/P1=0.

## 검증
- 실패 재현: `./gradlew :exposed-domain:compileTestKotlin --no-configuration-cache --stacktrace`
- 통과: `repo-test-summary -- ./gradlew :exposed-domain:compileTestKotlin :exposed-sql-web-virtualthread:testClasses --continue`
- `git diff --check`
- `qmd update`
- `qmd embed --max-docs-per-batch 10`

## 미실행
- 전체 workshop build는 실행하지 않았습니다.