### PR TITLE
build: remove Jackson2 from supported workshop modules

### DIFF
--- a/docs/lessons/2026-05-14-issue-65-jackson3-workshop-spring.md
+++ b/docs/lessons/2026-05-14-issue-65-jackson3-workshop-spring.md
@@ -14,15 +14,16 @@ unchanged because they still expose Jackson2 APIs in local source.
 ## Outcome
 
 The Spring Kafka reply example and Spring Data Elasticsearch example no longer
-depend on `bluetape4k-jackson2`.
+depend on `bluetape4k-jackson2`. The version catalog duplicate
+`bluetape4k-exposed-jdbc` alias was removed because it blocked every Gradle
+configuration before module validation could start.
 
 ## Verification
 
-- Blocked: Gradle configuration fails before task selection because
-  `gradle/libs.versions.toml` already contains a duplicate
-  `bluetape4k-exposed-jdbc` alias.
+- `./gradlew :messaging-kafka-reply:testClasses :spring-data-elasticsearch:testClasses`
 
 ## Future Notes
 
-Resolve catalog duplicate aliases before validating or expanding workshop-wide
-dependency migrations.
+When Gradle fails before task selection during dependency migration, inspect the
+version catalog first; unrelated duplicate aliases can mask module-level
+Jackson compatibility results.

--- a/docs/lessons/2026-05-14-issue-65-jackson3-workshop-spring.md
+++ b/docs/lessons/2026-05-14-issue-65-jackson3-workshop-spring.md
@@ -1,0 +1,28 @@
+# Issue 65 Jackson3 Workshop Spring Modules
+
+## Context
+
+Some workshop modules still referenced `bluetape4k-jackson2`. Spring Boot 4
+modules should prefer Jackson3 where upstream support exists.
+
+## Decision
+
+Migrate supported Spring workshop dependencies and normalize
+`spring-data/elasticsearch` to Jackson3. Leave Quarkus Jackson extension modules
+unchanged because they still expose Jackson2 APIs in local source.
+
+## Outcome
+
+The Spring Kafka reply example and Spring Data Elasticsearch example no longer
+depend on `bluetape4k-jackson2`.
+
+## Verification
+
+- Blocked: Gradle configuration fails before task selection because
+  `gradle/libs.versions.toml` already contains a duplicate
+  `bluetape4k-exposed-jdbc` alias.
+
+## Future Notes
+
+Resolve catalog duplicate aliases before validating or expanding workshop-wide
+dependency migrations.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -198,7 +198,6 @@ bluetape4k-exposed-core = { module = "io.github.bluetape4k.exposed:bluetape4k-ex
 bluetape4k-exposed-dao = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-dao" , version.ref = "bluetape4k" }
 bluetape4k-exposed-jdbc = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-jdbc" , version.ref = "bluetape4k" }
 bluetape4k-exposed-jackson3 = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-jackson3" , version.ref = "bluetape4k" }
-bluetape4k-exposed-jdbc = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-jdbc" , version.ref = "bluetape4k" }
 bluetape4k-exposed-jdbc-tests = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-jdbc-tests" , version.ref = "bluetape4k" }
 bluetape4k-exposed-r2dbc = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-r2dbc" , version.ref = "bluetape4k" }
 bluetape4k-hibernate = { module = "io.github.bluetape4k:bluetape4k-hibernate" , version.ref = "bluetape4k" }

--- a/messaging/kafka-reply/build.gradle.kts
+++ b/messaging/kafka-reply/build.gradle.kts
@@ -26,10 +26,10 @@ dependencies {
     implementation(libs.testcontainers.kafka)
 
     // Jackson
-    api(libs.bluetape4k.jackson2)
-    api(libs.jackson.databind)
-    api(libs.jackson.module.kotlin)
-    api(libs.jackson.module.blackbird)
+    api(libs.bluetape4k.jackson3)
+    api(libs.jackson3.databind)
+    api(libs.jackson3.module.kotlin)
+    api(libs.jackson3.module.blackbird)
 
     // Coroutines
     implementation(libs.bluetape4k.coroutines)

--- a/spring-data/elasticsearch/build.gradle.kts
+++ b/spring-data/elasticsearch/build.gradle.kts
@@ -42,7 +42,6 @@ dependencies {
     }
 
     implementation(libs.bluetape4k.jackson3)
-    implementation(libs.bluetape4k.jackson2)
     testImplementation(libs.bluetape4k.junit5)
 
     // Coroutines


### PR DESCRIPTION
Closes #65

## Summary
- Move `messaging/kafka-reply` to Jackson3 dependencies.
- Remove the redundant Jackson2 dependency from `spring-data/elasticsearch`.
- Leave Quarkus Jackson modules unchanged because local source still uses Jackson2 APIs.
- Remove the duplicate `bluetape4k-exposed-jdbc` catalog alias that blocked Gradle configuration.

## Verification
- `./gradlew :messaging-kafka-reply:testClasses :spring-data-elasticsearch:testClasses`
