### PR TITLE
fix: add missing bluetape4k.exposed.dao/jdbc dependencies (#67)

### DIFF
--- a/docs/lessons/2026-05-14-issue-67-exposed-compile-failures.md
+++ b/docs/lessons/2026-05-14-issue-67-exposed-compile-failures.md
@@ -1,0 +1,54 @@
+# Lessons Learned — Exposed compileTestKotlin failures after lib→core migration (2026-05-14)
+
+**관련 PR**: #68
+**영향 모듈**: `:exposed-spring-transaction`, `:exposed-sql-webflux-coroutines`
+
+## L1: 집계 artifact를 세분화 좌표로 교체할 때 모든 하위 아티팩트를 명시적으로 선언해야 한다
+
+### 문제
+`7c4feb86` 커밋에서 `libs.bluetape4k.exposed.lib` (core + dao + jdbc 통합 artifact)를
+`libs.bluetape4k.exposed.core` 하나로 교체했다.
+이 변경 후 `dao`와 `jdbc` 하위 모듈을 참조하는 테스트 코드가 unresolved reference로 컴파일 실패했다.
+
+### 교훈
+집계 artifact를 세분화 좌표로 교체할 때는 반드시 모든 하위 artifact를 개별적으로 선언해야 한다.
+
+```kotlin
+// BAD — 집계 artifact만 교체
+implementation(libs.bluetape4k.exposed.core)  // 구 lib의 일부만 대체
+
+// GOOD — 사용 중인 하위 모듈을 모두 선언
+implementation(libs.bluetape4k.exposed.core)
+implementation(libs.bluetape4k.exposed.dao)   // dao 패키지 사용 시
+implementation(libs.bluetape4k.exposed.jdbc)  // jdbc 패키지 사용 시
+```
+
+**검증 방법**: 교체 후 `./gradlew clean :module:compileTestKotlin --no-build-cache`로
+캐시 없이 컴파일을 확인한다.
+
+---
+
+## L2: Gradle 빌드 캐시가 누락된 의존성 오류를 장기간 숨긴다
+
+### 문제
+의존성 누락 후에도 Gradle incremental build cache가 이전 성공 결과를 재사용해
+로컬 및 일반 CI 빌드에서 오류가 표면화되지 않았다.
+Nightly 실행이 clean 환경(`--no-build-cache` 또는 fresh runner)에서 실행되어
+처음으로 검출됐다.
+
+### 교훈
+의존성 변경(추가·제거·교체)이 포함된 PR은 반드시 `./gradlew clean :module:compileTestKotlin`을
+실행해 캐시 없이 컴파일 성공 여부를 확인한다.
+
+---
+
+## L3: 부분 수정(partial fix)은 반드시 전체 범위를 검증해야 한다
+
+### 문제
+`a7c2b10d`에서 `:exposed-sql-webflux-coroutines`에 `bluetape4k.exposed.dao`는 복원했지만
+같은 커밋(`7c4feb86`)에서 손실된 `bluetape4k.exposed.jdbc`는 복원하지 않았다.
+
+### 교훈
+부분 수정 커밋을 만들 때, 원래 누락된 커밋 diff 전체를 검토해 누락 범위를 완전히 파악한다.
+`git show <commit> -- <file>` 으로 실제 변경 내용을 확인하고,
+영향 모듈 전체에 동일 패턴이 없는지 `rg`로 교차 검증한다.

--- a/exposed/spring-transaction/build.gradle.kts
+++ b/exposed/spring-transaction/build.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
 
     // Exposed
     implementation(libs.bluetape4k.exposed.core)
+    implementation(libs.bluetape4k.exposed.dao)
     implementation(libs.exposed.core)
     implementation(libs.exposed.dao)
     implementation(libs.exposed.jdbc)

--- a/exposed/sql-webflux-coroutines/build.gradle.kts
+++ b/exposed/sql-webflux-coroutines/build.gradle.kts
@@ -32,6 +32,7 @@ dependencies {
     // Exposed
     implementation(libs.bluetape4k.exposed.core)
     implementation(libs.bluetape4k.exposed.dao)
+    implementation(libs.bluetape4k.exposed.jdbc)
     implementation(libs.exposed.core)
     implementation(libs.exposed.dao)
     implementation(libs.exposed.jdbc)


### PR DESCRIPTION
## Summary

Fixes #67 — two `compileTestKotlin` failures in Exposed workshop modules.

### Root Cause

Commit `7c4feb86` ("build: Keep bluetape4k dependency coordinates catalog-managed") replaced the aggregate `libs.bluetape4k.exposed.lib` artifact with the fine-grained `libs.bluetape4k.exposed.core` in both modules. The old `.lib` bundled `core + dao + jdbc` in one coordinate; the migration preserved only `core`, silently dropping `dao` and `jdbc`.

A partial fix (`a7c2b10d`) restored `bluetape4k.exposed.dao` to `:exposed-sql-webflux-coroutines` but missed `bluetape4k.exposed.jdbc`. The `:exposed-spring-transaction` module received no partial fix at all.

The gap went undetected because Gradle's incremental build cache served stale `compileTestKotlin` outputs. A clean Nightly run bypasses the cache and exposed the missing declarations.

| Module | Missing dependency | Unresolved symbols |
|--------|-------------------|--------------------|
| `:exposed-spring-transaction` | `bluetape4k.exposed.dao` | `TimebasedUUIDEntityID`, `TimebasedUUIDEntity`, `TimebasedUUIDEntityClass`, `idEquals`, `idHashCode`, `entityToStringBuilder` |
| `:exposed-sql-webflux-coroutines` | `bluetape4k.exposed.jdbc` | `newVirtualThreadJdbcTransaction`, `virtualThreadJdbcTransactionAsync` |

### Other modules checked

- `:exposed-dao-web-transaction`: already declares both `bluetape4k.exposed.core` + `.dao` ✅
- `:exposed-sql-web-virtualthread`: already declares both `bluetape4k.exposed.core` + `.dao` ✅
- No other module uses `newVirtualThreadJdbcTransaction` / `virtualThreadJdbcTransactionAsync` ✅

### Changes

- `exposed/spring-transaction/build.gradle.kts`: add `implementation(libs.bluetape4k.exposed.dao)`
- `exposed/sql-webflux-coroutines/build.gradle.kts`: add `implementation(libs.bluetape4k.exposed.jdbc)`

### Test Results

```
./gradlew :exposed-spring-transaction:compileTestKotlin :exposed-sql-webflux-coroutines:compileTestKotlin
BUILD SUCCESSFUL in 42s

./gradlew :exposed-spring-transaction:test
BUILD SUCCESSFUL in 27s

./gradlew :exposed-sql-webflux-coroutines:test
BUILD SUCCESSFUL in 27s
```

### Acceptance Criteria

- [x] `:exposed-spring-transaction:compileTestKotlin` passes
- [x] `:exposed-sql-webflux-coroutines:compileTestKotlin` passes