### PR TITLE
[docs] Refresh workshop READMEs for Spring Boot 4

### DIFF
--- a/exposed/dao-web-transaction/README.md
+++ b/exposed/dao-web-transaction/README.md
@@ -1,6 +1,6 @@
 # Exposed Dao Web Transaction Example
 
-This Spring Boot 3 based project uses Exposed for CRUD (Create, Read, Update, Delete) operations.
+This Spring Boot 4 based project uses Exposed for CRUD (Create, Read, Update, Delete) operations.
 
 ## 트랜잭션 처리 흐름
 

--- a/observability/micrometer-tracing-coroutines/README.md
+++ b/observability/micrometer-tracing-coroutines/README.md
@@ -1,4 +1,4 @@
-# Micrometer Observation for Spring Boot 3 Webflux & Coroutines
+# Micrometer Observation for Spring Boot 4 WebFlux & Coroutines
 
 ## 아키텍처 다이어그램
 

--- a/spring-boot/chaos-monkey/README.md
+++ b/spring-boot/chaos-monkey/README.md
@@ -1,4 +1,4 @@
-# Chaos Monkey + Spring Boot 3 Demo
+# Chaos Monkey + Spring Boot 4 Demo
 
 원본: [chaos-monkey-springboot](https://github.com/vaquarkhan/chaos-monkey-springboot)
 
@@ -53,7 +53,7 @@ There are two required steps for enabling Chaos Monkey for a Spring Boot applica
 <dependency>
     <groupId>de.codecentric</groupId>
     <artifactId>chaos-monkey-spring-boot</artifactId>
-    <version>2.2.0</version>
+    <version>4.0.0</version>
 </dependency>
 ```
 


### PR DESCRIPTION
## Summary
- Update stale Spring Boot 3 labels in workshop README files to Spring Boot 4.
- Align the Chaos Monkey dependency snippet with the current Spring Boot 4-compatible catalog version.

## Validation
- git diff --check
- README search for Spring Boot 3/4 compatibility phrases returned no matches

## Notes
- Documentation-only change; no Gradle build was run.