### PR TITLE
docs: refresh workshop WIP after R2DBC test audit

### DIFF
--- a/WIP.md
+++ b/WIP.md
@@ -1,23 +1,29 @@
 # WIP - bluetape4k-workshop
 
-Snapshot: 2026-05-13 KST
+Snapshot: 2026-05-18 KST
 Scope: open GitHub issues assigned to `debop`, created on or after 2026-01-01.
-Open count: 6 issues.
+Open count: 7 issues.
 
 ## Recently Completed
 
 - CI/Nightly, Spring Boot 4.0.x alignment, Gradle 9.5.0/version-catalog migration, local OMX ignore rules, and assertion migration are merged.
 - JDBC helper dependency fixes for Exposed workshop modules are merged by PR #60 and PR #61.
 - Dependency governance, compatibility guards, and dependency bumps are merged through PR #33 through PR #59.
+- QMD-backed audit registered `#120` for disabled R2DBC WebFlux integration tests.
 
 ## Current Direction
 
 Workshop issues should consume stable library APIs. Avoid building graph or leader runnable examples before the owning library repository has settled the core API or semantics.
 
+Restore disabled Spring/R2DBC coverage before expanding new examples in the same
+area. A passing build with pending tests is not enough protection for workshop
+behavior.
+
 ## Priority Queue
 
 | Priority | Issue | Difficulty | Notes |
 |---|---|---:|---|
+| P2 | [#120](https://github.com/bluetape4k/bluetape4k-workshop/issues/120) R2DBC WebFlux tests disabled | M | `:spring-data-r2dbc-webflux:test` succeeds with 44 pending tests; wire deterministic schema/data initialization and remove broad `@Disabled`. |
 | P3 | [#14](https://github.com/bluetape4k/bluetape4k-workshop/issues/14) Ktor-first workshop example | M | Independent enough to start, but lower strategic leverage. |
 | P3 | [#9](https://github.com/bluetape4k/bluetape4k-workshop/issues/9) bluetape4k-graph examples epic | L | Track runnable workshop side only; library examples belong in `bluetape4k-graph`. |
 | P3 | [#11](https://github.com/bluetape4k/bluetape4k-workshop/issues/11) knowledge-graph example | M | Depends on graph example/core API stability. |
@@ -39,12 +45,17 @@ bluetape4k-leader lease/state semantics
 
 #14 Ktor-first workshop
   -> independent, but not a blocker
+
+#120 R2DBC WebFlux disabled tests
+  -> independent correctness/test lane
+  -> fix before adding more Spring Data R2DBC examples
 ```
 
 ## WIP Limits
 
 | Lane | Limit | Current next |
 |---|---:|---|
+| Data/reactive test coverage | 1 | `#120` first if touching Spring Data R2DBC examples. |
 | Independent workshop | 1 | `#14` if examples are desired now. |
 | Graph examples | 0 until graph core settles | `#9/#11/#12/#13` wait. |
 | Leader examples | 0 until leader semantics settles | `#10` waits. |

--- a/docs/lessons/2026-05-18-wip-audit-r2dbc-webflux-tests.md
+++ b/docs/lessons/2026-05-18-wip-audit-r2dbc-webflux-tests.md
@@ -1,0 +1,33 @@
+# WIP Audit R2DBC WebFlux Tests
+
+## Context
+
+The 2026-05-18 qmd-backed workshop audit checked prior compile-drift lessons,
+live GitHub issues, and current source markers before refreshing `WIP.md`.
+
+## Decision or Finding
+
+`spring-data/r2dbc-webflux` has service, annotated-controller, and functional
+handler integration tests disabled at class level because schema initialization
+was left unresolved. The module already ships `data/schema.sql`, `data/data.sql`,
+and a commented `ConnectionFactoryInitializer` block, so the gap is a focused
+test-restoration bug rather than a new example feature.
+
+## Outcome
+
+Registered GitHub issue #120 and moved it ahead of example epics in the
+repo-local WIP queue.
+
+## Verification
+
+- `qmd query ... --no-rerank -c bluetape4k-docs` surfaced the prior workshop
+  compile-drift lesson.
+- `gh issue list --assignee debop` confirmed the existing open assigned queue.
+- `gh issue list --search "r2dbc schema disabled tests"` found no duplicate.
+- `./gradlew :spring-data-r2dbc-webflux:test --tests ...` completed with
+  `BUILD SUCCESSFUL`, `0 passing`, and `44 pending`.
+
+## Future Guidance
+
+When a workshop module reports a green Gradle build, check whether meaningful
+tests are pending or disabled before treating the example as protected.


### PR DESCRIPTION
## Summary

- registered issue #120 for disabled `spring-data/r2dbc-webflux` integration tests
- refreshed `WIP.md` with the live assigned issue queue and new P2 test coverage item
- added a lesson capturing qmd/GitHub/test evidence from the audit

## Verification

- `qmd query ... --no-rerank -c bluetape4k-docs`
- `gh issue list --assignee debop`
- `gh issue view 120`
- `./gradlew :spring-data-r2dbc-webflux:test --tests "io.bluetape4k.workshop.r2dbc.service.UserServiceTest" --tests "io.bluetape4k.workshop.r2dbc.controller.UserControllerTest" --tests "io.bluetape4k.workshop.r2dbc.handler.UserHandlerIT"` (`BUILD SUCCESSFUL`, `0 passing`, `44 pending`)

## Not Tested

- Full repository build was not run; this PR only changes WIP and lesson documentation.
