### PR TITLE
chore: validation matrix, smoke script, daily smoke CI (Epic #76 issue #91)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -46,6 +46,33 @@ jobs:
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
 
+  smoke-test:
+    name: Smoke Test (no Testcontainers)
+    if: ${{ (github.event_name == 'schedule' && github.event.schedule == '0 19 * * 1-6') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'smoke') }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+      - uses: gradle/actions/setup-gradle@v6
+        with:
+          gradle-version: wrapper
+          cache-read-only: true
+      - name: Run smoke tests (no Testcontainers)
+        env:
+          GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
+        run: ./scripts/smoke-validate.sh all-smoke
+      - name: Upload smoke test results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: smoke-test-results
+          path: '**/build/test-results/test/*.xml'
+          retention-days: 7
+
   test:
     name: Test (Testcontainers)
     if: ${{ (github.event_name == 'schedule' && github.event.schedule == '0 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
@@ -94,6 +121,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build
+      - smoke-test
       - test
     if: always()
     steps:

--- a/docs/lessons/2026-05-23-issue-91-validation-matrix.md
+++ b/docs/lessons/2026-05-23-issue-91-validation-matrix.md
@@ -1,0 +1,49 @@
+# Issue #91 — Workshop Validation Matrix
+
+## Context
+
+Epic #76 restructuring adds, removes, and converts modules. A validation
+framework was needed to keep the workshop buildable and testable after each
+change wave, and to give developers targeted smoke commands instead of running
+the full suite.
+
+## Decision
+
+Three-tier validation model:
+
+| Tier | Trigger | Scope |
+|------|---------|-------|
+| T1 Compile | Every push/PR (CI) | All 56 modules, compile only |
+| T2 Smoke | Daily nightly (Mon–Sat) | 23 no-Testcontainers modules |
+| T3 Full | Weekly nightly (Sunday) | All 56 modules + Testcontainers |
+
+Deliverables:
+- `docs/superpowers/specs/2026-05-22-issue-91-validation-matrix.md` — full matrix with module lists and per-domain commands
+- `scripts/smoke-validate.sh` — domain-group runner (`all-smoke`, `data-access`, `spring-boot`, `serialization`, `messaging`, `async`, `observability`, `redis`, `stale-check`)
+- `.github/workflows/nightly.yml` — added `smoke-test` job (T2) that runs daily on no-Testcontainers modules
+
+## Outcome
+
+- 56 active modules confirmed (no stale Gradle includes)
+- 23 smoke-safe modules identified (no Testcontainers)
+- 0 stale README references to archived modules
+- 0 broken README image links (fixed regex: title strings in Markdown `![](path "title")` no longer cause false positives)
+- actionlint: nightly.yml OK
+
+## Verification
+
+```bash
+./gradlew projects --no-daemon -q | grep -c "^+---"  # → 56
+bash scripts/smoke-validate.sh stale-check            # → 0 stale, 0 broken
+actionlint .github/workflows/nightly.yml              # → OK
+```
+
+## Future Guidance
+
+- After each Epic #76 wave (delete/add/convert), re-run `stale-check` before PR creation.
+- When adding a new Testcontainers module, add it to the T3 Full group in the
+  validation matrix spec.
+- When adding a new no-Testcontainers module, add it to both the T2 Smoke
+  list in the spec and to `scripts/smoke-validate.sh all-smoke` + `nightly.yml smoke-test`.
+- The broken-link regex must use `[^ ")\t]+` (not `[^)]+`) to avoid capturing
+  optional Markdown image title strings as part of the file path.

--- a/docs/superpowers/specs/2026-05-22-issue-91-validation-matrix.md
+++ b/docs/superpowers/specs/2026-05-22-issue-91-validation-matrix.md
@@ -1,0 +1,193 @@
+# Issue #91 — Workshop Validation Matrix
+
+**Date**: 2026-05-22
+**Issue**: https://github.com/bluetape4k/bluetape4k-workshop/issues/91
+**Parent Epic**: #76
+**Status**: Active
+
+---
+
+## 1. Validation Tiers
+
+| Tier | Trigger | Scope | Docker required |
+|------|---------|-------|-----------------|
+| **T1 Compile** | Every push / PR | `./gradlew build -x test` all 56 modules | No |
+| **T2 Smoke** | Every weekday (nightly) | In-memory modules only (no Testcontainers) | No |
+| **T3 Full** | Every Sunday (nightly) | All 56 modules including Testcontainers | Yes |
+| **T4 Local group** | Developer convenience | Per-domain `scripts/smoke-validate.sh <group>` | Depends |
+
+---
+
+## 2. Module Classification
+
+### T2 Smoke — No Testcontainers (23 modules)
+
+| Module (Gradle project) | Domain group |
+|-------------------------|-------------|
+| `:jackson-examples` | Serialization |
+| `:jsonview-examples` | Serialization |
+| `:okio-examples` | Serialization |
+| `:kotlin-design-patterns` | Async/Reactive |
+| `:spring-boot-application-event-demo` | Spring Boot Operations |
+| `:spring-boot-cache-caffeine` | Spring Boot Operations |
+| `:spring-boot-cbor-mvc` | Spring Boot Operations |
+| `:spring-boot-chaos-monkey` | Spring Boot Operations |
+| `:spring-boot-problem` | Spring Boot Operations |
+| `:spring-boot-protobuf-mvc` | Spring Boot Operations |
+| `:spring-boot-resilience4j-coroutines` | Spring Boot Operations |
+| `:spring-boot-stomp-websocket` | Spring Boot Operations |
+| `:spring-boot-webflux-coroutines` | Spring Boot Operations |
+| `:spring-boot-webflux-websocket` | Spring Boot Operations |
+| `:spring-data-r2dbc-examples` | Data Access |
+| `:spring-data-r2dbc-webflux-exposed` | Data Access |
+| `:spring-modulith-events-deep-dive` | Spring Boot Operations |
+| `:spring-security-mvc-hello` | Spring Boot Operations |
+| `:spring-security-webflux-hello-security` | Spring Boot Operations |
+| `:spring-security-webflux-jwt` | Spring Boot Operations |
+| `:vertx-coroutines` | Async/Reactive |
+| `:virtualthreads-rules` | Observability/Performance |
+| `:micrometer-observation` | Observability/Performance |
+
+> **Known skip**: `:spring-data-r2dbc-webflux` — tests disabled pending #120 schema fix.
+
+### T3 Full — Testcontainers (33 modules)
+
+| Module | Infrastructure needed |
+|--------|-----------------------|
+| `:exposed-domain` | PostgreSQL |
+| `:exposed-dao-web-transaction` | PostgreSQL |
+| `:exposed-spring-transaction` | PostgreSQL |
+| `:exposed-sql-web-virtualthread` | PostgreSQL |
+| `:exposed-sql-webflux-coroutines` | PostgreSQL |
+| `:spring-data-r2dbc-coroutines` | PostgreSQL |
+| `:spring-data-r2dbc-webflux` | PostgreSQL (#120 disabled) |
+| `:spring-data-jpa-querydsl` | PostgreSQL |
+| `:spring-data-mongodb-coroutines` | MongoDB |
+| `:spring-data-mongodb-transactions` | MongoDB |
+| `:spring-data-elasticsearch` | Elasticsearch |
+| `:spring-data-elasticsearch-webflux` | Elasticsearch |
+| `:spring-data-redis-examples` | Redis |
+| `:spring-boot-cache-redis` | Redis |
+| `:spring-modulith-jpa-demo` | PostgreSQL |
+| `:messaging-kafka` | Kafka |
+| `:messaging-kafka-reply` | Kafka |
+| `:redis-cluster-demo` | Redis Cluster |
+| `:redis-redisson-examples` | Redis |
+| `:bucker4j-bluetape4k-webflux` | Redis |
+| `:bucket4j-redis` | Redis |
+| `:micrometer-tracing-coroutines` | Zipkin / OTLP |
+| `:gatling-virtualthread-simulation` | HTTP target |
+| `:kotlin-coroutines` | (misc Testcontainers) |
+| `:virtualthreads-spring-mvc-tomcat` | PostgreSQL |
+| `:virtualthreads-spring-webflux` | PostgreSQL |
+| `:vertx-vertx-sqlclient` | PostgreSQL |
+| `:vertx-vertx-webclient` | HTTP target |
+| `:aws-s3-spring-cloud` | LocalStack S3 |
+| `:api-gateway` | Redis + downstream |
+| `:customers` | (none currently) |
+| `:orders` | (none currently) |
+| `:spring-data-r2dbc-webflux-exposed` | (H2 in-memory — smoke OK) |
+
+---
+
+## 3. Per-Domain Smoke Commands
+
+Run via `scripts/smoke-validate.sh <group>` or directly:
+
+### Data Access (in-memory subset)
+```bash
+./gradlew :spring-data-r2dbc-examples:test :spring-data-r2dbc-webflux-exposed:test --continue
+```
+
+### Data Access (Testcontainers)
+```bash
+./gradlew :exposed-dao-web-transaction:test :exposed-spring-transaction:test \
+  :exposed-sql-web-virtualthread:test :exposed-sql-webflux-coroutines:test \
+  :spring-data-r2dbc-coroutines:test :spring-data-jpa-querydsl:test \
+  :spring-data-mongodb-coroutines:test :spring-data-mongodb-transactions:test \
+  :spring-data-elasticsearch:test :spring-data-elasticsearch-webflux:test \
+  :spring-data-redis-examples:test --continue --max-workers=1
+```
+
+### Spring Boot Operations (smoke)
+```bash
+./gradlew :spring-boot-application-event-demo:test :spring-boot-cache-caffeine:test \
+  :spring-boot-problem:test :spring-boot-resilience4j-coroutines:test \
+  :spring-boot-webflux-coroutines:test :spring-boot-webflux-websocket:test \
+  :spring-boot-chaos-monkey:test :spring-boot-stomp-websocket:test \
+  :spring-modulith-events-deep-dive:test \
+  :spring-security-mvc-hello:test :spring-security-webflux-hello-security:test \
+  :spring-security-webflux-jwt:test --continue
+```
+
+### Serialization and Messaging (smoke)
+```bash
+./gradlew :jackson-examples:test :jsonview-examples:test :okio-examples:test --continue
+```
+
+### Serialization and Messaging (Testcontainers)
+```bash
+./gradlew :messaging-kafka:test :messaging-kafka-reply:test --continue --max-workers=1
+```
+
+### Async and Reactive
+```bash
+./gradlew :kotlin-coroutines:test :kotlin-design-patterns:test \
+  :vertx-coroutines:test :vertx-vertx-sqlclient:test :vertx-vertx-webclient:test --continue
+```
+
+### Observability and Performance
+```bash
+./gradlew :micrometer-observation:test :micrometer-tracing-coroutines:test \
+  :virtualthreads-rules:test :virtualthreads-spring-mvc-tomcat:test \
+  :virtualthreads-spring-webflux:test --continue --max-workers=1
+```
+
+### Redis / Architecture Extensions
+```bash
+./gradlew :redis-cluster-demo:test :redis-redisson-examples:test \
+  :bucker4j-bluetape4k-webflux:test :bucket4j-redis:test --continue --max-workers=1
+```
+
+---
+
+## 4. Stale-Include Guard
+
+```bash
+# Verify no stale Gradle project registrations
+./gradlew projects -q | grep "Project ':" | wc -l
+# Expected: 56 (as of 2026-05-22 after #78)
+
+# Verify removed modules are not referenced in any README
+for m in async-logging kotlin/workshop reactive/mutiny gatling/gradle-plugin-demo mapping/mapstruct; do
+  rg "$m" --include="*.md" . && echo "STALE: $m" || true
+done
+```
+
+---
+
+## 5. README Link Check
+
+```bash
+# Check all relative image links in READMEs resolve to existing files
+fd README.md . --exclude .worktrees | xargs -I{} bash -c '
+  dir=$(dirname {})
+  rg "!\[.*\]\(([^)]+)\)" {} -o -r '"'"'$1'"'"' | while read link; do
+    [[ "$link" =~ ^http ]] && continue
+    [[ -f "$dir/$link" ]] || echo "BROKEN: {} → $link"
+  done
+'
+```
+
+---
+
+## 6. Acceptance Criteria Status
+
+- [x] Validation matrix defined (T1/T2/T3/T4 tiers)
+- [x] Module classification: 23 smoke-safe, 33 Testcontainers
+- [x] Per-domain smoke commands documented
+- [x] `scripts/smoke-validate.sh` added
+- [x] Nightly CI updated with daily T2 smoke-test job
+- [x] Stale-include check: 56 modules, no stale refs
+- [x] README link check command documented
+- [ ] #120 (`r2dbc-webflux` disabled tests) tracked separately

--- a/scripts/smoke-validate.sh
+++ b/scripts/smoke-validate.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+# smoke-validate.sh — Domain-group targeted test runner for bluetape4k-workshop
+#
+# Usage:
+#   ./scripts/smoke-validate.sh <group>
+#   ./scripts/smoke-validate.sh all-smoke     # all no-Testcontainers modules
+#   ./scripts/smoke-validate.sh compile       # compile-only (no tests)
+#   ./scripts/smoke-validate.sh stale-check   # Gradle project count + README link check
+#
+# Groups: data-access  spring-boot  serialization  messaging  async  observability  redis
+# Each group runs with --continue so a single failure does not abort the rest.
+
+set -euo pipefail
+
+GRADLEW="./gradlew"
+MAX_WORKERS="${MAX_WORKERS:-2}"
+
+run() {
+  echo "▶ $*"
+  eval "$*"
+}
+
+case "${1:-help}" in
+
+  compile)
+    run "$GRADLEW build -x test --parallel --continue"
+    ;;
+
+  all-smoke)
+    run "$GRADLEW \
+      :jackson-examples:test \
+      :jsonview-examples:test \
+      :okio-examples:test \
+      :kotlin-design-patterns:test \
+      :micrometer-observation:test \
+      :spring-boot-application-event-demo:test \
+      :spring-boot-cache-caffeine:test \
+      :spring-boot-cbor-mvc:test \
+      :spring-boot-chaos-monkey:test \
+      :spring-boot-problem:test \
+      :spring-boot-protobuf-mvc:test \
+      :spring-boot-resilience4j-coroutines:test \
+      :spring-boot-stomp-websocket:test \
+      :spring-boot-webflux-coroutines:test \
+      :spring-boot-webflux-websocket:test \
+      :spring-data-r2dbc-examples:test \
+      :spring-data-r2dbc-webflux-exposed:test \
+      :spring-modulith-events-deep-dive:test \
+      :spring-security-mvc-hello:test \
+      :spring-security-webflux-hello-security:test \
+      :spring-security-webflux-jwt:test \
+      :vertx-coroutines:test \
+      :virtualthreads-rules:test \
+      --continue"
+    ;;
+
+  data-access)
+    # Smoke (in-memory / H2)
+    run "$GRADLEW \
+      :spring-data-r2dbc-examples:test \
+      :spring-data-r2dbc-webflux-exposed:test \
+      --continue"
+    ;;
+
+  data-access-full)
+    # Testcontainers required
+    run "$GRADLEW \
+      :exposed-dao-web-transaction:test \
+      :exposed-spring-transaction:test \
+      :exposed-sql-web-virtualthread:test \
+      :exposed-sql-webflux-coroutines:test \
+      :spring-data-r2dbc-coroutines:test \
+      :spring-data-jpa-querydsl:test \
+      :spring-data-mongodb-coroutines:test \
+      :spring-data-mongodb-transactions:test \
+      :spring-data-elasticsearch:test \
+      :spring-data-elasticsearch-webflux:test \
+      :spring-data-redis-examples:test \
+      --continue --max-workers=1"
+    ;;
+
+  spring-boot)
+    run "$GRADLEW \
+      :spring-boot-application-event-demo:test \
+      :spring-boot-cache-caffeine:test \
+      :spring-boot-problem:test \
+      :spring-boot-resilience4j-coroutines:test \
+      :spring-boot-webflux-coroutines:test \
+      :spring-boot-webflux-websocket:test \
+      :spring-boot-chaos-monkey:test \
+      :spring-boot-cbor-mvc:test \
+      :spring-boot-protobuf-mvc:test \
+      :spring-boot-stomp-websocket:test \
+      :spring-modulith-events-deep-dive:test \
+      :spring-security-mvc-hello:test \
+      :spring-security-webflux-hello-security:test \
+      :spring-security-webflux-jwt:test \
+      --continue"
+    ;;
+
+  serialization)
+    run "$GRADLEW \
+      :jackson-examples:test \
+      :jsonview-examples:test \
+      :okio-examples:test \
+      --continue"
+    ;;
+
+  messaging)
+    # Testcontainers: Kafka
+    run "$GRADLEW \
+      :messaging-kafka:test \
+      :messaging-kafka-reply:test \
+      --continue --max-workers=1"
+    ;;
+
+  async)
+    run "$GRADLEW \
+      :kotlin-coroutines:test \
+      :kotlin-design-patterns:test \
+      :vertx-coroutines:test \
+      :vertx-vertx-sqlclient:test \
+      :vertx-vertx-webclient:test \
+      --continue"
+    ;;
+
+  observability)
+    run "$GRADLEW \
+      :micrometer-observation:test \
+      :micrometer-tracing-coroutines:test \
+      :virtualthreads-rules:test \
+      :virtualthreads-spring-mvc-tomcat:test \
+      :virtualthreads-spring-webflux:test \
+      --continue --max-workers=1"
+    ;;
+
+  redis)
+    run "$GRADLEW \
+      :redis-cluster-demo:test \
+      :redis-redisson-examples:test \
+      :bucker4j-bluetape4k-webflux:test \
+      :bucket4j-redis:test \
+      --continue --max-workers=1"
+    ;;
+
+  stale-check)
+    echo "=== Gradle project count ==="
+    count=$("$GRADLEW" projects -q 2>/dev/null | grep -c "Project ':'")
+    echo "Active modules: $count (expected: 56)"
+
+    echo ""
+    echo "=== Stale module refs in READMEs ==="
+    stale=0
+    for m in async-logging kotlin/workshop reactive/mutiny gatling/gradle-plugin-demo mapping/mapstruct; do
+      if rg -l "$m" --include="*.md" . 2>/dev/null | grep -qv "\.worktrees\|docs/lessons\|docs/superpowers"; then
+        echo "STALE REF: $m"
+        stale=$((stale + 1))
+      fi
+    done
+    [ "$stale" -eq 0 ] && echo "No stale refs found." || echo "WARNING: $stale stale ref(s) found."
+
+    echo ""
+    echo "=== README broken image links ==="
+    broken=0
+    while IFS= read -r readme; do
+      dir=$(dirname "$readme")
+      while IFS= read -r link; do
+        [[ "$link" =~ ^http ]] && continue
+        if [[ ! -f "$dir/$link" ]]; then
+          echo "BROKEN: $readme → $link"
+          broken=$((broken + 1))
+        fi
+      done < <(rg '!\[.*\]\(([^ ")\t]+)' "$readme" -o -r '$1' 2>/dev/null || true)
+    done < <(fd README.md . --exclude .worktrees --exclude build)
+    [ "$broken" -eq 0 ] && echo "No broken image links found." || echo "WARNING: $broken broken link(s) found."
+    ;;
+
+  help|*)
+    echo "Usage: $0 <group>"
+    echo ""
+    echo "Groups:"
+    echo "  compile          Compile all modules (no tests)"
+    echo "  all-smoke        All no-Testcontainers modules"
+    echo "  data-access      Data Access (in-memory)"
+    echo "  data-access-full Data Access (Testcontainers)"
+    echo "  spring-boot      Spring Boot Operations (smoke)"
+    echo "  serialization    Jackson / JSON / Okio"
+    echo "  messaging        Kafka (Testcontainers)"
+    echo "  async            Coroutines / Vert.x"
+    echo "  observability    Micrometer / Virtual Threads"
+    echo "  redis            Redis / Redisson / Rate Limit"
+    echo "  stale-check      Gradle project count + README link check"
+    ;;
+esac


### PR DESCRIPTION
## Summary

Implements Issue #91 — workshop validation framework to keep the curated module set buildable and testable after each Epic #76 wave.

## Changes

### `scripts/smoke-validate.sh`
Domain-group runner: `all-smoke`, `data-access`, `spring-boot`, `serialization`, `messaging`, `async`, `observability`, `redis`, `stale-check`.

### `.github/workflows/nightly.yml`
Added `smoke-test` job (T2) — runs daily Mon–Sat on 23 no-Testcontainers modules without Docker. Full Testcontainers job stays Sunday-only (T3).

| Tier | Trigger | Docker |
|------|---------|--------|
| T1 Compile | Every push/PR | No |
| T2 Smoke | Daily Mon–Sat | No |
| T3 Full | Sunday | Yes |

### `docs/superpowers/specs/`
Full matrix: 23 smoke-safe modules, 33 Testcontainers modules, per-domain commands, stale-include guard, README link-check command.

## Verification

```bash
./gradlew projects --no-daemon -q | grep -c '^+---'  # 56 modules
bash scripts/smoke-validate.sh stale-check           # 0 stale refs, 0 broken links
actionlint .github/workflows/nightly.yml             # OK
```

Closes #91
Parent Epic: #76