### PR TITLE
[fix] exposed-domain JDBC helper 테스트 의존성 복구

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ Bluetape4k 라이브러리를 활용한 백엔드 예제 모음입니다.
 ./gradlew detekt                         # 정적 분석
 ```
 
+`exposed-domain` 테스트는 `io.bluetape4k.exposed.jdbc.selectImplicitAll` 같은
+main JDBC helper extension을 직접 검증합니다. `bluetape4k-exposed-jdbc-tests`는
+test fixture 계약만 제공하므로, 해당 테스트 모듈에는 `bluetape4k-exposed-jdbc`
+test dependency도 함께 선언해야 합니다.
+
 ## 전체 모듈 구성
 
 ```mermaid

--- a/docs/lessons/2026-05-12-exposed-jdbc-helper-test-dependency.md
+++ b/docs/lessons/2026-05-12-exposed-jdbc-helper-test-dependency.md
@@ -1,0 +1,32 @@
+# exposed-domain JDBC helper test dependency
+
+## Context
+
+`exposed-domain` tests import `io.bluetape4k.exposed.jdbc.selectImplicitAll` while
+also depending on `bluetape4k-exposed-jdbc-tests`.
+
+## Decision or Finding
+
+The `*-jdbc-tests` artifact provides shared test contracts and fixtures, but it
+does not replace the main `bluetape4k-exposed-jdbc` artifact that owns JDBC
+helper extensions.
+
+## Outcome
+
+The version catalog now exposes `bluetape4k-exposed-jdbc`, and
+`exposed-domain` declares it as a test dependency alongside
+`bluetape4k-exposed-jdbc-tests`.
+
+## Verification
+
+Run:
+
+```bash
+./gradlew :exposed-domain:compileTestKotlin --continue
+```
+
+## Future Guidance
+
+When a workshop test imports production helper extensions from a bluetape4k
+module, declare the production artifact explicitly. Do not assume a `*-tests`
+artifact exports production helpers transitively.

--- a/exposed/domain/build.gradle.kts
+++ b/exposed/domain/build.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
     implementation(libs.bluetape4k.exposed.core)
     implementation(libs.bluetape4k.exposed.dao)
     implementation(libs.bluetape4k.exposed.jackson3)
+    testImplementation(libs.bluetape4k.exposed.jdbc)
     testImplementation(libs.bluetape4k.exposed.jdbc.tests)
 
     implementation(libs.exposed.core)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -197,6 +197,7 @@ bluetape4k-cassandra = { module = "io.github.bluetape4k:bluetape4k-cassandra" , 
 bluetape4k-exposed-core = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-core" , version.ref = "bluetape4k" }
 bluetape4k-exposed-dao = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-dao" , version.ref = "bluetape4k" }
 bluetape4k-exposed-jackson3 = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-jackson3" , version.ref = "bluetape4k" }
+bluetape4k-exposed-jdbc = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-jdbc" , version.ref = "bluetape4k" }
 bluetape4k-exposed-jdbc-tests = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-jdbc-tests" , version.ref = "bluetape4k" }
 bluetape4k-exposed-r2dbc = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-r2dbc" , version.ref = "bluetape4k" }
 bluetape4k-hibernate = { module = "io.github.bluetape4k:bluetape4k-hibernate" , version.ref = "bluetape4k" }


### PR DESCRIPTION
## 요약
- daily-bug-scan에서 지난 24시간 develop 변경을 6-Tier로 재검토했습니다.
- `exposed-domain` 테스트가 `io.bluetape4k.exposed.jdbc.selectImplicitAll` production helper를 직접 import하지만, module에는 `bluetape4k-exposed-jdbc-tests`만 선언되어 있었습니다.
- `bluetape4k-exposed-jdbc` catalog alias와 test dependency를 추가하고, README 및 Lessons에 계약을 남겼습니다.

## 6-Tier Code Review
- Tier 1 Security: dependency/test 문서 변경이며 secret grep 결과 없음. P0/P1=0.
- Tier 2 Ops/SRE: runtime path 변경 없음, test compile contract 복구. P0/P1=0.
- Tier 3 Structural: `*-jdbc-tests`와 production `bluetape4k-exposed-jdbc` artifact 책임 분리 확인. P0/P1=0.
- Tier 4 Kotlin/Quality: source edit 없음, Gradle catalog alias를 기존 naming pattern에 맞춤. P0/P1=0.
- Tier 5 Tests/Types/Silent Failure: `selectImplicitAll` import 소유 artifact를 명시해 compile false-negative 방지. P0/P1=0.
- Tier 6 Performance/Stability: dependency graph의 test scope만 변경, runtime artifact 영향 없음. P0/P1=0.
- Advisor: Claude Opus advisor P0/P1 없음. P2 문서 범위 지적은 lesson 검증 명령을 `:exposed-domain:compileTestKotlin` 중심으로 축소해 반영했습니다.

## 검증
- `./gradlew :exposed-domain:compileTestKotlin --continue` 성공
- `./gradlew :exposed-domain:compileTestKotlin :exposed-sql-web-virtualthread:testClasses --continue` 성공
- `git diff --check` 성공
- GitHub workflow YAML parse 성공
- `qmd update` / `qmd embed --max-docs-per-batch 10` 성공

## Lessons
- `docs/lessons/2026-05-12-exposed-jdbc-helper-test-dependency.md` 추가

## 참고
- `codex`, `codex-automation` labels는 이 repo에 없어 추가하지 못했습니다.
