### PR TITLE
Align examples with exposed artifactId rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ observability, virtual threads, Vert.x, and gateway-style applications.
 ```
 
 `exposed-domain` 테스트는 `io.bluetape4k.exposed.jdbc.selectImplicitAll` 같은
-main JDBC helper extension을 직접 검증합니다. `bluetape4k-exposed-jdbc-tests`는
-test fixture 계약만 제공하므로, 해당 테스트 모듈에는 `bluetape4k-exposed-jdbc`
+main JDBC helper extension을 직접 검증합니다. `exposed-jdbc-tests`는
+test fixture 계약만 제공하므로, 해당 테스트 모듈에는 `exposed-jdbc`
 test dependency도 함께 선언해야 합니다.
 
 ## 전체 모듈 구성

--- a/exposed/dao-web-transaction/build.gradle.kts
+++ b/exposed/dao-web-transaction/build.gradle.kts
@@ -34,13 +34,13 @@ dependencies {
     implementation(libs.bluetape4k.jdbc)
 
     // Exposed
-    implementation(libs.bluetape4k.exposed.core)
-    implementation(libs.bluetape4k.exposed.dao)
     implementation(libs.exposed.core)
     implementation(libs.exposed.dao)
-    implementation(libs.exposed.kotlin.datetime)
-    implementation(libs.exposed.spring.boot4.starter)
-    implementation(libs.exposed.spring7.transaction)
+    implementation(libs.jetbrains.exposed.core)
+    implementation(libs.jetbrains.exposed.dao)
+    implementation(libs.jetbrains.exposed.kotlin.datetime)
+    implementation(libs.jetbrains.exposed.spring.boot4.starter)
+    implementation(libs.jetbrains.exposed.spring7.transaction)
 
     // Jackson for Kotlin
     implementation(libs.jackson3.module.kotlin)

--- a/exposed/domain/build.gradle.kts
+++ b/exposed/domain/build.gradle.kts
@@ -7,27 +7,27 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.exposed.bom))
+    implementation(platform(libs.jetbrains.exposed.bom))
 
     testImplementation(project(":shared"))
 
-    implementation(libs.bluetape4k.exposed.core)
-    implementation(libs.bluetape4k.exposed.dao)
-    testImplementation(libs.bluetape4k.exposed.jdbc)
-    implementation(libs.bluetape4k.exposed.jackson3)
-    testImplementation(libs.bluetape4k.exposed.jdbc)
-    testImplementation(libs.bluetape4k.exposed.jdbc.tests)
-
     implementation(libs.exposed.core)
-    implementation(libs.exposed.crypt)
     implementation(libs.exposed.dao)
-    implementation(libs.exposed.java.time)
-    implementation(libs.exposed.jdbc)
-    implementation(libs.exposed.json)
-    implementation(libs.exposed.kotlin.datetime)
-    implementation(libs.exposed.migration.jdbc)
-    implementation(libs.exposed.money)
-    implementation(libs.exposed.spring.boot4.starter)
+    testImplementation(libs.exposed.jdbc)
+    implementation(libs.exposed.jackson3)
+    testImplementation(libs.exposed.jdbc)
+    testImplementation(libs.exposed.jdbc.tests)
+
+    implementation(libs.jetbrains.exposed.core)
+    implementation(libs.jetbrains.exposed.crypt)
+    implementation(libs.jetbrains.exposed.dao)
+    implementation(libs.jetbrains.exposed.java.time)
+    implementation(libs.jetbrains.exposed.jdbc)
+    implementation(libs.jetbrains.exposed.json)
+    implementation(libs.jetbrains.exposed.kotlin.datetime)
+    implementation(libs.jetbrains.exposed.migration.jdbc)
+    implementation(libs.jetbrains.exposed.money)
+    implementation(libs.jetbrains.exposed.spring.boot4.starter)
 
     implementation(libs.bluetape4k.jdbc)
     testImplementation(libs.bluetape4k.junit5)

--- a/exposed/spring-transaction/build.gradle.kts
+++ b/exposed/spring-transaction/build.gradle.kts
@@ -9,17 +9,17 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.exposed.bom))
+    implementation(platform(libs.jetbrains.exposed.bom))
     implementation(project(":exposed-domain"))
 
     // Exposed
-    implementation(libs.bluetape4k.exposed.core)
-    implementation(libs.bluetape4k.exposed.dao)
     implementation(libs.exposed.core)
     implementation(libs.exposed.dao)
-    implementation(libs.exposed.jdbc)
-    implementation(libs.exposed.kotlin.datetime)
-    implementation(libs.exposed.spring.boot4.starter)
+    implementation(libs.jetbrains.exposed.core)
+    implementation(libs.jetbrains.exposed.dao)
+    implementation(libs.jetbrains.exposed.jdbc)
+    implementation(libs.jetbrains.exposed.kotlin.datetime)
+    implementation(libs.jetbrains.exposed.spring.boot4.starter)
 
     // Database Drivers
     implementation(libs.hikaricp)

--- a/exposed/sql-web-virtualthread/build.gradle.kts
+++ b/exposed/sql-web-virtualthread/build.gradle.kts
@@ -35,14 +35,14 @@ dependencies {
     implementation(libs.bluetape4k.jdbc)
 
     // Exposed
-    implementation(libs.bluetape4k.exposed.core)
-    implementation(libs.bluetape4k.exposed.dao)
     implementation(libs.exposed.core)
-    implementation(libs.exposed.jdbc)
     implementation(libs.exposed.dao)
-    implementation(libs.exposed.java.time)
-    implementation(libs.exposed.migration.jdbc)
-    // implementation(libs.exposed.spring.boot.starter) // 직접 DatabaseConfig 에서 Database를 설정해서, 중복됨
+    implementation(libs.jetbrains.exposed.core)
+    implementation(libs.jetbrains.exposed.jdbc)
+    implementation(libs.jetbrains.exposed.dao)
+    implementation(libs.jetbrains.exposed.java.time)
+    implementation(libs.jetbrains.exposed.migration.jdbc)
+    // implementation(libs.jetbrains.exposed.spring.boot.starter) // 직접 DatabaseConfig 에서 Database를 설정해서, 중복됨
 
     // Database Drivers
     implementation(libs.hikaricp)

--- a/exposed/sql-webflux-coroutines/build.gradle.kts
+++ b/exposed/sql-webflux-coroutines/build.gradle.kts
@@ -30,15 +30,15 @@ dependencies {
     implementation(libs.bluetape4k.jdbc)
 
     // Exposed
-    implementation(libs.bluetape4k.exposed.core)
-    implementation(libs.bluetape4k.exposed.dao)
-    implementation(libs.bluetape4k.exposed.jdbc)
     implementation(libs.exposed.core)
     implementation(libs.exposed.dao)
     implementation(libs.exposed.jdbc)
-    implementation(libs.exposed.kotlin.datetime)
-    implementation(libs.exposed.migration.jdbc)
-    // implementation(libs.exposed.spring.boot.starter) // 직접 DatabaseConfig 에서 Database를 설정해서, 중복됨
+    implementation(libs.jetbrains.exposed.core)
+    implementation(libs.jetbrains.exposed.dao)
+    implementation(libs.jetbrains.exposed.jdbc)
+    implementation(libs.jetbrains.exposed.kotlin.datetime)
+    implementation(libs.jetbrains.exposed.migration.jdbc)
+    // implementation(libs.jetbrains.exposed.spring.boot.starter) // 직접 DatabaseConfig 에서 Database를 설정해서, 중복됨
 
     // Database Drivers
     implementation(libs.hikaricp)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -194,12 +194,12 @@ bluetape4k-protobuf = { module = "io.github.bluetape4k:bluetape4k-protobuf" , ve
 bluetape4k-retrofit2 = { module = "io.github.bluetape4k:bluetape4k-retrofit2" , version.ref = "bluetape4k" }
 bluetape4k-vertx = { module = "io.github.bluetape4k:bluetape4k-vertx" , version.ref = "bluetape4k" }
 bluetape4k-cassandra = { module = "io.github.bluetape4k:bluetape4k-cassandra" , version.ref = "bluetape4k" }
-bluetape4k-exposed-core = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-core" , version.ref = "bluetape4k" }
-bluetape4k-exposed-dao = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-dao" , version.ref = "bluetape4k" }
-bluetape4k-exposed-jdbc = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-jdbc" , version.ref = "bluetape4k" }
-bluetape4k-exposed-jackson3 = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-jackson3" , version.ref = "bluetape4k" }
-bluetape4k-exposed-jdbc-tests = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-jdbc-tests" , version.ref = "bluetape4k" }
-bluetape4k-exposed-r2dbc = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-r2dbc" , version.ref = "bluetape4k" }
+exposed-core = { module = "io.github.bluetape4k.exposed:exposed-core" , version.ref = "bluetape4k" }
+exposed-dao = { module = "io.github.bluetape4k.exposed:exposed-dao" , version.ref = "bluetape4k" }
+exposed-jdbc = { module = "io.github.bluetape4k.exposed:exposed-jdbc" , version.ref = "bluetape4k" }
+exposed-jackson3 = { module = "io.github.bluetape4k.exposed:exposed-jackson3" , version.ref = "bluetape4k" }
+exposed-jdbc-tests = { module = "io.github.bluetape4k.exposed:exposed-jdbc-tests" , version.ref = "bluetape4k" }
+exposed-r2dbc = { module = "io.github.bluetape4k.exposed:exposed-r2dbc" , version.ref = "bluetape4k" }
 bluetape4k-hibernate = { module = "io.github.bluetape4k:bluetape4k-hibernate" , version.ref = "bluetape4k" }
 bluetape4k-jdbc = { module = "io.github.bluetape4k:bluetape4k-jdbc" , version.ref = "bluetape4k" }
 bluetape4k-mongodb = { module = "io.github.bluetape4k:bluetape4k-mongodb" , version.ref = "bluetape4k" }
@@ -585,20 +585,20 @@ querydsl-jpa = { module = "com.querydsl:querydsl-jpa", version.ref = "querydsl" 
 mybatis-dynamic-sql = { module = "org.mybatis.dynamic-sql:mybatis-dynamic-sql", version = "1.5.2" }  # https://mvnrepository.com/artifact/org.mybatis.dynamic-sql/mybatis-dynamic-sql
 
 # Exposed
-exposed-bom = { module = "org.jetbrains.exposed:exposed-bom", version.ref = "exposed" }
-exposed-core = { module = "org.jetbrains.exposed:exposed-core", version.ref = "exposed" }
-exposed-crypt = { module = "org.jetbrains.exposed:exposed-crypt", version.ref = "exposed" }
-exposed-dao = { module = "org.jetbrains.exposed:exposed-dao", version.ref = "exposed" }
-exposed-java-time = { module = "org.jetbrains.exposed:exposed-java-time", version.ref = "exposed" }
-exposed-jdbc = { module = "org.jetbrains.exposed:exposed-jdbc", version.ref = "exposed" }
-exposed-json = { module = "org.jetbrains.exposed:exposed-json", version.ref = "exposed" }
-exposed-kotlin-datetime = { module = "org.jetbrains.exposed:exposed-kotlin-datetime", version.ref = "exposed" }
-exposed-migration-jdbc = { module = "org.jetbrains.exposed:exposed-migration-jdbc", version.ref = "exposed" }
-exposed-money = { module = "org.jetbrains.exposed:exposed-money", version.ref = "exposed" }
-exposed-r2dbc = { module = "org.jetbrains.exposed:exposed-r2dbc", version.ref = "exposed" }
-exposed-spring-boot-starter = { module = "org.jetbrains.exposed:exposed-spring-boot-starter", version.ref = "exposed" }
-exposed-spring-boot4-starter = { module = "org.jetbrains.exposed:exposed-spring-boot4-starter", version.ref = "exposed" }
-exposed-spring7-transaction = { module = "org.jetbrains.exposed:spring7-transaction", version.ref = "exposed" }
+jetbrains-exposed-bom = { module = "org.jetbrains.exposed:exposed-bom", version.ref = "exposed" }
+jetbrains-exposed-core = { module = "org.jetbrains.exposed:exposed-core", version.ref = "exposed" }
+jetbrains-exposed-crypt = { module = "org.jetbrains.exposed:exposed-crypt", version.ref = "exposed" }
+jetbrains-exposed-dao = { module = "org.jetbrains.exposed:exposed-dao", version.ref = "exposed" }
+jetbrains-exposed-java-time = { module = "org.jetbrains.exposed:exposed-java-time", version.ref = "exposed" }
+jetbrains-exposed-jdbc = { module = "org.jetbrains.exposed:exposed-jdbc", version.ref = "exposed" }
+jetbrains-exposed-json = { module = "org.jetbrains.exposed:exposed-json", version.ref = "exposed" }
+jetbrains-exposed-kotlin-datetime = { module = "org.jetbrains.exposed:exposed-kotlin-datetime", version.ref = "exposed" }
+jetbrains-exposed-migration-jdbc = { module = "org.jetbrains.exposed:exposed-migration-jdbc", version.ref = "exposed" }
+jetbrains-exposed-money = { module = "org.jetbrains.exposed:exposed-money", version.ref = "exposed" }
+jetbrains-exposed-r2dbc = { module = "org.jetbrains.exposed:exposed-r2dbc", version.ref = "exposed" }
+jetbrains-exposed-spring-boot-starter = { module = "org.jetbrains.exposed:exposed-spring-boot-starter", version.ref = "exposed" }
+jetbrains-exposed-spring-boot4-starter = { module = "org.jetbrains.exposed:exposed-spring-boot4-starter", version.ref = "exposed" }
+jetbrains-exposed-spring7-transaction = { module = "org.jetbrains.exposed:spring7-transaction", version.ref = "exposed" }
 
 # R2DBC
 r2dbc-h2 = { module = "io.r2dbc:r2dbc-h2", version.ref = "r2dbc-h2" }

--- a/spring-data/r2dbc-webflux-exposed/README.md
+++ b/spring-data/r2dbc-webflux-exposed/README.md
@@ -35,7 +35,7 @@ flowchart TB
 ```
 
 Spring Data R2DBC와 Spring WebFlux, JetBrains Exposed ORM을 함께 사용하는 예제입니다.
-`bluetape4k-exposed-r2dbc` 모듈을 활용해 Exposed 테이블 정의를 R2DBC 환경에서 사용합니다.
+`exposed-r2dbc` 모듈을 활용해 Exposed 테이블 정의를 R2DBC 환경에서 사용합니다.
 
 ## 구성
 

--- a/spring-data/r2dbc-webflux-exposed/build.gradle.kts
+++ b/spring-data/r2dbc-webflux-exposed/build.gradle.kts
@@ -26,8 +26,8 @@ dependencies {
     implementation(libs.h2.v2)
 
     // Exposed R2dbc
-    implementation(libs.bluetape4k.exposed.r2dbc)
     implementation(libs.exposed.r2dbc)
+    implementation(libs.jetbrains.exposed.r2dbc)
 
     // Spring Boot
     implementation(libs.spring.boot.autoconfigure.lib)


### PR DESCRIPTION
## Context\n\nFollows bluetape4k/bluetape4k-exposed#77 after exposed and dependencies snapshots were published.\n\n## Changes\n\n- Update bluetape4k Exposed coordinates/accessors to the new exposed-* artifactIds.\n- Move JetBrains Exposed catalog aliases under libs.jetbrains.exposed.* to avoid accessor collisions.\n- Keep Kotlin package imports io.bluetape4k.exposed unchanged.\n- Refresh current README references.\n\n## Verification\n\n- ./gradlew :exposed-domain:test :exposed-dao-web-transaction:test :exposed-sql-web-virtualthread:test :exposed-sql-webflux-coroutines:test :exposed-spring-transaction:test :spring-data-r2dbc-webflux-exposed:test --no-daemon\n- rg old artifact/accessor patterns over Gradle/catalog/README files\n- git diff --check\n\nRefs bluetape4k/bluetape4k-exposed#77