### PR TITLE
chore: verify H2 2.4.240 compatibility in vertx and spring-boot modules (#146)

### DIFF
--- a/docs/lessons/2026-05-23-issue-146-h2-compat.md
+++ b/docs/lessons/2026-05-23-issue-146-h2-compat.md
@@ -1,0 +1,27 @@
+# Lesson: Issue #146 — H2 2.4.240 Compatibility Verification
+
+**Date**: 2026-05-23  
+**Branch**: `chore/issue-146-h2-compat`
+
+## Findings
+
+H2 was bumped from 1.4.197 → 2.4.240 in `gradle/libs.versions.toml` (alias `h2-lib`).
+
+All 4 affected modules pass with H2 2.4.240:
+
+| Module | H2 scope | Test result |
+|--------|----------|-------------|
+| `vertx-coroutines` | `implementation` | ✅ 3/3 pass |
+| `vertx-vertx-sqlclient` | `testImplementation` | ✅ 14/14 pass |
+| `spring-boot-chaos-monkey` | `implementation` | ✅ 2/2 pass |
+| `redis-redisson-examples` | `testRuntimeOnly` | ⚠️ H2 not exercised; failures are pre-existing `ForyBinarySerializer NoSuchMethodError` (tracked separately) |
+
+## Conclusion
+
+No SQL compatibility fixes needed. H2 2.4.x strict SQL mode, IDENTITY column changes,
+and sequence handling do not affect these modules' usage patterns (embedded in-memory, simple DDL).
+
+## Action
+
+- `redis-redisson-examples` Fory serializer failures tracked as separate issue.
+- No changes required to application or test code.


### PR DESCRIPTION
Closes #146

## Verification Results

H2 `2.4.240` (already in `gradle/libs.versions.toml` as `h2-lib`) is confirmed compatible with all affected modules.

| Module | H2 Scope | Tests | Result |
|--------|----------|-------|--------|
| `vertx-coroutines` | `implementation` | 3 | ✅ |
| `vertx-vertx-sqlclient` | `testImplementation` | 14 | ✅ |
| `spring-boot-chaos-monkey` | `implementation` | 2 | ✅ |
| `redis-redisson-examples` | `testRuntimeOnly` | H2 not exercised | ⚠️ pre-existing Fory failures (unrelated) |

## Conclusion

No code changes required. H2 2.4.x strict SQL mode and IDENTITY column changes do not affect these modules.

The `redis-redisson-examples` `ForyBinarySerializer NoSuchMethodError` failures are pre-existing and unrelated to H2 — they should be tracked as a separate issue.

## Verification Commands

```bash
./gradlew :vertx-coroutines:test :vertx-vertx-sqlclient:test :spring-boot-chaos-monkey:test
```