### PR TITLE
fix: resolve race condition in CapturingStreamListener (#69)

### DIFF
--- a/spring-data/redis-examples/src/main/kotlin/io/bluetape4k/workshop/redis/stream/sync/CapturingStreamListener.kt
+++ b/spring-data/redis-examples/src/main/kotlin/io/bluetape4k/workshop/redis/stream/sync/CapturingStreamListener.kt
@@ -22,8 +22,8 @@ class CapturingStreamListener: StreamListener<String, MapRecord<String, String, 
      * @param message
      */
     override fun onMessage(message: MapRecord<String, String, String>) {
-        dequeue.add(message)
         counter.incrementAndGet()
+        dequeue.add(message)
     }
 
     val receivedRecordCount get() = counter.value


### PR DESCRIPTION
## Summary

Fixes #69 — flaky `SyncStreamApiTest > stream listener 를 통한 연속적 읽기` test.

### Root Cause

Race condition in `CapturingStreamListener.onMessage()`:

```kotlin
// BEFORE (broken)
override fun onMessage(message: ...) {
    dequeue.add(message)       // (1) take() unblocks here
    counter.incrementAndGet()  // (2) may not have run when test checks count
}

// AFTER (fixed)
override fun onMessage(message: ...) {
    counter.incrementAndGet()  // (1) counter is already N
    dequeue.add(message)       // (2) take() unblocks — count is guaranteed correct
}
```

`take()` in the test unblocks as soon as `dequeue.add()` is called. If the test thread checks `receivedRecordCount` before `counter.incrementAndGet()` runs, it sees count N-1 instead of N.

Swapping the order guarantees the counter is already incremented by the time `take()` returns to the test thread.

### Changes

- `CapturingStreamListener.kt`: swap counter increment before deque add (1-line change)

### Test Results

```
./gradlew :spring-data-redis-examples:test
BUILD SUCCESSFUL in 33s — 39 tests completed, 0 failed
```