### PR TITLE
chore: align workshop bluetape4k versions with dependencies BOM

### DIFF
--- a/docs/lessons/2026-05-23-dependencies-only-consumer-policy.md
+++ b/docs/lessons/2026-05-23-dependencies-only-consumer-policy.md
@@ -1,0 +1,30 @@
+# Dependencies-Only Consumer Policy
+
+## Context
+
+The workshop repository previously carried direct bluetape4k artifact version
+aliases while also importing the ecosystem BOM. That made release upgrades
+harder because the BOM and local aliases could drift independently.
+
+## Decision
+
+Use `bluetape4k-dependencies` as the only bluetape4k version source in the
+version catalog. Keep bluetape4k artifact aliases versionless so dependency
+management resolves them from the BOM.
+
+## Outcome
+
+The catalog now removes direct bluetape4k version refs, imports
+`bluetape4k-dependencies`, and uses the current BOM-managed Spring Boot core
+artifact coordinate.
+
+## Verification
+
+Ran forbidden-reference grep, `git diff --check`, and
+`./gradlew :redis-redisson-examples:compileKotlin --no-daemon --no-configuration-cache`.
+
+## Future Guidance
+
+For release-upgrade PRs, update only the `bluetape4k-dependencies` version for
+bluetape4k ecosystem artifacts unless a module intentionally consumes a
+non-BOM artifact.


### PR DESCRIPTION
## Summary\n- make bluetape4k-dependencies the only bluetape4k version source\n- remove direct bluetape4k artifact version refs from the catalog\n- switch Spring Boot core usage to the current BOM-managed artifact\n- add a release-upgrade lesson for future consumer repo updates\n\n## Verification\n- forbidden-reference grep across workshop/application catalogs\n- git diff --check\n- ./gradlew :redis-redisson-examples:compileKotlin --no-daemon --no-configuration-cache