### PR TITLE
chore: upgrade JetBrains Exposed to 1.3.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -56,7 +56,7 @@ hibernate-reactive = "4.3.3.Final"  # https://mvnrepository.com/artifact/org.hib
 hibernate-validator = "9.1.0.Final"  # https://mvnrepository.com/artifact/org.hibernate.validator/hibernate-validator
 querydsl = "5.1.0"  # https://mvnrepository.com/artifact/com.querydsl/querydsl-apt
 
-exposed = "1.2.0"  # https://mvnrepository.com/artifact/org.jetbrains.exposed/exposed-bom
+exposed = "1.3.0"  # https://mvnrepository.com/artifact/org.jetbrains.exposed/exposed-bom
 r2dbc = "1.0.0.RELEASE"  # https://mvnrepository.com/artifact/io.r2dbc/r2dbc-spi
 r2dbc-h2 = "1.1.0.RELEASE"  # https://mvnrepository.com/artifact/io.r2dbc/r2dbc-h2
 r2dbc-pool = "1.0.2.RELEASE"  # https://mvnrepository.com/artifact/io.r2dbc/r2dbc-pool


### PR DESCRIPTION
Aligns JetBrains Exposed version to 1.3.0 across the bluetape4k ecosystem.

## Why
`bluetape4k-exposed` and `bluetape4k-leader` already use `exposed = 1.3.0`.
`bluetape4k-dependencies` is the version source-of-truth and requires all repos to stay in sync.

## Changes
- `gradle/libs.versions.toml`: `exposed 1.2.0` → `1.3.0`