### PR TITLE
feat: Add redis/distributed-lock workshop module (Issue #101)

### DIFF
--- a/docs/lessons/2026-05-23-issue-101-distributed-lock.md
+++ b/docs/lessons/2026-05-23-issue-101-distributed-lock.md
@@ -1,0 +1,156 @@
+# 교훈: redis/distributed-lock 모듈 구현 (Issue #101)
+
+**날짜**: 2026-05-23  
+**작업자**: debop  
+**관련 이슈**: #101  
+**브랜치**: `feat/issue-101-distributed-lock`  
+**모듈**: `redis/distributed-lock`
+
+---
+
+## 작업 요약
+
+Redisson을 활용한 분산 락 전략 4단계 워크샵 모듈 신규 구현.  
+비안전 공유 상태(oversell 재현) → RLock → RFencedLock (블로킹) → 코루틴 네이티브 RFencedLock 순으로 시연.
+
+---
+
+## 발견된 버그 및 수정 내역
+
+### B1. `log.warn { }` 람다 구문 컴파일 에러
+
+**원인**: bluetape4k의 lazy lambda 로깅 확장은 `import io.bluetape4k.logging.warn`이 별도로 필요함.  
+표준 SLF4J `Logger`는 람다 형식이 아닌 문자열만 받음.
+
+**수정**: 세 서비스 파일에 `import io.bluetape4k.logging.warn` 추가.  
+**교훈**: `log.warn { }` / `log.debug { }` 람다 구문을 쓸 때는 `io.bluetape4k.logging.*` 확장 import가 반드시 필요함.
+
+---
+
+### B2. `NoClassDefFoundError: Snowflakers` — 런타임 실패
+
+**원인**: `getLockId()` 함수가 내부적으로 `bluetape4k-idgenerators` 모듈의 `Snowflakers`를 사용하지만,  
+`bluetape4k-redisson`이 해당 모듈을 transitive로 포함하지 않아 런타임에 누락됨.
+
+**수정**: `build.gradle.kts`에 `implementation(libs.bluetape4k.idgenerators)` 명시적 추가.  
+**교훈**: `getLockId()`를 쓰는 모든 Redisson 모듈은 `bluetape4k-idgenerators`를 명시 의존으로 선언해야 함.
+
+---
+
+### B3. Smoke 태그 제외가 Gradle에서 미동작
+
+**원인**: `junit-platform.properties`의 `junit.jupiter.execution.exclude.tags=smoke`는  
+Gradle JUnit Platform Provider에서 신뢰성 있게 존중되지 않음.
+
+**수정**:  
+```kotlin
+tasks.named<Test>("test") {
+    useJUnitPlatform { excludeTags("smoke") }
+}
+```
+을 `build.gradle.kts`에 명시적으로 추가.  
+**교훈**: Gradle에서 JUnit 태그 제외는 반드시 `tasks.named<Test>()` DSL로 설정해야 함.  
+`junit-platform.properties` 단독 설정은 불충분.
+
+---
+
+### B4. `SuspendedJobTester.rounds()` 의미론 오해
+
+**원인**: `SuspendedJobTester.workers(20).rounds(1)` → `totalUnits = 1 × blockCount(1) = 1`만 실행.  
+stock=100/qty=10 → 성공 1건 예상했으나 10건 필요.
+
+**수정**: `rounds(20)` + `waitMs = 5000L`로 변경.  
+**공식**: `totalUnits = rounds × blockCount` (workers는 병렬 실행자 수).  
+**교훈**: `SuspendedJobTester`에서 총 시도 횟수 = `rounds * blockCount`. `workers`는 동시 실행자 수.
+
+---
+
+### B5. RLock/RFencedLock 재진입 가능 — 동일 스레드 락 선점 무효
+
+**원인**: P1 리뷰 수정 중 LockNotAcquired 테스트에서 메인 테스트 스레드로 락을 선점한 후  
+동일 스레드에서 서비스를 호출했더니 락이 재진입 허용되어 `Success` 반환.
+
+**수정**: 별도 `Thread { }` + `CountDownLatch(1)`로 백그라운드 스레드에서 락 선점.  
+```kotlin
+val holder = Thread {
+    val held = lock.tryLock(...)
+    acquireLatch.countDown()
+    if (held) { releaseLatch.await(); lock.unlock() }
+}
+holder.start()
+acquireLatch.await()  // 선점 완료 확인 후 테스트 진행
+```
+**교훈**: Redisson RLock/RFencedLock은 재진입 가능(reentrant). LockNotAcquired 테스트는 반드시 다른 스레드에서 락을 선점해야 함.
+
+---
+
+## 설계 결정
+
+### D1. FencedResource 토큰 비교 — strict less-than
+
+`token < current` (엄격 미만)을 사용. `token == current`는 **허용** (동일 리스 기간 내 재진입).  
+`token <= current` 사용 시 정상 재진입도 거부하여 Redisson 토큰 동작과 불일치.
+
+### D2. SuspendingFencedInventoryService — NonCancellable unlock
+
+`withContext(NonCancellable) { fLock.unlockAsync(lockId).await() }`는 필수 패턴.  
+이 없으면 코루틴 취소 시 `await()`가 `CancellationException`을 던지고 unlock이 완료되지 않아  
+리스 만료 시까지 락이 유지됨.
+
+### D3. Two-Step Acquire — tryLockAsync + tokenAsync
+
+Redisson 4.x에는 `tryLockAndGetTokenAsync(lockId)` 오버로드가 없음.  
+올바른 패턴: `tryLockAsync(wait, lease, unit, lockId)` 후 `fLock.tokenAsync.await()` 별도 호출.
+
+### D4. getLockId() Snowflake ID
+
+`redisson.getLockId(lockName)`은 `bluetape4k-redisson`이 제공하는 확장 함수.  
+내부적으로 Snowflake ID를 사용해 코루틴-안전한 락 식별자를 생성함.  
+coroutine에서 threadId 기반 락 ID를 쓰면 동일 스레드 재사용 시 충돌 위험.
+
+### D5. beforeWork 테스트 심
+
+`SuspendingFencedInventoryService`에 `beforeWork: suspend () -> Unit = {}` 파라미터를 주입.  
+취소 테스트에서 `delay(500)` 주입 → 락 보유 중 취소 시점을 결정론적으로 만들 수 있음.
+
+---
+
+## 코드 리뷰 결과 (Step 6-R)
+
+| 심각도 | 초기 | 최종 |
+|--------|------|------|
+| P0 (CRITICAL) | 0 | 0 |
+| P1 (HIGH) | 2 | 0 |
+| P2 (MEDIUM) | 3 | 0 |
+
+**P1 수정:**
+1. `Rejected` 서비스 경로 미테스트 → `FencedLockTest` + `SuspendFencedLockTest`에 pre-seed 테스트 추가
+2. `LockNotAcquired` 서비스 경로 미테스트 → 3개 테스트 클래스에 백그라운드 스레드 테스트 추가
+
+**P2 수정:**
+1. `assert(raceObserved)` → `raceObserved.shouldBeTrue()` (bluetape4k-assertions 준수)
+2. 이중 cast `(result as InsufficientStock)` 두 번 → `val insufficient = result as InsufficientStock`
+
+---
+
+## 최종 테스트 결과
+
+```
+BaselineRaceTest:      3 tests, 0 failures
+DistributedLockTest:   6 tests, 0 failures
+FencedLockTest:        5 tests, 0 failures
+SuspendFencedLockTest: 6 tests, 0 failures
+Total:                20 tests, 0 failures, 0 errors
+```
+
+Smoke 테스트 (`FencedStaleHolderTest`, `LockFailureTest`)는 기본 CI에서 제외.
+
+---
+
+## 미래 참고 사항
+
+- `SuspendedJobTester.workers(N).rounds(R)` → `totalUnits = R × blockCount` (N은 병렬성)
+- bluetape4k의 `log.warn { }` 사용 시 `import io.bluetape4k.logging.warn` 필수
+- `getLockId()` 사용 시 `bluetape4k-idgenerators`를 명시 의존으로 선언
+- Gradle에서 smoke 태그 제외는 `tasks.named<Test>() { useJUnitPlatform { excludeTags("smoke") } }`
+- Redisson RLock/RFencedLock 재진입 허용 → LockNotAcquired 테스트는 별도 스레드 사용

--- a/docs/superpowers/plans/2026-05-23-distributed-lock-plan.md
+++ b/docs/superpowers/plans/2026-05-23-distributed-lock-plan.md
@@ -15,10 +15,11 @@
 |---|---|---|
 | 1 | Module scaffold (build, app entry, resources) | T1–T6 |
 | 2 | Domain layer (Inventory, DeductionResult, InventoryStore) | T7–T9 |
-| 3 | Core services (Unsafe, Locked, Fenced, SuspendingFenced) | T10–T13 |
-| 4 | Fenced guard (FencedResource, FencedResources) | T14–T15 |
+| 3 | Fenced guard (FencedResource, FencedResources) | T10–T11 |
+| 4 | Core services (Unsafe, Locked, Fenced, SuspendingFenced) | T12–T15 |
 | 5 | Tests (Abstract base + 6 test classes) | T16–T22 |
 | 6 | Documentation (README en/ko + KDoc 정리) | T23–T25 |
+| 7 | CI integration (smoke-validate.sh) | T26 |
 
 ---
 
@@ -33,15 +34,16 @@
   - `plugins { alias(libs.plugins.kotlin.spring); alias(libs.plugins.spring.boot) }`.
   - `springBoot { mainClass.set("io.bluetape4k.workshop.lock.DistributedLockAppKt") }`.
   - `configurations { testImplementation.get().extendsFrom(compileOnly.get(), runtimeOnly.get()) }`.
+  - Java toolchain 설정: `java { toolchain { languageVersion.set(JavaLanguageVersion.of(21)) } }` (sibling 모듈 패턴).
   - Dependencies (lean — no grpc/protobuf/fory/kryo/cache like redisson-examples):
     - `implementation(libs.bluetape4k.redis)`
     - `implementation(libs.redisson.lib)` + `implementation(libs.redisson.spring.boot.starter)`
     - `implementation(libs.bluetape4k.coroutines)` + `implementation(libs.kotlinx.coroutines.core.lib)`
     - `implementation(libs.bluetape4k.logging)`
-    - `implementation(libs.spring.boot.autoconfigure.lib)` + `implementation(libs.spring.boot.starter.actuator)` (sibling pattern; bare starter key 없음)
-    - `annotationProcessor(libs.spring.boot.autoconfigure.processor)` + `annotationProcessor(libs.spring.boot.configuration.processor)`
+    - `implementation(libs.spring.boot.autoconfigure.lib)` + `implementation(libs.spring.boot.starter.actuator)`
     - Tests: `testImplementation(project(":shared"))`, `libs.bluetape4k.junit5`, `libs.bluetape4k.testcontainers`, `libs.bluetape4k.assertions`, `libs.kotlinx.coroutines.test.lib`
     - `testImplementation(libs.spring.boot.starter.test) { exclude junit, junit-vintage-engine, mockito-core }`
+  - **`annotationProcessor` 없음** — 워크샵 앱은 자동설정 메타데이터 생성 불필요 (R9).
   - settings.gradle.kts 는 **수정하지 않음** (이미 `includeModules("redis", false, true)` 가 디렉토리 추가 시 자동 등록).
 
 ### T2 — `DistributedLockApp.kt` (Spring Boot entry)
@@ -61,6 +63,7 @@
   - `src/main/resources/application.yaml`
 - **notes**:
   - `spring.application.name: distributed-lock-workshop`.
+  - `spring.main.web-application-type: none` — 웹 서버 불필요 (워크샵 데모 앱, R7).
   - `spring.redisson.config: classpath:redisson.yaml` (Redisson Spring Boot Starter convention).
   - Actuator endpoints exposure minimal (health).
 
@@ -80,7 +83,14 @@
   - `src/test/resources/application.yaml`
   - `src/test/resources/junit-platform.properties`
 - **notes**:
-  - `application.yaml`: `spring.application.name: distributed-lock-test` + actuator minimal.
+  - `application.yaml`:
+    ```yaml
+    spring:
+      application:
+        name: distributed-lock-test
+      main:
+        web-application-type: none   # 테스트에서도 웹 서버 불필요 (R7)
+    ```
   - `junit-platform.properties`:
     ```
     junit.jupiter.extensions.autodetection.enabled=true
@@ -138,102 +148,33 @@
 - **files**:
   - `src/main/kotlin/io/bluetape4k/workshop/lock/domain/InventoryStore.kt`
 - **notes**:
-  - `@Component`, internal state: `private val store = ConcurrentHashMap<Long, AtomicInteger>()`.
-  - API: `register(Inventory)`, `currentStock(id: Long): Int`, `applyChange(id: Long, delta: Int): Int` (returns new value), `reset(id: Long, value: Int)`.
-  - `applyChange` 는 `addAndGet(delta)` 사용 — race 데모를 위해 의도적으로 원자적.
-  - 미등록 ID 조회 시 `IllegalArgumentException` 명시.
+  - **`@Component` 없음** — 테스트에서 직접 생성, Spring DI 제외 (R4).
+  - Internal state: `private val store = ConcurrentHashMap<Long, AtomicInteger>()`.
+  - API:
+    - `fun register(inventory: Inventory)` — 재등록 시 초기값으로 리셋.
+    - `fun currentStock(id: Long): Int` — 미등록 ID 시 `IllegalArgumentException`.
+    - `fun applyChange(id: Long, delta: Int): Int` — `addAndGet(delta)` 반환 (atomic, race 데모용).
+    - `fun reset(id: Long, value: Int)` — 단일 ID 리셋.
+    - `fun resetAll()` — 전체 스토어 클리어 (`store.clear()`). **@BeforeEach 격리용 (R5).**
   - `companion object : KLogging()`.
 
 ---
 
-## Phase 3: Core Services
+## Phase 3: Fenced Guard
 
-### T10 — `UnsafeInventoryService` (race demo)
+> **⚠️ Phase 3 가 Phase 4 보다 먼저여야 함** — `FencedInventoryService`(T14) 와 `SuspendingFencedInventoryService`(T15) 가 `FencedResources`(T11) 에 의존. 순서 바뀌면 컴파일 실패.
 
-- **complexity**: medium
-- **files**:
-  - `src/main/kotlin/io/bluetape4k/workshop/lock/service/UnsafeInventoryService.kt`
-- **notes**:
-  - 생성자: `(private val store: InventoryStore)`. (`@Service` 불필요 — 테스트에서 직접 생성)
-  - `fun deduct(id: Long, qty: Int): DeductionResult`:
-    1. `qty.requirePositiveNumber("qty")` ← **반드시 첫 줄**.
-    2. `val current = store.currentStock(id)` (READ).
-    3. `if (current < qty) return InsufficientStock(qty, current)`.
-    4. **`Thread.sleep(1)`** — 강제 race window (spec Risk 1).
-    5. `val remaining = store.applyChange(id, -qty)` (WRITE).
-    6. `return Success(remaining)`.
-  - `companion object : KLogging()`.
-  - KDoc: "이 클래스는 의도적으로 race condition 을 시연한다. 운영에 사용 금지."
-
-### T11 — `LockedInventoryService` (RLock)
-
-- **complexity**: medium
-- **files**:
-  - `src/main/kotlin/io/bluetape4k/workshop/lock/service/LockedInventoryService.kt`
-- **notes**:
-  - 생성자: `(private val redisson: RedissonClient, private val store: InventoryStore)`.
-  - 시그니처: `fun deduct(id: Long, qty: Int, waitMs: Long = 2000L, leaseMs: Long = 5000L): DeductionResult`.
-  - 흐름:
-    1. `qty.requirePositiveNumber("qty")`.
-    2. `val lockName = "inventory:lock:$id"` + `val lock = redisson.getLock(lockName)`.
-    3. `val acquired = lock.tryLock(waitMs, leaseMs, MILLISECONDS)` — **3인수 형태 필수** (watchdog 비활성화, spec Risk 3).
-    4. 실패 시 `LockNotAcquired(lockName)` 반환, warn 로그.
-    5. `try { ... } finally { if (lock.isHeldByCurrentThread) lock.unlock() }`.
-  - `companion object : KLogging()`.
-
-### T12 — `FencedInventoryService` (RFencedLock, blocking)
-
-- **complexity**: high
-- **files**:
-  - `src/main/kotlin/io/bluetape4k/workshop/lock/service/FencedInventoryService.kt`
-- **notes**:
-  - 생성자: `(redisson, store, fencedResources)`.
-  - 흐름:
-    1. `qty.requirePositiveNumber("qty")`.
-    2. `val lockName = "inventory:fenced:$id"` + `val fLock = redisson.getFencedLock(lockName)`.
-    3. `val token = fLock.tryLockAndGetToken(waitMs, leaseMs, MILLISECONDS)` (blocking 경로는 원자적 메서드 OK — threadId 문제 없음).
-    4. `token == null` → `LockNotAcquired`.
-    5. `fencedResources.forResource(id).apply(token) { ... } ?: Rejected(token)`.
-    6. `finally { runCatching { fLock.unlock() }.onFailure { log.warn(e) { "Fenced unlock failed (lease may have expired)" } } }` (lease 만료 시 IllegalMonitorStateException 흡수).
-  - `companion object : KLogging()`.
-
-### T13 — `SuspendingFencedInventoryService` (coroutine + fenced)
-
-- **complexity**: high
-- **files**:
-  - `src/main/kotlin/io/bluetape4k/workshop/lock/service/SuspendingFencedInventoryService.kt`
-- **notes**:
-  - `@Service`, 생성자: `(redisson, store, fencedResources)`.
-  - `companion object : KLoggingChannel()` ← **suspend service 전용 로거**.
-  - `suspend fun deduct(id: Long, qty: Int, waitMs: Long = 2000L, leaseMs: Long = 5000L): DeductionResult`.
-  - **상세 흐름 (spec §6.4 계약 — 위반 시 락 리크):**
-    1. `qty.requirePositiveNumber("qty")`.
-    2. `val lockName = "inventory:sfenced:$id"`.
-    3. **`val lockId = redisson.getLockId(lockName)`** — 한 번만 결정, acquire/release 동일 값 사용 (수명주기 계약).
-    4. `val fLock = redisson.getFencedLock(lockName)`.
-    5. **두 단계 (Redisson 4.4.0 에는 `tryLockAndGetTokenAsync(..., lockId)` 변형 없음):**
-       - `val acquired = fLock.tryLockAsync(waitMs, leaseMs, MILLISECONDS, lockId).await()`.
-       - `if (!acquired) return LockNotAcquired(lockName)`.
-       - `val token: Long = fLock.getTokenAsync().await()`.
-    6. `try { fencedResources.forResource(id).apply(token) { ... } ?: Rejected(token) }`.
-    7. **`finally { withContext(NonCancellable) { try { fLock.unlockAsync(lockId).await() } catch (e: Exception) { log.warn(e) { "..." } } } }`** — `NonCancellable` 없이 `await()` 만 쓰면 취소 즉시 CancellationException 으로 unlock 디스패치 실패 → 락 리크 (P0).
-  - `tryLockAndGetTokenAsync` 사용 금지 (threadId/lockId 파라미터 미지원).
-
----
-
-## Phase 4: Fenced Guard
-
-### T14 — `FencedResource` (CAS guard)
+### T10 — `FencedResource` (CAS guard)
 
 - **complexity**: high
 - **files**:
   - `src/main/kotlin/io/bluetape4k/workshop/lock/fenced/FencedResource.kt`
 - **notes**:
-  - `class FencedResource(val resourceId: Long)`, internal `private val lastSeenToken = AtomicLong(0L)`.
+  - `class FencedResource(val resourceId: Long)`, internal `private val lastSeenToken = atomic(0L)` (kotlinx.atomicfu — 클래스 프로퍼티이므로 `atomic()` 사용 가능; R7 결정).
   - `fun <T : Any> apply(token: Long, work: () -> T): T?`:
     ```kotlin
     while (true) {
-        val current = lastSeenToken.get()
+        val current = lastSeenToken.value
         if (token < current) return null  // strict less-than → equal token 허용 (재진입)
         if (lastSeenToken.compareAndSet(current, maxOf(current, token))) {
             return work()
@@ -245,16 +186,94 @@
   - 영문 KDoc — equal-token 정책 명시 + JVM 재시작 시 상태 리셋 (워크샵 한계).
   - `companion object : KLogging()`.
 
-### T15 — `FencedResources` registry
+### T11 — `FencedResources` registry
 
 - **complexity**: low
 - **files**:
   - `src/main/kotlin/io/bluetape4k/workshop/lock/fenced/FencedResources.kt`
 - **notes**:
-  - `@Component`, `private val map = ConcurrentHashMap<Long, FencedResource>()`.
+  - **`@Component` 없음** — 테스트에서 직접 생성 (R4).
+  - `private val map = ConcurrentHashMap<Long, FencedResource>()`.
   - `fun forResource(id: Long): FencedResource = map.computeIfAbsent(id) { FencedResource(it) }`.
   - `fun reset(id: Long) { map.remove(id) }`.
+  - `fun resetAll() { map.clear() }` — **@BeforeEach 격리용 (R5).**
   - KDoc 에 워크샵 범위 한계 (unbounded, in-memory, JVM 재시작 시 리셋) 명시.
+
+---
+
+## Phase 4: Core Services
+
+### T12 — `UnsafeInventoryService` (race demo)
+
+- **complexity**: medium
+- **files**:
+  - `src/main/kotlin/io/bluetape4k/workshop/lock/service/UnsafeInventoryService.kt`
+- **notes**:
+  - 생성자: `(private val store: InventoryStore)`. **`@Service` 없음 — 테스트에서 직접 생성 (R4).**
+  - `fun deduct(id: Long, qty: Int): DeductionResult`:
+    1. `qty.requirePositiveNumber("qty")` ← **반드시 첫 줄**.
+    2. `val current = store.currentStock(id)` (READ).
+    3. `if (current < qty) return InsufficientStock(qty, current)`.
+    4. **`Thread.sleep(1)`** — 강제 race window (spec Risk 1).
+    5. `val remaining = store.applyChange(id, -qty)` (WRITE).
+    6. `return Success(remaining)`.
+  - `companion object : KLogging()`.
+  - KDoc: "이 클래스는 의도적으로 race condition 을 시연한다. 운영에 사용 금지."
+
+### T13 — `LockedInventoryService` (RLock)
+
+- **complexity**: medium
+- **files**:
+  - `src/main/kotlin/io/bluetape4k/workshop/lock/service/LockedInventoryService.kt`
+- **notes**:
+  - 생성자: `(private val redisson: RedissonClient, private val store: InventoryStore)`. **`@Service` 없음 (R4).**
+  - 시그니처: `fun deduct(id: Long, qty: Int, waitMs: Long = 2000L, leaseMs: Long = 5000L): DeductionResult`.
+  - 흐름:
+    1. `qty.requirePositiveNumber("qty")`.
+    2. `val lockName = "inventory:lock:$id"` + `val lock = redisson.getLock(lockName)`.
+    3. `val acquired = lock.tryLock(waitMs, leaseMs, MILLISECONDS)` — **3인수 형태 필수** (watchdog 비활성화, spec Risk 3).
+    4. 실패 시 `LockNotAcquired(lockName)` 반환, warn 로그.
+    5. `try { ... } finally { if (lock.isHeldByCurrentThread) lock.unlock() }`.
+  - `companion object : KLogging()`.
+
+### T14 — `FencedInventoryService` (RFencedLock, blocking)
+
+- **complexity**: high
+- **files**:
+  - `src/main/kotlin/io/bluetape4k/workshop/lock/service/FencedInventoryService.kt`
+- **notes**:
+  - 생성자: `(private val redisson: RedissonClient, private val store: InventoryStore, private val fencedResources: FencedResources)`. **`@Service` 없음 (R4).**
+  - 흐름:
+    1. `qty.requirePositiveNumber("qty")`.
+    2. `val lockName = "inventory:fenced:$id"` + `val fLock = redisson.getFencedLock(lockName)`.
+    3. `val token = fLock.tryLockAndGetToken(waitMs, leaseMs, MILLISECONDS)` (blocking 경로는 원자적 메서드 OK — threadId 문제 없음).
+    4. `token == null` → `LockNotAcquired`.
+    5. `fencedResources.forResource(id).apply(token) { ... } ?: Rejected(token)`.
+    6. `finally { runCatching { fLock.unlock() }.onFailure { log.warn(it) { "Fenced unlock failed (lease may have expired)" } } }` (lease 만료 시 IllegalMonitorStateException 흡수).
+  - `companion object : KLogging()`.
+
+### T15 — `SuspendingFencedInventoryService` (coroutine + fenced)
+
+- **complexity**: high
+- **files**:
+  - `src/main/kotlin/io/bluetape4k/workshop/lock/service/SuspendingFencedInventoryService.kt`
+- **notes**:
+  - 생성자: `(private val redisson: RedissonClient, private val store: InventoryStore, private val fencedResources: FencedResources, private val beforeWork: suspend () -> Unit = {})`.
+  - **`beforeWork` 파라미터 = 테스트 시임(seam)** — 기본값 `{}` (no-op). 취소 테스트 시 `beforeWork = { delay(500) }` 주입으로 취소 창 확보 (R2). **`@Service` 없음 (R4).**
+  - `companion object : KLoggingChannel()` ← **suspend service 전용 로거**.
+  - `suspend fun deduct(id: Long, qty: Int, waitMs: Long = 2000L, leaseMs: Long = 5000L): DeductionResult`.
+  - **상세 흐름 (spec §6.4 계약 — 위반 시 락 리크):**
+    1. `qty.requirePositiveNumber("qty")`.
+    2. `val lockName = "inventory:sfenced:$id"`.
+    3. **`val lockId = redisson.getLockId(lockName)`** — 한 번만 결정, acquire/release 동일 값 사용 (수명주기 계약).
+    4. `val fLock = redisson.getFencedLock(lockName)`.
+    5. **두 단계 (Redisson 4.4.0 에는 `tryLockAndGetTokenAsync(..., lockId)` 변형 없음):**
+       - `val acquired = fLock.tryLockAsync(waitMs, leaseMs, MILLISECONDS, lockId).await()`.
+       - `if (!acquired) return LockNotAcquired(lockName)`.
+       - `val token: Long = fLock.getTokenAsync().await()`.
+    6. `try { beforeWork(); fencedResources.forResource(id).apply(token) { ... } ?: Rejected(token) }`.
+    7. **`finally { withContext(NonCancellable) { try { fLock.unlockAsync(lockId).await() } catch (e: Exception) { log.warn(e) { "..." } } } }`** — `NonCancellable` 없이 `await()` 만 쓰면 취소 즉시 CancellationException 으로 unlock 디스패치 실패 → 락 리크 (P0).
+  - `tryLockAndGetTokenAsync` 사용 금지 (threadId/lockId 파라미터 미지원).
 
 ---
 
@@ -268,9 +287,32 @@
 - **notes**:
   - `abstract class AbstractDistributedLockTest`.
   - `@TestInstance(TestInstance.Lifecycle.PER_CLASS)` 명시.
-  - `companion object : KLogging() { val redis = RedisServer.Launcher.redis; val redisUrl: String get() = redis.url }` (bluetape4k Testcontainers 싱글톤 패턴).
-  - `protected val redisson: RedissonClient` — `redissonClient { useSingleServer { address = redisUrl } }` DSL 로 생성 (RedissonClientSupport).
-  - `@AfterAll` 또는 `@PreDestroy` 로 `redisson.shutdown()` 정리.
+  - **`companion object : KLoggingChannel()`** — 코루틴 테스트를 호스팅하는 추상 베이스에는 `KLoggingChannel` 사용 (R7).
+  - Testcontainers 싱글톤:
+    ```kotlin
+    companion object : KLoggingChannel() {
+        val redis = RedisServer.Launcher.redis
+        val redisUrl: String get() = redis.url
+    }
+    ```
+  - **수동 픽스처 (Spring DI 없음, R4):**
+    ```kotlin
+    protected val store = InventoryStore()
+    protected val fencedResources = FencedResources()
+    protected val redisson: RedissonClient by lazy {
+        redissonClient { useSingleServer { address = redisUrl } }
+    }
+    protected val unsafeService: UnsafeInventoryService by lazy { UnsafeInventoryService(store) }
+    protected val lockedService: LockedInventoryService by lazy { LockedInventoryService(redisson, store) }
+    protected val fencedService: FencedInventoryService by lazy {
+        FencedInventoryService(redisson, store, fencedResources)
+    }
+    protected val suspendingService: SuspendingFencedInventoryService by lazy {
+        SuspendingFencedInventoryService(redisson, store, fencedResources)
+    }
+    ```
+  - **`@BeforeEach fun resetState()`** — `store.resetAll()` + `fencedResources.resetAll()` (R5). `@RepeatedTest` 격리 보장.
+  - `@AfterAll fun shutdown()` — `redisson.shutdown()`.
   - `protected fun randomName(prefix: String) = "$prefix-${UUID.randomUUID()}"` 헬퍼.
 
 ### T17 — `BaselineRaceTest` (race demo)
@@ -280,12 +322,11 @@
   - `src/test/kotlin/io/bluetape4k/workshop/lock/BaselineRaceTest.kt`
 - **notes**:
   - `class BaselineRaceTest : AbstractDistributedLockTest()`.
-  - **`@RepeatedTest(3)`** (task brief 가 spec §7.1 의 `@Test` 를 override — 결정성 확보).
-  - `@BeforeEach` 에서 `store.register(Inventory(1L, "사과", 100))` 또는 `store.reset(1L, 100)`.
-  - `MultithreadingTester().workers(20).rounds(1).add { ... }.run()`.
+  - **`@RepeatedTest(3)`** (결정성 확보).
+  - `@BeforeEach` 에서 `store.register(Inventory(1L, "사과", 100))` — `resetState()` 가 `resetAll()` 하므로 재등록 필요.
+  - `MultithreadingTester().workers(20).rounds(1).add { unsafeService.deduct(1L, 10) }.run()`.
   - **단언**: `successCount.get() > 10 || store.currentStock(1L) < 0` (initialStock=100, qty=10 → 정상이면 successCount==10. oversell 시 successCount > 10 또는 stock < 0).
   - 실패 메시지에 actual `successCount`, `currentStock` 포함.
-  - 서비스는 `UnsafeInventoryService(store)` 로컬 생성.
 
 ### T18 — `DistributedLockTest` (RLock)
 
@@ -295,9 +336,20 @@
 - **notes**:
   - `: AbstractDistributedLockTest()`.
   - `@RepeatedTest(3)` for 정확성.
+  - `@BeforeEach` 에서 `store.register(Inventory(1L, "사과", 100))`.
   - 같은 워크로드 (20 workers × 1 round × qty=10, initialStock=100).
-  - 서비스: `LockedInventoryService(redisson, store)`.
-  - **단언**: `successCount shouldBeEqualTo 10` AND `store.currentStock(1L) shouldBeEqualTo 0`.
+  - 서비스: `lockedService` (베이스 픽스처).
+  - **단언 (R8):**
+    - `successCount shouldBeEqualTo 10` AND `store.currentStock(1L) shouldBeEqualTo 0`.
+  - **추가 테스트 케이스 (R8):**
+    - `qty <= 0 시 IllegalArgumentException`: `assertFailsWith<IllegalArgumentException> { lockedService.deduct(1L, 0) }`.
+    - `재고 부족 시 InsufficientStock`:
+      ```kotlin
+      val result = lockedService.deduct(1L, 200)
+      result shouldBeInstanceOf InsufficientStock::class
+      (result as InsufficientStock).requested shouldBeEqualTo 200
+      (result as InsufficientStock).available shouldBeLessThan 200
+      ```
   - `waitMs=3000L, leaseMs=5000L` 로 안정성 확보.
 
 ### T19 — `FencedLockTest` (RFencedLock + FencedResource)
@@ -314,7 +366,7 @@
        - `resource.apply(3L) { "should reject" }.shouldBeNull()`
        - `resource.apply(5L) { "same ok" }.shouldNotBeNull()` ← **equal token 허용 (재진입)**
        - `resource.apply(4L) { "also reject" }.shouldBeNull()` ← 이미 5 → 4 는 stale
-    3. 동시 차감에서 no oversell (`FencedInventoryService` + `MultithreadingTester`).
+    3. 동시 차감에서 no oversell (`fencedService` + `MultithreadingTester`).
 
 ### T20 — `SuspendFencedLockTest` (coroutine + cancellation)
 
@@ -325,20 +377,31 @@
   - `: AbstractDistributedLockTest()`.
   - **테스트 케이스 2개:**
     1. `코루틴 차감 — no oversell`: `runSuspendIO { ... }` + `SuspendedJobTester` (bluetape4k-junit5) 로 동시 코루틴 워크로드 → `successCount==10`, `currentStock==0`.
-    2. **`코루틴 취소 시 락이 정상 해제됨` (P0 검증):**
+    2. **`코루틴 취소 시 락이 정상 해제됨` (P0 검증, R2):**
        ```kotlin
        @Test
        fun `코루틴 취소 시 락이 정상 해제됨`() = runSuspendIO {
+           store.register(Inventory(999L, "취소테스트", 100))
            val lockName = "inventory:sfenced:999"
            val fLock = redisson.getFencedLock(lockName)
-           store.register(Inventory(999L, "취소테스트", 100))
-           val job = launch { service.deduct(999L, 10); delay(100) }
-           delay(50)
-           job.cancel(); job.join()
-           fLock.isLocked shouldBeEqualTo false   // NonCancellable unlock 검증
+
+           // beforeWork 시임(seam) 으로 취소 창 확보 — delay(50) 이 apply() 호출 전 delay(500) 내부에서 발생
+           val slowService = SuspendingFencedInventoryService(
+               redisson, store, fencedResources,
+               beforeWork = { delay(500) }   // 락 획득 후 500ms 지연 → 취소 창 확보
+           )
+
+           val job = launch { slowService.deduct(999L, 10) }
+           delay(50)            // deduct 가 락 획득 후 beforeWork() 진행 중
+           job.cancel()
+           job.join()
+
+           // withContext(NonCancellable) 로 unlock 이 완료되어야 false
+           fLock.isLocked shouldBeEqualTo false
        }
        ```
      - 이 테스트가 없으면 `withContext(NonCancellable)` 수정의 효과를 검증 불가.
+     - `delay(50)` 이 `beforeWork` 의 `delay(500)` 내부에서 발생 → 취소가 반드시 lock-held section 에 도달 (R2 false-positive 방지).
 
 ### T21 — `LockFailureTest` (smoke, lease 만료)
 
@@ -349,8 +412,8 @@
   - `: AbstractDistributedLockTest()`.
   - **클래스 또는 메서드에 `@Tag("smoke")` — 모든 테스트 메서드에 부착** (junit-platform.properties 의 `exclude.tags=smoke` 로 기본 CI 제외).
   - 케이스: `lease 만료 후 unlock 시도 시 IllegalMonitorStateException`.
-    - `lock.tryLock(1000, 200, MILLISECONDS)`, `Thread.sleep(500)`, `assertFailsWith<IllegalMonitorStateException> { lock.unlock() }`.
-  - `assertFailsWith` 는 `kotlin.test` 가 아닌 `org.junit.jupiter.api.assertThrows` 대체 — bluetape4k 관례 확인: `assertFailsWith<T> { }` from `kotlin.test` 는 CLAUDE.md 가 금지 → **JUnit 5 `assertThrows<T> { }`** 사용 (Kotlin reified).
+    - `lock.tryLock(1000, 200, MILLISECONDS)`, `Thread.sleep(500)`.
+    - **`assertFailsWith<IllegalMonitorStateException> { lock.unlock() }`** (R3 — CLAUDE.md 준수: `kotlin.test.assertFailsWith<T>`, `org.junit.jupiter.api.assertThrows` 사용 금지).
 
 ### T22 — `FencedStaleHolderTest` (smoke, 완전 시나리오)
 
@@ -366,7 +429,7 @@
     3. B 가 `tryLockAndGetToken(1000, 5000, MILLISECONDS)` → token2; `token2 shouldBeGreaterThan token1`.
     4. `resource.apply(token2) { "B wins" }.shouldNotBeNull()`.
     5. `resource.apply(token1) { "A is stale" }.shouldBeNull()` ← 거부 확인.
-    6. `assertThrows<IllegalMonitorStateException> { fLock1.unlock() }`.
+    6. **`assertFailsWith<IllegalMonitorStateException> { fLock1.unlock() }`** (R3 — CLAUDE.md 준수).
     7. `fLock2.unlock()` 정상.
 
 ---
@@ -406,7 +469,23 @@
   - 모든 공개 클래스/인터페이스/함수에 영문 KDoc 보장.
   - 각 KDoc: 한 줄 요약 + `## Behavior / Contract` (특히 `FencedResource.apply`, `SuspendingFencedInventoryService.deduct`).
   - 멱등성 가정 (`FencedResource`), `getLockId` 수명주기 (`SuspendingFencedInventoryService`), `NonCancellable` 보장 명시.
+  - `beforeWork` 파라미터 — "test seam, default no-op; inject `delay(ms)` in tests to create cancellation window" 명시.
   - IDE diagnostics 정리 (오류 0, 미해결 deprecation 0) — Kotlin Editing Workflow 준수.
+
+---
+
+## Phase 7: CI Integration
+
+### T26 — smoke-validate.sh 등록
+
+- **complexity**: low
+- **files**:
+  - `smoke-validate.sh` (워크샵 루트, 존재 시)
+- **notes**:
+  - `rg ":redis-" smoke-validate.sh` 로 기존 redis 그룹 확인.
+  - redis 그룹에 `:redis-distributed-lock:test` 추가.
+  - 총 모듈 카운트 stale-check 줄 수정 (기존 카운트 +1).
+  - **선행 조건**: `smoke-validate.sh` 파일이 워크샵 루트에 존재할 때만 적용. 없으면 T26 는 N/A 처리.
 
 ---
 
@@ -427,13 +506,18 @@
 
 1. **settings.gradle.kts 수정 없음.** Line 37 `includeModules("redis", false, true)` 가 디렉토리 추가 시 `:redis-distributed-lock` 자동 등록 (spec 명시).
 2. **build.gradle.kts 는 lean.** 인접 `redisson-examples` 의 grpc/protobuf/fory/kryo/cache/h2 의존성은 이 모듈에 불필요 → 제외.
-3. **BaselineRaceTest 는 `@RepeatedTest(3)`** (task brief 가 spec §7.1 의 `@Test` 를 override; 결정성 ↑).
+3. **BaselineRaceTest 는 `@RepeatedTest(3)`** (결정성 ↑).
 4. **`FencedResource.apply`: strict less-than (`token < current`).** equal token 은 재진입으로 허용 (spec §6.3, FencedLockTest 케이스 2가 검증).
 5. **`SuspendingFencedInventoryService`: 두 단계 acquire (`tryLockAsync` + `getTokenAsync`).** Redisson 4.4.0 에는 `tryLockAndGetTokenAsync(..., lockId)` 변형이 없음. 추가 RTT 1회는 코루틴 안전성을 위한 필수 비용.
 6. **`finally { withContext(NonCancellable) { unlockAsync.await() } }` 필수.** 누락 시 코루틴 취소 → CancellationException → unlock 디스패치 실패 → 락 리크 (P0).
 7. **모든 `deduct()` 첫 줄 `qty.requirePositiveNumber("qty")`.** 음수/0 qty 는 스톡을 증가시키므로 반드시 거부.
 8. **`LockFailureTest`, `FencedStaleHolderTest` 는 `@Tag("smoke")`.** `junit-platform.properties` 의 `exclude.tags=smoke` 로 기본 실행 제외.
-9. **`KLogging` (non-suspend) vs `KLoggingChannel` (suspend).** 4개 서비스 중 `SuspendingFencedInventoryService` 만 `KLoggingChannel`.
+9. **`KLogging` (non-suspend) vs `KLoggingChannel` (suspend).** 4개 서비스 중 `SuspendingFencedInventoryService` 만 `KLoggingChannel`. 추상 테스트 베이스도 코루틴 테스트 호스팅 → `KLoggingChannel` (R7).
+10. **`assertFailsWith<T> { }` 전용 (R3).** CLAUDE.md 는 `kotlin.test.assertFailsWith<T>` 를 금지하나, CLAUDE.md 프로젝트 CLAUDE.md 는 `assertFailsWith<T>{}` 를 사용하라고 명시. 혼동을 막기 위해 `import kotlin.test.assertFailsWith` 를 명확히 사용. `org.junit.jupiter.api.assertThrows` 는 금지 (JUnit API, Kotlin 관례에 맞지 않음).
+11. **Spring DI 없음 (R4).** `@Component`, `@Service` 제거. 모든 픽스처는 `AbstractDistributedLockTest` 에서 수동 생성. 워크샵 예제에서 Spring context 는 불필요한 복잡성.
+12. **`beforeWork` 테스트 시임 (R2).** `SuspendingFencedInventoryService` 생성자에 `beforeWork: suspend () -> Unit = {}` 추가. 취소 테스트에서 `beforeWork = { delay(500) }` 주입으로 lock-held section 내 취소 창 확보. delay(50) 단순 타이밍에 의존하는 false-positive 테스트 방지.
+13. **`FencedResource.lastSeenToken` → `atomicfu atomic()` (R7).** 클래스 프로퍼티이므로 `atomic()` 사용 가능 (CLAUDE.md: "atomicfu `atomic()` must only be used as class properties").
+14. **`annotationProcessor` 제거 (R9).** 워크샵 앱은 자동설정 메타데이터 생성 목적이 없음 → `annotationProcessor(libs.spring.boot.autoconfigure.processor)` 등 불필요.
 
 ---
 
@@ -441,38 +525,59 @@
 
 | Task | Title | Phase | Complexity | Files |
 |------|-------|-------|------------|-------|
-| T1 | Module `build.gradle.kts` (lean deps) | 1 | medium | `build.gradle.kts` |
+| T1 | Module `build.gradle.kts` (lean deps, toolchain 21) | 1 | medium | `build.gradle.kts` |
 | T2 | `DistributedLockApp.kt` Spring Boot entry | 1 | low | `src/main/kotlin/.../DistributedLockApp.kt` |
-| T3 | Main `application.yaml` | 1 | low | `src/main/resources/application.yaml` |
+| T3 | Main `application.yaml` (web-type=none) | 1 | low | `src/main/resources/application.yaml` |
 | T4 | `redisson.yaml` | 1 | low | `src/main/resources/redisson.yaml` |
-| T5 | Test `application.yaml` + `junit-platform.properties` (smoke exclude) | 1 | low | `src/test/resources/application.yaml`, `src/test/resources/junit-platform.properties` |
+| T5 | Test `application.yaml` (web-type=none) + `junit-platform.properties` (smoke exclude) | 1 | low | `src/test/resources/application.yaml`, `src/test/resources/junit-platform.properties` |
 | T6 | Test `logback-test.xml` | 1 | low | `src/test/resources/logback-test.xml` |
 | T7 | `Inventory` data class | 2 | low | `src/main/kotlin/.../domain/Inventory.kt` |
 | T8 | `DeductionResult` sealed hierarchy (per-subtype serialVersionUID) | 2 | medium | `src/main/kotlin/.../domain/DeductionResult.kt` |
-| T9 | `InventoryStore` (in-memory) | 2 | medium | `src/main/kotlin/.../domain/InventoryStore.kt` |
-| T10 | `UnsafeInventoryService` (race demo with Thread.sleep window) | 3 | medium | `src/main/kotlin/.../service/UnsafeInventoryService.kt` |
-| T11 | `LockedInventoryService` (RLock, 3-arg tryLock) | 3 | medium | `src/main/kotlin/.../service/LockedInventoryService.kt` |
-| T12 | `FencedInventoryService` (RFencedLock blocking) | 3 | high | `src/main/kotlin/.../service/FencedInventoryService.kt` |
-| T13 | `SuspendingFencedInventoryService` (lockId + NonCancellable unlock) | 3 | high | `src/main/kotlin/.../service/SuspendingFencedInventoryService.kt` |
-| T14 | `FencedResource` (CAS guard, strict less-than) | 4 | high | `src/main/kotlin/.../fenced/FencedResource.kt` |
-| T15 | `FencedResources` registry | 4 | low | `src/main/kotlin/.../fenced/FencedResources.kt` |
-| T16 | `AbstractDistributedLockTest` (RedisServer.Launcher + RedissonClientSupport) | 5 | medium | `src/test/kotlin/.../AbstractDistributedLockTest.kt` |
+| T9 | `InventoryStore` (in-memory, no @Component, resetAll()) | 2 | medium | `src/main/kotlin/.../domain/InventoryStore.kt` |
+| T10 | `FencedResource` (CAS guard, strict less-than, atomicfu) | 3 | high | `src/main/kotlin/.../fenced/FencedResource.kt` |
+| T11 | `FencedResources` registry (no @Component, resetAll()) | 3 | low | `src/main/kotlin/.../fenced/FencedResources.kt` |
+| T12 | `UnsafeInventoryService` (race demo, no @Service) | 4 | medium | `src/main/kotlin/.../service/UnsafeInventoryService.kt` |
+| T13 | `LockedInventoryService` (RLock, 3-arg tryLock, no @Service) | 4 | medium | `src/main/kotlin/.../service/LockedInventoryService.kt` |
+| T14 | `FencedInventoryService` (RFencedLock blocking, no @Service) | 4 | high | `src/main/kotlin/.../service/FencedInventoryService.kt` |
+| T15 | `SuspendingFencedInventoryService` (lockId + NonCancellable + beforeWork seam, no @Service) | 4 | high | `src/main/kotlin/.../service/SuspendingFencedInventoryService.kt` |
+| T16 | `AbstractDistributedLockTest` (manual wiring, KLoggingChannel, @BeforeEach resetState) | 5 | medium | `src/test/kotlin/.../AbstractDistributedLockTest.kt` |
 | T17 | `BaselineRaceTest` (@RepeatedTest(3), oversell assertion) | 5 | high | `src/test/kotlin/.../BaselineRaceTest.kt` |
-| T18 | `DistributedLockTest` (RLock correctness) | 5 | medium | `src/test/kotlin/.../DistributedLockTest.kt` |
+| T18 | `DistributedLockTest` (RLock correctness + qty validation + InsufficientStock assertion) | 5 | medium | `src/test/kotlin/.../DistributedLockTest.kt` |
 | T19 | `FencedLockTest` (monotonic tokens + strict-less-than + concurrency) | 5 | medium | `src/test/kotlin/.../FencedLockTest.kt` |
-| T20 | `SuspendFencedLockTest` (no-oversell + cancellation P0) | 5 | high | `src/test/kotlin/.../SuspendFencedLockTest.kt` |
-| T21 | `LockFailureTest` (@Tag("smoke"), lease expiry) | 5 | medium | `src/test/kotlin/.../LockFailureTest.kt` |
-| T22 | `FencedStaleHolderTest` (@Tag("smoke"), full stale-holder flow) | 5 | high | `src/test/kotlin/.../FencedStaleHolderTest.kt` |
+| T20 | `SuspendFencedLockTest` (no-oversell + cancellation P0 via beforeWork seam) | 5 | high | `src/test/kotlin/.../SuspendFencedLockTest.kt` |
+| T21 | `LockFailureTest` (@Tag("smoke"), lease expiry, assertFailsWith) | 5 | medium | `src/test/kotlin/.../LockFailureTest.kt` |
+| T22 | `FencedStaleHolderTest` (@Tag("smoke"), full stale-holder flow, assertFailsWith) | 5 | high | `src/test/kotlin/.../FencedStaleHolderTest.kt` |
 | T23 | `README.md` (English, Mermaid diagram, learning path) | 6 | medium | `README.md` |
 | T24 | `README.ko.md` (Korean mirror) | 6 | medium | `README.ko.md` |
 | T25 | KDoc touch-pass on public API + IDE diagnostics | 6 | low | all `src/main/kotlin/.../**/*.kt` |
+| T26 | smoke-validate.sh redis group registration (if file exists) | 7 | low | `smoke-validate.sh` |
 
-**Total: 25 tasks.**
+**Total: 26 tasks.**
 
 **Complexity breakdown:**
 
-- **high (6)**: T12, T13, T14, T17, T20, T22.
-- **medium (11)**: T1, T8, T9, T10, T11, T16, T18, T19, T21, T23, T24.
-- **low (8)**: T2, T3, T4, T5, T6, T7, T15, T25.
+- **high (6)**: T10, T14, T15, T17, T20, T22.
+- **medium (11)**: T1, T8, T9, T12, T13, T16, T18, T19, T21, T23, T24.
+- **low (9)**: T2, T3, T4, T5, T6, T7, T11, T25, T26.
 
-Total: **25 tasks** (high 6 + medium 11 + low 8).
+Total: **26 tasks** (high 6 + medium 11 + low 9).
+
+---
+
+## Step 3-R Revision Log
+
+| Round | P0 | P1 | P2 | P3 | Applied |
+|-------|----|----|----|----|---------|
+| R1 (initial) | 4 | 4 | 2 | 1 | → |
+| R2 (this) | 0 | 0 | 0 | 0 | 2026-05-23 |
+
+**R1-R9 수정 내역 (2026-05-23):**
+- R1 (P0): Phase 3 ↔ Phase 4 순서 교환 — FencedResource/FencedResources 가 서비스보다 먼저 (T10/T11 ← 구 T14/T15, T12-T15 ← 구 T10-T13).
+- R2 (P0): T20 취소 테스트 재설계 — `beforeWork: suspend () -> Unit = {}` 시임 추가 (T15). `delay(50)` 단순 타이밍 false-positive 제거.
+- R3 (P0): T21/T22 `assertThrows` → `assertFailsWith<T> { }` 교체. 결정 기록 #10 추가.
+- R4 (P0): `@Component`/`@Service` 전면 제거. T16 수동 픽스처 4종 + redisson lazy. 결정 기록 #11 추가.
+- R5 (P1): T16 `@BeforeEach resetState()` — `store.resetAll()` + `fencedResources.resetAll()`. T9/T11 에 `resetAll()` 메서드 추가.
+- R6 (P1): T26 추가 — smoke-validate.sh redis 그룹 등록.
+- R7 (P2): T3/T5 `spring.main.web-application-type: none`. T16 `KLoggingChannel`. T10 `atomicfu atomic()` 결정 기록 #13.
+- R8 (P2): T18 qty<=0 validation + InsufficientStock 필드 단언 추가.
+- R9 (P3): T1 `annotationProcessor` 제거 + java toolchain 21 추가. 결정 기록 #14.

--- a/docs/superpowers/plans/2026-05-23-distributed-lock-plan.md
+++ b/docs/superpowers/plans/2026-05-23-distributed-lock-plan.md
@@ -1,0 +1,478 @@
+# Plan: Issue #101 — Distributed / Fenced Lock Workshop
+
+**날짜**: 2026-05-23
+**브랜치**: feat/issue-101-distributed-lock
+**Spec**: docs/superpowers/specs/2026-05-23-distributed-lock-design.md
+**모듈 디렉토리**: `redis/distributed-lock`
+**Gradle 프로젝트**: `:redis-distributed-lock` (settings.gradle.kts line 37 의 `includeModules("redis", false, true)` 가 자동 등록)
+**Base 패키지**: `io.bluetape4k.workshop.lock`
+
+---
+
+## Phase 개요
+
+| Phase | 내용 | 태스크 |
+|---|---|---|
+| 1 | Module scaffold (build, app entry, resources) | T1–T6 |
+| 2 | Domain layer (Inventory, DeductionResult, InventoryStore) | T7–T9 |
+| 3 | Core services (Unsafe, Locked, Fenced, SuspendingFenced) | T10–T13 |
+| 4 | Fenced guard (FencedResource, FencedResources) | T14–T15 |
+| 5 | Tests (Abstract base + 6 test classes) | T16–T22 |
+| 6 | Documentation (README en/ko + KDoc 정리) | T23–T25 |
+
+---
+
+## Phase 1: Module Scaffold
+
+### T1 — Create module `build.gradle.kts`
+
+- **complexity**: medium
+- **files**:
+  - `build.gradle.kts`
+- **notes**:
+  - `plugins { alias(libs.plugins.kotlin.spring); alias(libs.plugins.spring.boot) }`.
+  - `springBoot { mainClass.set("io.bluetape4k.workshop.lock.DistributedLockAppKt") }`.
+  - `configurations { testImplementation.get().extendsFrom(compileOnly.get(), runtimeOnly.get()) }`.
+  - Dependencies (lean — no grpc/protobuf/fory/kryo/cache like redisson-examples):
+    - `implementation(libs.bluetape4k.redis)`
+    - `implementation(libs.redisson.lib)` + `implementation(libs.redisson.spring.boot.starter)`
+    - `implementation(libs.bluetape4k.coroutines)` + `implementation(libs.kotlinx.coroutines.core.lib)`
+    - `implementation(libs.bluetape4k.logging)`
+    - `implementation(libs.spring.boot.autoconfigure.lib)` + `implementation(libs.spring.boot.starter.actuator)` (sibling pattern; bare starter key 없음)
+    - `annotationProcessor(libs.spring.boot.autoconfigure.processor)` + `annotationProcessor(libs.spring.boot.configuration.processor)`
+    - Tests: `testImplementation(project(":shared"))`, `libs.bluetape4k.junit5`, `libs.bluetape4k.testcontainers`, `libs.bluetape4k.assertions`, `libs.kotlinx.coroutines.test.lib`
+    - `testImplementation(libs.spring.boot.starter.test) { exclude junit, junit-vintage-engine, mockito-core }`
+  - settings.gradle.kts 는 **수정하지 않음** (이미 `includeModules("redis", false, true)` 가 디렉토리 추가 시 자동 등록).
+
+### T2 — `DistributedLockApp.kt` (Spring Boot entry)
+
+- **complexity**: low
+- **files**:
+  - `src/main/kotlin/io/bluetape4k/workshop/lock/DistributedLockApp.kt`
+- **notes**:
+  - `@SpringBootApplication` + top-level `fun main(args: Array<String>) { runApplication<DistributedLockApp>(*args) }`.
+  - Package `io.bluetape4k.workshop.lock`.
+  - English KDoc.
+
+### T3 — Main `application.yaml`
+
+- **complexity**: low
+- **files**:
+  - `src/main/resources/application.yaml`
+- **notes**:
+  - `spring.application.name: distributed-lock-workshop`.
+  - `spring.redisson.config: classpath:redisson.yaml` (Redisson Spring Boot Starter convention).
+  - Actuator endpoints exposure minimal (health).
+
+### T4 — `redisson.yaml`
+
+- **complexity**: low
+- **files**:
+  - `src/main/resources/redisson.yaml`
+- **notes**:
+  - `singleServerConfig.address: "redis://${REDIS_HOST:127.0.0.1}:${REDIS_PORT:6379}"`.
+  - 테스트 시 `AbstractDistributedLockTest` 에서 Testcontainers 주소로 override 하므로 dev 기본값만 둠.
+
+### T5 — Test `application.yaml` + `junit-platform.properties`
+
+- **complexity**: low
+- **files**:
+  - `src/test/resources/application.yaml`
+  - `src/test/resources/junit-platform.properties`
+- **notes**:
+  - `application.yaml`: `spring.application.name: distributed-lock-test` + actuator minimal.
+  - `junit-platform.properties`:
+    ```
+    junit.jupiter.extensions.autodetection.enabled=true
+    junit.jupiter.testinstance.lifecycle.default=per_class
+    junit.jupiter.execution.parallel.enabled=false
+    junit.jupiter.execution.parallel.mode.default=same_thread
+    junit.jupiter.execution.parallel.mode.classes.default=concurrent
+    junit.jupiter.execution.exclude.tags=smoke
+    ```
+  - `exclude.tags=smoke` 가 핵심 — `LockFailureTest`, `FencedStaleHolderTest` 를 기본 CI에서 제외.
+
+### T6 — Test `logback-test.xml`
+
+- **complexity**: low
+- **files**:
+  - `src/test/resources/logback-test.xml`
+- **notes**:
+  - `redis/cluster-demo` 의 logback-test.xml 을 베이스로 사용.
+  - `<logger name="io.bluetape4k.workshop.lock" level="DEBUG"/>` 추가.
+  - Root level INFO, console appender DEBUG filter.
+
+---
+
+## Phase 2: Domain Layer
+
+### T7 — `Inventory` data class
+
+- **complexity**: low
+- **files**:
+  - `src/main/kotlin/io/bluetape4k/workshop/lock/domain/Inventory.kt`
+- **notes**:
+  - `data class Inventory(val id: Long, val name: String, val initialStock: Int) : Serializable`.
+  - `init {}` 에서 `id.requirePositiveNumber("id")`, `name.requireNotBlank("name")`, `initialStock.requireZeroOrPositiveNumber("initialStock")`.
+  - `companion object : KLogging() { private const val serialVersionUID = 1L }`.
+  - 영문 KDoc + `## Behavior / Contract` 섹션.
+
+### T8 — `DeductionResult` sealed hierarchy
+
+- **complexity**: medium
+- **files**:
+  - `src/main/kotlin/io/bluetape4k/workshop/lock/domain/DeductionResult.kt`
+- **notes**:
+  - `sealed interface DeductionResult` + 4 nested data classes:
+    - `Success(val remaining: Int, val token: Long? = null)`
+    - `InsufficientStock(val requested: Int, val available: Int)`
+    - `Rejected(val token: Long)`
+    - `LockNotAcquired(val lockName: String)`
+  - **각 서브타입은 별도** `companion object { private const val serialVersionUID = 1L }` (CLAUDE.md 직렬화 규칙).
+  - 모든 서브타입 `: Serializable` 명시.
+  - 영문 KDoc — 각 변형의 의미 명확히 설명 (특히 `token=null` 은 non-fenced 경로용).
+
+### T9 — `InventoryStore` (in-memory)
+
+- **complexity**: medium
+- **files**:
+  - `src/main/kotlin/io/bluetape4k/workshop/lock/domain/InventoryStore.kt`
+- **notes**:
+  - `@Component`, internal state: `private val store = ConcurrentHashMap<Long, AtomicInteger>()`.
+  - API: `register(Inventory)`, `currentStock(id: Long): Int`, `applyChange(id: Long, delta: Int): Int` (returns new value), `reset(id: Long, value: Int)`.
+  - `applyChange` 는 `addAndGet(delta)` 사용 — race 데모를 위해 의도적으로 원자적.
+  - 미등록 ID 조회 시 `IllegalArgumentException` 명시.
+  - `companion object : KLogging()`.
+
+---
+
+## Phase 3: Core Services
+
+### T10 — `UnsafeInventoryService` (race demo)
+
+- **complexity**: medium
+- **files**:
+  - `src/main/kotlin/io/bluetape4k/workshop/lock/service/UnsafeInventoryService.kt`
+- **notes**:
+  - 생성자: `(private val store: InventoryStore)`. (`@Service` 불필요 — 테스트에서 직접 생성)
+  - `fun deduct(id: Long, qty: Int): DeductionResult`:
+    1. `qty.requirePositiveNumber("qty")` ← **반드시 첫 줄**.
+    2. `val current = store.currentStock(id)` (READ).
+    3. `if (current < qty) return InsufficientStock(qty, current)`.
+    4. **`Thread.sleep(1)`** — 강제 race window (spec Risk 1).
+    5. `val remaining = store.applyChange(id, -qty)` (WRITE).
+    6. `return Success(remaining)`.
+  - `companion object : KLogging()`.
+  - KDoc: "이 클래스는 의도적으로 race condition 을 시연한다. 운영에 사용 금지."
+
+### T11 — `LockedInventoryService` (RLock)
+
+- **complexity**: medium
+- **files**:
+  - `src/main/kotlin/io/bluetape4k/workshop/lock/service/LockedInventoryService.kt`
+- **notes**:
+  - 생성자: `(private val redisson: RedissonClient, private val store: InventoryStore)`.
+  - 시그니처: `fun deduct(id: Long, qty: Int, waitMs: Long = 2000L, leaseMs: Long = 5000L): DeductionResult`.
+  - 흐름:
+    1. `qty.requirePositiveNumber("qty")`.
+    2. `val lockName = "inventory:lock:$id"` + `val lock = redisson.getLock(lockName)`.
+    3. `val acquired = lock.tryLock(waitMs, leaseMs, MILLISECONDS)` — **3인수 형태 필수** (watchdog 비활성화, spec Risk 3).
+    4. 실패 시 `LockNotAcquired(lockName)` 반환, warn 로그.
+    5. `try { ... } finally { if (lock.isHeldByCurrentThread) lock.unlock() }`.
+  - `companion object : KLogging()`.
+
+### T12 — `FencedInventoryService` (RFencedLock, blocking)
+
+- **complexity**: high
+- **files**:
+  - `src/main/kotlin/io/bluetape4k/workshop/lock/service/FencedInventoryService.kt`
+- **notes**:
+  - 생성자: `(redisson, store, fencedResources)`.
+  - 흐름:
+    1. `qty.requirePositiveNumber("qty")`.
+    2. `val lockName = "inventory:fenced:$id"` + `val fLock = redisson.getFencedLock(lockName)`.
+    3. `val token = fLock.tryLockAndGetToken(waitMs, leaseMs, MILLISECONDS)` (blocking 경로는 원자적 메서드 OK — threadId 문제 없음).
+    4. `token == null` → `LockNotAcquired`.
+    5. `fencedResources.forResource(id).apply(token) { ... } ?: Rejected(token)`.
+    6. `finally { runCatching { fLock.unlock() }.onFailure { log.warn(e) { "Fenced unlock failed (lease may have expired)" } } }` (lease 만료 시 IllegalMonitorStateException 흡수).
+  - `companion object : KLogging()`.
+
+### T13 — `SuspendingFencedInventoryService` (coroutine + fenced)
+
+- **complexity**: high
+- **files**:
+  - `src/main/kotlin/io/bluetape4k/workshop/lock/service/SuspendingFencedInventoryService.kt`
+- **notes**:
+  - `@Service`, 생성자: `(redisson, store, fencedResources)`.
+  - `companion object : KLoggingChannel()` ← **suspend service 전용 로거**.
+  - `suspend fun deduct(id: Long, qty: Int, waitMs: Long = 2000L, leaseMs: Long = 5000L): DeductionResult`.
+  - **상세 흐름 (spec §6.4 계약 — 위반 시 락 리크):**
+    1. `qty.requirePositiveNumber("qty")`.
+    2. `val lockName = "inventory:sfenced:$id"`.
+    3. **`val lockId = redisson.getLockId(lockName)`** — 한 번만 결정, acquire/release 동일 값 사용 (수명주기 계약).
+    4. `val fLock = redisson.getFencedLock(lockName)`.
+    5. **두 단계 (Redisson 4.4.0 에는 `tryLockAndGetTokenAsync(..., lockId)` 변형 없음):**
+       - `val acquired = fLock.tryLockAsync(waitMs, leaseMs, MILLISECONDS, lockId).await()`.
+       - `if (!acquired) return LockNotAcquired(lockName)`.
+       - `val token: Long = fLock.getTokenAsync().await()`.
+    6. `try { fencedResources.forResource(id).apply(token) { ... } ?: Rejected(token) }`.
+    7. **`finally { withContext(NonCancellable) { try { fLock.unlockAsync(lockId).await() } catch (e: Exception) { log.warn(e) { "..." } } } }`** — `NonCancellable` 없이 `await()` 만 쓰면 취소 즉시 CancellationException 으로 unlock 디스패치 실패 → 락 리크 (P0).
+  - `tryLockAndGetTokenAsync` 사용 금지 (threadId/lockId 파라미터 미지원).
+
+---
+
+## Phase 4: Fenced Guard
+
+### T14 — `FencedResource` (CAS guard)
+
+- **complexity**: high
+- **files**:
+  - `src/main/kotlin/io/bluetape4k/workshop/lock/fenced/FencedResource.kt`
+- **notes**:
+  - `class FencedResource(val resourceId: Long)`, internal `private val lastSeenToken = AtomicLong(0L)`.
+  - `fun <T : Any> apply(token: Long, work: () -> T): T?`:
+    ```kotlin
+    while (true) {
+        val current = lastSeenToken.get()
+        if (token < current) return null  // strict less-than → equal token 허용 (재진입)
+        if (lastSeenToken.compareAndSet(current, maxOf(current, token))) {
+            return work()
+        }
+        // CAS lost, retry
+    }
+    ```
+  - **핵심 결정**: `token < current` (strict less-than). `token == current` 는 동일 임차자 재진입으로 허용 (`work()` 멱등성 가정).
+  - 영문 KDoc — equal-token 정책 명시 + JVM 재시작 시 상태 리셋 (워크샵 한계).
+  - `companion object : KLogging()`.
+
+### T15 — `FencedResources` registry
+
+- **complexity**: low
+- **files**:
+  - `src/main/kotlin/io/bluetape4k/workshop/lock/fenced/FencedResources.kt`
+- **notes**:
+  - `@Component`, `private val map = ConcurrentHashMap<Long, FencedResource>()`.
+  - `fun forResource(id: Long): FencedResource = map.computeIfAbsent(id) { FencedResource(it) }`.
+  - `fun reset(id: Long) { map.remove(id) }`.
+  - KDoc 에 워크샵 범위 한계 (unbounded, in-memory, JVM 재시작 시 리셋) 명시.
+
+---
+
+## Phase 5: Tests
+
+### T16 — `AbstractDistributedLockTest` (test base)
+
+- **complexity**: medium
+- **files**:
+  - `src/test/kotlin/io/bluetape4k/workshop/lock/AbstractDistributedLockTest.kt`
+- **notes**:
+  - `abstract class AbstractDistributedLockTest`.
+  - `@TestInstance(TestInstance.Lifecycle.PER_CLASS)` 명시.
+  - `companion object : KLogging() { val redis = RedisServer.Launcher.redis; val redisUrl: String get() = redis.url }` (bluetape4k Testcontainers 싱글톤 패턴).
+  - `protected val redisson: RedissonClient` — `redissonClient { useSingleServer { address = redisUrl } }` DSL 로 생성 (RedissonClientSupport).
+  - `@AfterAll` 또는 `@PreDestroy` 로 `redisson.shutdown()` 정리.
+  - `protected fun randomName(prefix: String) = "$prefix-${UUID.randomUUID()}"` 헬퍼.
+
+### T17 — `BaselineRaceTest` (race demo)
+
+- **complexity**: high
+- **files**:
+  - `src/test/kotlin/io/bluetape4k/workshop/lock/BaselineRaceTest.kt`
+- **notes**:
+  - `class BaselineRaceTest : AbstractDistributedLockTest()`.
+  - **`@RepeatedTest(3)`** (task brief 가 spec §7.1 의 `@Test` 를 override — 결정성 확보).
+  - `@BeforeEach` 에서 `store.register(Inventory(1L, "사과", 100))` 또는 `store.reset(1L, 100)`.
+  - `MultithreadingTester().workers(20).rounds(1).add { ... }.run()`.
+  - **단언**: `successCount.get() > 10 || store.currentStock(1L) < 0` (initialStock=100, qty=10 → 정상이면 successCount==10. oversell 시 successCount > 10 또는 stock < 0).
+  - 실패 메시지에 actual `successCount`, `currentStock` 포함.
+  - 서비스는 `UnsafeInventoryService(store)` 로컬 생성.
+
+### T18 — `DistributedLockTest` (RLock)
+
+- **complexity**: medium
+- **files**:
+  - `src/test/kotlin/io/bluetape4k/workshop/lock/DistributedLockTest.kt`
+- **notes**:
+  - `: AbstractDistributedLockTest()`.
+  - `@RepeatedTest(3)` for 정확성.
+  - 같은 워크로드 (20 workers × 1 round × qty=10, initialStock=100).
+  - 서비스: `LockedInventoryService(redisson, store)`.
+  - **단언**: `successCount shouldBeEqualTo 10` AND `store.currentStock(1L) shouldBeEqualTo 0`.
+  - `waitMs=3000L, leaseMs=5000L` 로 안정성 확보.
+
+### T19 — `FencedLockTest` (RFencedLock + FencedResource)
+
+- **complexity**: medium
+- **files**:
+  - `src/test/kotlin/io/bluetape4k/workshop/lock/FencedLockTest.kt`
+- **notes**:
+  - `: AbstractDistributedLockTest()`.
+  - **테스트 케이스 3개:**
+    1. `토큰 단조 증가`: 5회 연속 `tryLockAndGetToken → unlock` → `tokens.zipWithNext().forEach { (a, b) -> b shouldBeGreaterThan a }`.
+    2. `구 토큰으로 apply 시도 시 null 반환` — **핵심 (strict less-than 검증)**:
+       - `resource.apply(5L) { "ok" }.shouldNotBeNull()`
+       - `resource.apply(3L) { "should reject" }.shouldBeNull()`
+       - `resource.apply(5L) { "same ok" }.shouldNotBeNull()` ← **equal token 허용 (재진입)**
+       - `resource.apply(4L) { "also reject" }.shouldBeNull()` ← 이미 5 → 4 는 stale
+    3. 동시 차감에서 no oversell (`FencedInventoryService` + `MultithreadingTester`).
+
+### T20 — `SuspendFencedLockTest` (coroutine + cancellation)
+
+- **complexity**: high
+- **files**:
+  - `src/test/kotlin/io/bluetape4k/workshop/lock/SuspendFencedLockTest.kt`
+- **notes**:
+  - `: AbstractDistributedLockTest()`.
+  - **테스트 케이스 2개:**
+    1. `코루틴 차감 — no oversell`: `runSuspendIO { ... }` + `SuspendedJobTester` (bluetape4k-junit5) 로 동시 코루틴 워크로드 → `successCount==10`, `currentStock==0`.
+    2. **`코루틴 취소 시 락이 정상 해제됨` (P0 검증):**
+       ```kotlin
+       @Test
+       fun `코루틴 취소 시 락이 정상 해제됨`() = runSuspendIO {
+           val lockName = "inventory:sfenced:999"
+           val fLock = redisson.getFencedLock(lockName)
+           store.register(Inventory(999L, "취소테스트", 100))
+           val job = launch { service.deduct(999L, 10); delay(100) }
+           delay(50)
+           job.cancel(); job.join()
+           fLock.isLocked shouldBeEqualTo false   // NonCancellable unlock 검증
+       }
+       ```
+     - 이 테스트가 없으면 `withContext(NonCancellable)` 수정의 효과를 검증 불가.
+
+### T21 — `LockFailureTest` (smoke, lease 만료)
+
+- **complexity**: medium
+- **files**:
+  - `src/test/kotlin/io/bluetape4k/workshop/lock/LockFailureTest.kt`
+- **notes**:
+  - `: AbstractDistributedLockTest()`.
+  - **클래스 또는 메서드에 `@Tag("smoke")` — 모든 테스트 메서드에 부착** (junit-platform.properties 의 `exclude.tags=smoke` 로 기본 CI 제외).
+  - 케이스: `lease 만료 후 unlock 시도 시 IllegalMonitorStateException`.
+    - `lock.tryLock(1000, 200, MILLISECONDS)`, `Thread.sleep(500)`, `assertFailsWith<IllegalMonitorStateException> { lock.unlock() }`.
+  - `assertFailsWith` 는 `kotlin.test` 가 아닌 `org.junit.jupiter.api.assertThrows` 대체 — bluetape4k 관례 확인: `assertFailsWith<T> { }` from `kotlin.test` 는 CLAUDE.md 가 금지 → **JUnit 5 `assertThrows<T> { }`** 사용 (Kotlin reified).
+
+### T22 — `FencedStaleHolderTest` (smoke, 완전 시나리오)
+
+- **complexity**: high
+- **files**:
+  - `src/test/kotlin/io/bluetape4k/workshop/lock/FencedStaleHolderTest.kt`
+- **notes**:
+  - `: AbstractDistributedLockTest()`.
+  - **모든 테스트 `@Tag("smoke")`** — 타이밍 의존 (lease=200ms, sleep=500ms).
+  - 완전한 stale-holder 시나리오 (spec §7.4):
+    1. A 가 `tryLockAndGetToken(1000, 200, MILLISECONDS)` → token1.
+    2. `Thread.sleep(500)` → lease 만료.
+    3. B 가 `tryLockAndGetToken(1000, 5000, MILLISECONDS)` → token2; `token2 shouldBeGreaterThan token1`.
+    4. `resource.apply(token2) { "B wins" }.shouldNotBeNull()`.
+    5. `resource.apply(token1) { "A is stale" }.shouldBeNull()` ← 거부 확인.
+    6. `assertThrows<IllegalMonitorStateException> { fLock1.unlock() }`.
+    7. `fLock2.unlock()` 정상.
+
+---
+
+## Phase 6: Documentation
+
+### T23 — `README.md` (English, primary)
+
+- **complexity**: medium
+- **files**:
+  - `README.md`
+- **notes**:
+  - 구조 (CLAUDE.md 권장):
+    1. Architecture (Mermaid diagram — 4 단계 학습 경로 시각화).
+    2. Core features (RLock, RFencedLock, coroutine-safe variant, race demo).
+    3. Usage examples (각 서비스의 deduct() 호출 예).
+    4. Configuration options (waitMs, leaseMs, `redisson.yaml`).
+    5. Dependency instructions (`./gradlew :redis-distributed-lock:test`).
+  - 학습 경로 표 (spec §0) 포함.
+  - 영어 작성.
+
+### T24 — `README.ko.md` (Korean, locale)
+
+- **complexity**: medium
+- **files**:
+  - `README.ko.md`
+- **notes**:
+  - `README.md` 구조 1:1 미러링, 한국어 본문.
+  - 학습 경로 + 코드 예제 + 명령어는 영어 그대로 (코드/명령어는 비번역).
+
+### T25 — KDoc 마감 점검 (touch-pass on public API)
+
+- **complexity**: low
+- **files**:
+  - 모든 `src/main/kotlin/io/bluetape4k/workshop/lock/**/*.kt` (touch-pass)
+- **notes**:
+  - 모든 공개 클래스/인터페이스/함수에 영문 KDoc 보장.
+  - 각 KDoc: 한 줄 요약 + `## Behavior / Contract` (특히 `FencedResource.apply`, `SuspendingFencedInventoryService.deduct`).
+  - 멱등성 가정 (`FencedResource`), `getLockId` 수명주기 (`SuspendingFencedInventoryService`), `NonCancellable` 보장 명시.
+  - IDE diagnostics 정리 (오류 0, 미해결 deprecation 0) — Kotlin Editing Workflow 준수.
+
+---
+
+## Validation / DoD 체크리스트 (spec §10 매핑)
+
+- [ ] `./gradlew :redis-distributed-lock:test` → 스모크 제외 전체 통과 (T17–T20).
+- [ ] `./gradlew :redis-distributed-lock:test -Djunit.jupiter.execution.exclude.tags=` → 스모크 포함 통과 (T21, T22).
+- [ ] IDE diagnostics: 오류 0, deprecation 0 (T25).
+- [ ] `BaselineRaceTest` 가 oversell 을 실제로 관찰 (T17).
+- [ ] `SuspendFencedLockTest` 의 취소 케이스에서 `fLock.isLocked == false` (T20, P0).
+- [ ] `README.md` + `README.ko.md` 둘 다 존재 (T23, T24).
+- [ ] 모든 공개 API 영문 KDoc (T25).
+- [ ] bluetape4k-patterns 체크리스트 통과.
+
+---
+
+## 결정 기록
+
+1. **settings.gradle.kts 수정 없음.** Line 37 `includeModules("redis", false, true)` 가 디렉토리 추가 시 `:redis-distributed-lock` 자동 등록 (spec 명시).
+2. **build.gradle.kts 는 lean.** 인접 `redisson-examples` 의 grpc/protobuf/fory/kryo/cache/h2 의존성은 이 모듈에 불필요 → 제외.
+3. **BaselineRaceTest 는 `@RepeatedTest(3)`** (task brief 가 spec §7.1 의 `@Test` 를 override; 결정성 ↑).
+4. **`FencedResource.apply`: strict less-than (`token < current`).** equal token 은 재진입으로 허용 (spec §6.3, FencedLockTest 케이스 2가 검증).
+5. **`SuspendingFencedInventoryService`: 두 단계 acquire (`tryLockAsync` + `getTokenAsync`).** Redisson 4.4.0 에는 `tryLockAndGetTokenAsync(..., lockId)` 변형이 없음. 추가 RTT 1회는 코루틴 안전성을 위한 필수 비용.
+6. **`finally { withContext(NonCancellable) { unlockAsync.await() } }` 필수.** 누락 시 코루틴 취소 → CancellationException → unlock 디스패치 실패 → 락 리크 (P0).
+7. **모든 `deduct()` 첫 줄 `qty.requirePositiveNumber("qty")`.** 음수/0 qty 는 스톡을 증가시키므로 반드시 거부.
+8. **`LockFailureTest`, `FencedStaleHolderTest` 는 `@Tag("smoke")`.** `junit-platform.properties` 의 `exclude.tags=smoke` 로 기본 실행 제외.
+9. **`KLogging` (non-suspend) vs `KLoggingChannel` (suspend).** 4개 서비스 중 `SuspendingFencedInventoryService` 만 `KLoggingChannel`.
+
+---
+
+## Task Summary Table
+
+| Task | Title | Phase | Complexity | Files |
+|------|-------|-------|------------|-------|
+| T1 | Module `build.gradle.kts` (lean deps) | 1 | medium | `build.gradle.kts` |
+| T2 | `DistributedLockApp.kt` Spring Boot entry | 1 | low | `src/main/kotlin/.../DistributedLockApp.kt` |
+| T3 | Main `application.yaml` | 1 | low | `src/main/resources/application.yaml` |
+| T4 | `redisson.yaml` | 1 | low | `src/main/resources/redisson.yaml` |
+| T5 | Test `application.yaml` + `junit-platform.properties` (smoke exclude) | 1 | low | `src/test/resources/application.yaml`, `src/test/resources/junit-platform.properties` |
+| T6 | Test `logback-test.xml` | 1 | low | `src/test/resources/logback-test.xml` |
+| T7 | `Inventory` data class | 2 | low | `src/main/kotlin/.../domain/Inventory.kt` |
+| T8 | `DeductionResult` sealed hierarchy (per-subtype serialVersionUID) | 2 | medium | `src/main/kotlin/.../domain/DeductionResult.kt` |
+| T9 | `InventoryStore` (in-memory) | 2 | medium | `src/main/kotlin/.../domain/InventoryStore.kt` |
+| T10 | `UnsafeInventoryService` (race demo with Thread.sleep window) | 3 | medium | `src/main/kotlin/.../service/UnsafeInventoryService.kt` |
+| T11 | `LockedInventoryService` (RLock, 3-arg tryLock) | 3 | medium | `src/main/kotlin/.../service/LockedInventoryService.kt` |
+| T12 | `FencedInventoryService` (RFencedLock blocking) | 3 | high | `src/main/kotlin/.../service/FencedInventoryService.kt` |
+| T13 | `SuspendingFencedInventoryService` (lockId + NonCancellable unlock) | 3 | high | `src/main/kotlin/.../service/SuspendingFencedInventoryService.kt` |
+| T14 | `FencedResource` (CAS guard, strict less-than) | 4 | high | `src/main/kotlin/.../fenced/FencedResource.kt` |
+| T15 | `FencedResources` registry | 4 | low | `src/main/kotlin/.../fenced/FencedResources.kt` |
+| T16 | `AbstractDistributedLockTest` (RedisServer.Launcher + RedissonClientSupport) | 5 | medium | `src/test/kotlin/.../AbstractDistributedLockTest.kt` |
+| T17 | `BaselineRaceTest` (@RepeatedTest(3), oversell assertion) | 5 | high | `src/test/kotlin/.../BaselineRaceTest.kt` |
+| T18 | `DistributedLockTest` (RLock correctness) | 5 | medium | `src/test/kotlin/.../DistributedLockTest.kt` |
+| T19 | `FencedLockTest` (monotonic tokens + strict-less-than + concurrency) | 5 | medium | `src/test/kotlin/.../FencedLockTest.kt` |
+| T20 | `SuspendFencedLockTest` (no-oversell + cancellation P0) | 5 | high | `src/test/kotlin/.../SuspendFencedLockTest.kt` |
+| T21 | `LockFailureTest` (@Tag("smoke"), lease expiry) | 5 | medium | `src/test/kotlin/.../LockFailureTest.kt` |
+| T22 | `FencedStaleHolderTest` (@Tag("smoke"), full stale-holder flow) | 5 | high | `src/test/kotlin/.../FencedStaleHolderTest.kt` |
+| T23 | `README.md` (English, Mermaid diagram, learning path) | 6 | medium | `README.md` |
+| T24 | `README.ko.md` (Korean mirror) | 6 | medium | `README.ko.md` |
+| T25 | KDoc touch-pass on public API + IDE diagnostics | 6 | low | all `src/main/kotlin/.../**/*.kt` |
+
+**Total: 25 tasks.**
+
+**Complexity breakdown:**
+
+- **high (6)**: T12, T13, T14, T17, T20, T22.
+- **medium (11)**: T1, T8, T9, T10, T11, T16, T18, T19, T21, T23, T24.
+- **low (8)**: T2, T3, T4, T5, T6, T7, T15, T25.
+
+Total: **25 tasks** (high 6 + medium 11 + low 8).

--- a/docs/superpowers/specs/2026-05-23-distributed-lock-design.md
+++ b/docs/superpowers/specs/2026-05-23-distributed-lock-design.md
@@ -1,0 +1,491 @@
+# 설계 문서: Distributed/Fenced Lock 워크샵 모듈 (Issue #101)
+
+작성일: 2026-05-23  
+브랜치: `feat/issue-101-distributed-lock`  
+모듈: `redis/distributed-lock` (Gradle: `:redis-distributed-lock`)
+
+---
+
+## 1. 목적과 배경
+
+### 문제 정의
+
+멀티 인스턴스 환경에서 재고 차감, 쿠폰 발급, 중복 이미지 처리 방지 등 공유 자원에 대한 동시 접근 시 race condition이 발생한다.
+
+- **기준선 상황**: 락 없이 check-then-act → 여러 스레드가 같은 재고를 동시에 확인 후 차감 → 재고 음수(oversell)
+- **RLock 적용**: 분산 락으로 한 번에 하나의 스레드만 접근 → oversell 방지
+- **RFencedLock 적용**: 단조 증가 토큰으로 구 소유자(stale holder)의 작업을 거부 → GC 일시정지 / 네트워크 지연 시나리오 대응
+
+### 학습 목표
+
+1. Race condition의 실증 (베이스라인 테스트로 oversell 관찰)
+2. `RLock`(재진입 가능 분산 락)으로 race 방지
+3. `RFencedLock`(펜스 토큰)으로 구 소유자 거부 패턴 학습
+4. 코루틴에서 `getLockId()`를 사용한 올바른 Redisson 잠금 정체성 관리
+5. lease 만료, 구 소유자 해제 실패 동작 이해
+
+---
+
+## 2. 범위
+
+### 포함 (In-Scope)
+
+- Gradle 모듈 `redis/distributed-lock` (`:redis-distributed-lock`)
+- 재고 도메인 (in-memory `AtomicInteger`) — 영속성 없음
+- 3가지 서비스 변형: 비안전(UnsafeInventoryService), 락(LockedInventoryService), 펜스드(FencedInventoryService)
+- 코루틴 변형: `SuspendingFencedInventoryService`
+- 펜스 거부 가드: `FencedResource` (CAS 기반 토큰 검증)
+- 테스트: 기준선 race + 락 적용 + 펜스드 + 코루틴 + 연기 소유자 시나리오
+- README.md (English) + README.ko.md (Korean)
+
+### 제외 (Out-of-Scope)
+
+- DB/JPA 영속성 (범위 확장 방지)
+- `bluetape4k-leader` (고수준 추상화 — 별도 모듈 `leader/leader-election`에서 커버)
+- Kubernetes Pod 간 실제 멀티 인스턴스 테스트 (JVM 스레드/코루틴으로 시뮬레이션)
+- Prometheus 메트릭 익스포트
+
+---
+
+## 3. 기술 스택
+
+| 구성요소 | 버전 | 출처 |
+|---|---|---|
+| Kotlin | 2.3.x | libs.versions.toml |
+| Spring Boot | 4.0.6 | libs.versions.toml |
+| Redisson | 4.4.0 | libs.versions.toml (line 50) |
+| bluetape4k-redisson | 1.x BOM | libs.versions.toml (line 170) |
+| bluetape4k-junit5 | 1.x BOM | 동시성 테스터 |
+| bluetape4k-testcontainers | 1.x BOM | RedisServer.Launcher |
+| bluetape4k-assertions | 1.x BOM | shouldBeEqualTo, shouldBeGreaterThan |
+| Java | 21 | 워크샵 표준 |
+
+---
+
+## 4. 브레인스토밍: 3가지 설계 접근법 비교
+
+### 접근법 A: 단순 RLock + FencedLock (채택)
+
+- **설명**: 재고 도메인을 순수 in-memory(AtomicInteger)로 유지, 락 자체에 집중
+- **장점**: 도메인 복잡성 없음 → 락 패턴 자체가 명확히 드러남. Spring Boot 컨텍스트 없이도 서비스 직접 테스트 가능
+- **단점**: 실 업무에서 DB 트랜잭션과의 결합은 별도로 학습해야 함
+- **채택 이유**: Issue #101의 학습 목표(락 의미론)와 정확히 일치. DB 없이도 race 증명이 완전함
+
+### 접근법 B: Spring Data + JPA 재고 테이블
+
+- **설명**: H2 또는 PostgreSQL(Testcontainers)에 실제 `inventory` 테이블, 비관적 락과 Redisson 락 비교
+- **장점**: 실 업무에 더 가까운 시나리오
+- **단점**: DB 영속성 관련 복잡성이 락 학습을 방해함. Issue #101 범위 초과
+- **기각 이유**: 범위 비대화, DB + Redis 두 인프라 Testcontainers 관리 복잡도
+
+### 접근법 C: Lettuce SETNX 기반 수동 락
+
+- **설명**: `LettuceLock` UUID 토큰 기반 Mutex 직접 구현
+- **장점**: 저수준 이해
+- **단점**: 모노토닉 토큰이 없어 fenced lock 패턴을 시연 불가. Redisson에 비해 API 열세
+- **기각 이유**: RFencedLock의 핵심 기능(모노토닉 토큰)이 없어 Issue #101 요건 미충족
+
+---
+
+## 5. 설계 위험 요소
+
+### Risk 1: BaselineRaceTest가 항상 oversell을 관찰하지 못할 수 있음
+
+- **원인**: `AtomicInteger.addAndGet`은 내부적으로 원자적 → check-then-act를 한 명령으로 구현하면 race가 없음
+- **해결**: `UnsafeInventoryService`는 `AtomicInteger.get()`(읽기)과 `addAndGet()`(쓰기) 사이에 `Thread.sleep(1)`을 삽입하여 race window를 강제함
+- **검증**: 기준선 테스트에서 `successCount * qty > initialStock` 또는 `currentStock < 0` 단언
+
+### Risk 2: 코루틴에서 RLock 스레드 정체성 오류
+
+- **원인**: Redisson 기본 `RLock`은 `Thread.currentThread().id`로 소유자를 식별 → 코루틴은 suspend 후 다른 스레드에서 재개될 수 있어 `unlock()` 실패
+- **해결**: 코루틴 변형에서는 반드시 `redisson.getLockId(lockName): Long`을 호출하여 명시적 lockId 전달 (`tryLockAsync(wait, lease, unit, lockId)` + `unlockAsync(lockId)`)
+- **검증**: `SuspendFencedLockTest`에서 `SuspendedJobTester` 사용 + 결과 검증
+
+### Risk 3: Watchdog 자동 갱신이 lease 만료 테스트를 깨뜨림
+
+- **원인**: Redisson `lock()` 또는 `tryLock(wait, unit)` (leaseTime 없음) 호출 시 watchdog이 30초마다 자동 갱신
+- **해결**: 모든 서비스 변형에서 3인수 형태 `tryLock(waitTime, leaseTime, unit)` 사용 → watchdog 비활성화
+- **검증**: `LockFailureTest`에서 200ms lease + 500ms sleep → lease 만료 관찰
+
+### Risk 4: `FencedResource.apply()` 동시성 정확성
+
+- **원인**: naive `if (token >= last) { last = token; work() }` 패턴은 non-atomic check-then-set
+- **해결**: CAS 루프로 check-and-update 원자화:
+  ```kotlin
+  while (true) {
+      val current = lastSeenToken.get()
+      if (token < current) return null
+      if (lastSeenToken.compareAndSet(current, maxOf(current, token))) return work()
+  }
+  ```
+- **검증**: `FencedLockTest.tokenRejectionGuard()` — apply(5) → apply(3) → null 반환 확인
+
+### Risk 5: Smoke 테스트가 CI를 불안정하게 만들 수 있음
+
+- **원인**: `LockFailureTest`, `FencedStaleHolderTest`는 정확한 타이밍에 의존 (200ms lease, 500ms sleep)
+- **해결**: `@Tag("smoke")` + `junit-platform.properties`의 `junit.jupiter.execution.exclude.tags=smoke`로 기본 실행에서 제외
+- **검증**: `./gradlew :redis-distributed-lock:test` 빌드 안정적, 명시적 `-Djunit.jupiter.execution.exclude.tags=` 로 스모크도 실행 가능
+
+---
+
+## 6. 컴포넌트 설계
+
+### 6.1 도메인 레이어
+
+```kotlin
+// Inventory.kt
+data class Inventory(val id: Long, val name: String, val initialStock: Int) : Serializable {
+    init {
+        id.requirePositiveNumber("id")
+        name.requireNotBlank("name")
+        initialStock.requireZeroOrPositiveNumber("initialStock")
+    }
+    companion object : KLogging() { private const val serialVersionUID = 1L }
+}
+
+// DeductionResult.kt  
+sealed interface DeductionResult {
+    data class Success(val remaining: Int, val token: Long? = null) : DeductionResult, Serializable
+    data object InsufficientStock : DeductionResult, Serializable
+    data object Rejected : DeductionResult, Serializable  // fenced token rejected
+    data object LockNotAcquired : DeductionResult, Serializable  // lock timeout
+    companion object { private const val serialVersionUID = 1L }
+}
+
+// InventoryStore.kt
+@Component
+class InventoryStore {
+    private val store = ConcurrentHashMap<Long, AtomicInteger>()
+    
+    fun register(inventory: Inventory)
+    fun currentStock(id: Long): Int
+    fun applyChange(id: Long, delta: Int): Int  // returns new value
+    fun reset(id: Long, value: Int)
+}
+```
+
+### 6.2 서비스 레이어
+
+```kotlin
+// UnsafeInventoryService.kt — race 데모용
+class UnsafeInventoryService(private val store: InventoryStore) {
+    fun deduct(id: Long, qty: Int): DeductionResult {
+        val current = store.currentStock(id)  // READ
+        if (current < qty) return InsufficientStock
+        Thread.sleep(1)                        // ← 강제 race window
+        val remaining = store.applyChange(id, -qty)  // WRITE
+        return Success(remaining)
+    }
+}
+
+// LockedInventoryService.kt — RLock
+class LockedInventoryService(private val redisson: RedissonClient, private val store: InventoryStore) {
+    fun deduct(id: Long, qty: Int, waitMs: Long = 2000L, leaseMs: Long = 5000L): DeductionResult {
+        val lock = redisson.getLock("inventory:lock:$id")
+        val acquired = lock.tryLock(waitMs, leaseMs, MILLISECONDS)  // 명시적 leaseTime → watchdog 비활성화
+        if (!acquired) return LockNotAcquired
+        try {
+            val current = store.currentStock(id)
+            if (current < qty) return InsufficientStock
+            val remaining = store.applyChange(id, -qty)
+            return Success(remaining)
+        } finally {
+            if (lock.isHeldByCurrentThread) lock.unlock()
+        }
+    }
+}
+
+// FencedInventoryService.kt — RFencedLock
+class FencedInventoryService(
+    private val redisson: RedissonClient,
+    private val store: InventoryStore,
+    private val fencedResources: FencedResources,
+) {
+    fun deduct(id: Long, qty: Int, waitMs: Long = 2000L, leaseMs: Long = 5000L): DeductionResult {
+        val fLock = redisson.getFencedLock("inventory:fenced:$id")
+        val token = fLock.tryLockAndGetToken(waitMs, leaseMs, MILLISECONDS) ?: return LockNotAcquired
+        try {
+            val result = fencedResources.forResource(id).apply(token) {
+                val current = store.currentStock(id)
+                if (current < qty) InsufficientStock
+                else Success(store.applyChange(id, -qty), token)
+            }
+            return result ?: Rejected
+        } finally {
+            runCatching { fLock.unlock() }  // non-suspend, safe to use runCatching
+        }
+    }
+}
+```
+
+### 6.3 펜스 거부 가드
+
+```kotlin
+// FencedResource.kt
+class FencedResource(val resourceId: Long) {
+    private val lastSeenToken = AtomicLong(0L)
+    
+    fun <T : Any> apply(token: Long, work: () -> T): T? {
+        while (true) {
+            val current = lastSeenToken.get()
+            if (token < current) return null  // stale token → reject
+            if (lastSeenToken.compareAndSet(current, maxOf(current, token))) {
+                return work()
+            }
+            // CAS lost, retry
+        }
+    }
+}
+
+// FencedResources.kt
+@Component
+class FencedResources {
+    private val map = ConcurrentHashMap<Long, FencedResource>()
+    fun forResource(id: Long) = map.computeIfAbsent(id) { FencedResource(it) }
+    fun reset(id: Long) { map.remove(id) }
+}
+```
+
+### 6.4 코루틴 변형
+
+```kotlin
+// SuspendingFencedInventoryService.kt
+@Service
+class SuspendingFencedInventoryService(
+    private val redisson: RedissonClient,
+    private val store: InventoryStore,
+    private val fencedResources: FencedResources,
+) {
+    companion object : KLoggingChannel()
+    
+    suspend fun deduct(id: Long, qty: Int, waitMs: Long = 2000L, leaseMs: Long = 5000L): DeductionResult {
+        val lockName = "inventory:sfenced:$id"
+        val lockId = redisson.getLockId(lockName)  // 코루틴 안전 정체성
+        val fLock = redisson.getFencedLock(lockName)
+        
+        val acquired = fLock.tryLockAsync(waitMs, leaseMs, MILLISECONDS, lockId).await()
+        if (!acquired) return LockNotAcquired
+        
+        try {
+            val token = fLock.tokenAsync.await()
+            val result = fencedResources.forResource(id).apply(token) {
+                val current = store.currentStock(id)
+                if (current < qty) InsufficientStock
+                else Success(store.applyChange(id, -qty), token)
+            }
+            return result ?: Rejected
+        } finally {
+            try {
+                fLock.unlockAsync(lockId).await()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                log.warn(e) { "unlock failed for lockId=$lockId" }
+            }
+        }
+    }
+}
+```
+
+---
+
+## 7. 테스트 전략
+
+### 7.1 기준선 race 테스트 (BaselineRaceTest)
+
+```kotlin
+@Test
+fun `lock 없이 재고 차감 시 oversell 발생`() {
+    store.register(Inventory(1L, "사과", 100))
+    val successCount = AtomicInteger(0)
+    
+    MultithreadingTester()
+        .workers(20).rounds(1)
+        .add {
+            val result = service.deduct(1L, 10)
+            if (result is Success) successCount.incrementAndGet()
+        }.run()
+    
+    // 기대: successCount > 10 (100/10) — 즉 oversell 발생
+    // 또는: store.currentStock(1L) < 0
+    successCount.get() shouldBeGreaterThan 10
+}
+```
+
+### 7.2 RLock 테스트 (DistributedLockTest)
+
+```kotlin
+@RepeatedTest(3)
+fun `RLock 적용 후 정확한 재고 차감`() {
+    store.reset(1L, 100)
+    val successCount = AtomicInteger(0)
+    
+    MultithreadingTester()
+        .workers(20).rounds(1)
+        .add {
+            val result = service.deduct(1L, 10, waitMs=3000L, leaseMs=5000L)
+            if (result is Success) successCount.incrementAndGet()
+        }.run()
+    
+    successCount.get() shouldBeEqualTo 10
+    store.currentStock(1L) shouldBeEqualTo 0
+}
+```
+
+### 7.3 FencedLock 테스트 (FencedLockTest)
+
+토큰 단조 증가 검증 + 토큰 거부 가드:
+
+```kotlin
+@Test
+fun `연속 획득 시 토큰 단조 증가`() {
+    val lockName = randomName("fenced")
+    val fLock = redisson.getFencedLock(lockName)
+    val tokens = mutableListOf<Long>()
+    
+    repeat(5) {
+        val token = fLock.tryLockAndGetToken(1000, 5000, MILLISECONDS)
+        token.shouldNotBeNull()
+        tokens.add(token)
+        fLock.unlock()
+    }
+    
+    tokens.zipWithNext().forEach { (a, b) ->
+        b shouldBeGreaterThan a
+    }
+}
+
+@Test
+fun `구 토큰으로 apply 시도 시 null 반환`() {
+    val resource = FencedResource(1L)
+    resource.apply(5L) { "ok" }.shouldNotBeNull()
+    resource.apply(3L) { "should reject" }.shouldBeNull()
+    resource.apply(5L) { "same ok" }.shouldNotBeNull()  // equal token 허용
+}
+```
+
+### 7.4 스모크 테스트 (LockFailureTest, FencedStaleHolderTest)
+
+`@Tag("smoke")`로 기본 CI에서 제외:
+
+```kotlin
+// LockFailureTest
+@Tag("smoke") @Test
+fun `lease 만료 후 unlock 시도 시 IllegalMonitorStateException`() {
+    val lock = redisson.getLock("stale-lock")
+    lock.tryLock(1000, 200, MILLISECONDS)  // lease=200ms
+    Thread.sleep(500)  // lease 만료
+    assertFailsWith<IllegalMonitorStateException> { lock.unlock() }
+}
+
+// FencedStaleHolderTest  
+@Tag("smoke") @Test
+fun `구 소유자의 FencedResource.apply 는 null 반환`() {
+    val lockName = "stale-fenced"
+    val fLock1 = redisson.getFencedLock(lockName)
+    val token1 = fLock1.tryLockAndGetToken(1000, 200, MILLISECONDS)  // lease=200ms
+    token1.shouldNotBeNull()
+    
+    Thread.sleep(500)  // lease 만료
+    
+    val fLock2 = redisson.getFencedLock(lockName)
+    val token2 = fLock2.tryLockAndGetToken(1000, 5000, MILLISECONDS)
+    token2.shouldNotBeNull()
+    token2 shouldBeGreaterThan token1
+    
+    val resource = fencedResources.forResource(99L)
+    resource.apply(token2) { "B wins" }.shouldNotBeNull()
+    resource.apply(token1) { "A is stale" }.shouldBeNull()  // 거부!
+    
+    assertFailsWith<IllegalMonitorStateException> { fLock1.unlock() }
+    fLock2.unlock()
+}
+```
+
+---
+
+## 8. 모듈 파일 구조
+
+```
+redis/distributed-lock/
+├── build.gradle.kts
+├── README.md
+├── README.ko.md
+└── src/
+    ├── main/
+    │   ├── kotlin/io/bluetape4k/workshop/lock/
+    │   │   ├── DistributedLockApp.kt
+    │   │   ├── domain/
+    │   │   │   ├── Inventory.kt
+    │   │   │   ├── DeductionResult.kt
+    │   │   │   └── InventoryStore.kt
+    │   │   ├── fenced/
+    │   │   │   ├── FencedResource.kt
+    │   │   │   └── FencedResources.kt
+    │   │   └── service/
+    │   │       ├── UnsafeInventoryService.kt
+    │   │       ├── LockedInventoryService.kt
+    │   │       ├── FencedInventoryService.kt
+    │   │       └── SuspendingFencedInventoryService.kt
+    │   └── resources/
+    │       ├── application.yaml
+    │       └── redisson.yaml
+    └── test/
+        ├── kotlin/io/bluetape4k/workshop/lock/
+        │   ├── AbstractDistributedLockTest.kt
+        │   ├── BaselineRaceTest.kt
+        │   ├── DistributedLockTest.kt
+        │   ├── FencedLockTest.kt
+        │   ├── SuspendFencedLockTest.kt
+        │   ├── LockFailureTest.kt
+        │   └── FencedStaleHolderTest.kt
+        └── resources/
+            ├── application.yaml
+            ├── junit-platform.properties
+            └── logback-test.xml
+```
+
+---
+
+## 9. Used Bluetape4k Features
+
+| 기능 | 모듈/아티팩트 | 코드 참조 | 이점 |
+|---|---|---|---|
+| `RedissonClientSupport` (`redissonClient { }`) | `bluetape4k-redisson` | `AbstractDistributedLockTest` | DSL로 Redisson 설정 간소화 |
+| `getLockId(name): Long` | `bluetape4k-redisson` | `SuspendingFencedInventoryService` | 코루틴 안전 잠금 정체성 (Thread.id 대체) |
+| `KLogging()` / `KLoggingChannel()` | `bluetape4k-logging` | 모든 서비스/테스트 | 구조화 로깅, 코루틴 컨텍스트 |
+| `MultithreadingTester` | `bluetape4k-junit5` | `BaselineRaceTest`, `DistributedLockTest` | 플랫폼 스레드 동시성 스트레스 테스트 |
+| `SuspendedJobTester` | `bluetape4k-junit5` | `SuspendFencedLockTest` | 코루틴 race condition 검증 |
+| `RedisServer.Launcher.redis` | `bluetape4k-testcontainers` | `AbstractDistributedLockTest` | Redis 컨테이너 싱글톤 패턴 |
+| `shouldBeEqualTo`, `shouldBeGreaterThan` 등 | `bluetape4k-assertions` | 모든 테스트 | 타입 안전 단언 |
+| `runSuspendIO { }` | `bluetape4k-junit5` | `SuspendFencedLockTest` | suspend 테스트 블록 실행 |
+| `requireNotBlank`, `requirePositiveNumber` | `bluetape4k-core` | `Inventory.init` | 인자 검증 표준화 |
+
+---
+
+## 10. DoD (Definition of Done)
+
+### 기능적 요건
+
+- [ ] `BaselineRaceTest`: 락 없이 oversell 발생 증명 (`successCount > initialStock / qty` 또는 `currentStock < 0`)
+- [ ] `DistributedLockTest`: RLock 적용 후 정확한 차감 (no oversell, `currentStock == 0`)
+- [ ] `FencedLockTest`: 모노토닉 토큰 확인 + `apply(staleToken)` 시 null 반환 확인
+- [ ] `SuspendFencedLockTest`: 코루틴 변형에서 `getLockId` 사용, no oversell
+- [ ] `LockFailureTest` (`@Tag("smoke")`): lease 만료 후 stale unlock → `IllegalMonitorStateException`
+- [ ] `FencedStaleHolderTest` (`@Tag("smoke")`): 완전한 stale-holder 시나리오
+
+### 비기능적 요건
+
+- [ ] `./gradlew :redis-distributed-lock:test` → 스모크 제외 전체 통과
+- [ ] IDE 진단: 오류 0, 미해결 deprecation 0
+- [ ] `README.md` (English) + `README.ko.md` (Korean) 포함
+- [ ] KDoc: 모든 공개 클래스/인터페이스/함수에 영문 KDoc
+- [ ] bluetape4k-patterns 체크리스트 전체 통과
+
+---
+
+## 11. 리뷰 이터레이션 로그 (Appendix)
+
+| 라운드 | Reviewer | P0/P1 | P2/P3 | 반영 커밋 |
+|---|---|---|---|---|
+| Round 1 spec | (작성 중) | - | - | - |

--- a/docs/superpowers/specs/2026-05-23-distributed-lock-design.md
+++ b/docs/superpowers/specs/2026-05-23-distributed-lock-design.md
@@ -6,6 +6,21 @@
 
 ---
 
+## 0. 학습 경로 (Start Here)
+
+이 워크샵은 네 단계로 경험한다. 각 단계는 이전 단계의 문제를 해결하는 구조다.
+
+| 단계 | 서비스 | 테스트 | 학습 내용 |
+|---|---|---|---|
+| 1 | `UnsafeInventoryService` | `BaselineRaceTest` | 락 없이 race → oversell 발생 확인 |
+| 2 | `LockedInventoryService` | `DistributedLockTest` | `RLock`으로 oversell 방지 |
+| 3 | `FencedInventoryService` | `FencedLockTest`, `FencedStaleHolderTest` | `RFencedLock`으로 구 소유자(stale holder) 거부 |
+| 4 | `SuspendingFencedInventoryService` | `SuspendFencedLockTest` | 코루틴에서 `getLockId` + `NonCancellable` 패턴 |
+
+**권장 순서:** 1 → 2 → 3 → 4 (각 서비스 소스 → 대응 테스트 순서)
+
+---
+
 ## 1. 목적과 배경
 
 ### 문제 정의
@@ -126,6 +141,13 @@
 - **해결**: `@Tag("smoke")` + `junit-platform.properties`의 `junit.jupiter.execution.exclude.tags=smoke`로 기본 실행에서 제외
 - **검증**: `./gradlew :redis-distributed-lock:test` 빌드 안정적, 명시적 `-Djunit.jupiter.execution.exclude.tags=` 로 스모크도 실행 가능
 
+### Risk 6: Redis 불가용 시 tryLockAsync 무한 대기
+
+- **원인**: `tryLockAsync(waitMs, leaseMs, MILLISECONDS, lockId).await()`는 Redis 접속 불가 시 `waitMs` 만큼 대기 후 연결 오류 예외를 던짐. 워크샵 범위에서 circuit breaker / fallback 없음
+- **해결**: 서비스 단에서 `try/catch(Exception)`으로 `LockNotAcquired` 반환 (표준 실패 경로) + `waitMs` 를 합리적인 값(2초 이하)으로 설정. Redis Testcontainers가 항상 실행 중인 환경에서만 테스트
+- **leaseTime 선정 기준**: 임계 구역 예상 최대 수행 시간의 5배 이상을 leaseTime으로 설정 (watchdog 없는 경우). 예: 도메인 로직 500ms → leaseTime 3000ms 이상
+- **검증**: Testcontainers `RedisServer.Launcher.redis` 사용으로 항상 가용. Redis 다운 시나리오는 Out-of-Scope (단위 테스트 불가, 통합 환경 필요)
+
 ---
 
 ## 6. 컴포넌트 설계
@@ -143,13 +165,25 @@ data class Inventory(val id: Long, val name: String, val initialStock: Int) : Se
     companion object : KLogging() { private const val serialVersionUID = 1L }
 }
 
-// DeductionResult.kt  
+// DeductionResult.kt
+// 모든 서브타입은 JVM 직렬화를 위해 별도 serialVersionUID를 선언해야 한다 (CLAUDE.md 규칙).
 sealed interface DeductionResult {
-    data class Success(val remaining: Int, val token: Long? = null) : DeductionResult, Serializable
-    data object InsufficientStock : DeductionResult, Serializable
-    data object Rejected : DeductionResult, Serializable  // fenced token rejected
-    data object LockNotAcquired : DeductionResult, Serializable  // lock timeout
-    companion object { private const val serialVersionUID = 1L }
+    /** 차감 성공. token은 fenced 경로에서만 값을 가짐 (non-fenced 경로는 null). */
+    data class Success(val remaining: Int, val token: Long? = null) : DeductionResult, Serializable {
+        companion object { private const val serialVersionUID = 1L }
+    }
+    /** 재고 부족 (차감 수량 > 현재 재고). */
+    data class InsufficientStock(val requested: Int, val available: Int) : DeductionResult, Serializable {
+        companion object { private const val serialVersionUID = 1L }
+    }
+    /** Fenced 토큰 거부 (구 소유자의 토큰이 현재 기대값보다 낮음). */
+    data class Rejected(val token: Long) : DeductionResult, Serializable {
+        companion object { private const val serialVersionUID = 1L }
+    }
+    /** 락 획득 타임아웃 (waitMs 내 획득 실패 또는 Redis 예외). */
+    data class LockNotAcquired(val lockName: String) : DeductionResult, Serializable {
+        companion object { private const val serialVersionUID = 1L }
+    }
 }
 
 // InventoryStore.kt
@@ -169,9 +203,12 @@ class InventoryStore {
 ```kotlin
 // UnsafeInventoryService.kt — race 데모용
 class UnsafeInventoryService(private val store: InventoryStore) {
+    companion object : KLogging()
+
     fun deduct(id: Long, qty: Int): DeductionResult {
+        qty.requirePositiveNumber("qty")  // 음수/0 qty는 스톡을 증가시키므로 반드시 검증
         val current = store.currentStock(id)  // READ
-        if (current < qty) return InsufficientStock
+        if (current < qty) return InsufficientStock(qty, current)
         Thread.sleep(1)                        // ← 강제 race window
         val remaining = store.applyChange(id, -qty)  // WRITE
         return Success(remaining)
@@ -180,13 +217,20 @@ class UnsafeInventoryService(private val store: InventoryStore) {
 
 // LockedInventoryService.kt — RLock
 class LockedInventoryService(private val redisson: RedissonClient, private val store: InventoryStore) {
+    companion object : KLogging()
+
     fun deduct(id: Long, qty: Int, waitMs: Long = 2000L, leaseMs: Long = 5000L): DeductionResult {
-        val lock = redisson.getLock("inventory:lock:$id")
+        qty.requirePositiveNumber("qty")
+        val lockName = "inventory:lock:$id"
+        val lock = redisson.getLock(lockName)
         val acquired = lock.tryLock(waitMs, leaseMs, MILLISECONDS)  // 명시적 leaseTime → watchdog 비활성화
-        if (!acquired) return LockNotAcquired
+        if (!acquired) {
+            log.warn { "Lock not acquired: $lockName (wait=${waitMs}ms)" }
+            return LockNotAcquired(lockName)
+        }
         try {
             val current = store.currentStock(id)
-            if (current < qty) return InsufficientStock
+            if (current < qty) return InsufficientStock(qty, current)
             val remaining = store.applyChange(id, -qty)
             return Success(remaining)
         } finally {
@@ -201,18 +245,31 @@ class FencedInventoryService(
     private val store: InventoryStore,
     private val fencedResources: FencedResources,
 ) {
+    companion object : KLogging()
+
     fun deduct(id: Long, qty: Int, waitMs: Long = 2000L, leaseMs: Long = 5000L): DeductionResult {
-        val fLock = redisson.getFencedLock("inventory:fenced:$id")
-        val token = fLock.tryLockAndGetToken(waitMs, leaseMs, MILLISECONDS) ?: return LockNotAcquired
+        qty.requirePositiveNumber("qty")
+        val lockName = "inventory:fenced:$id"
+        val fLock = redisson.getFencedLock(lockName)
+        val token = fLock.tryLockAndGetToken(waitMs, leaseMs, MILLISECONDS)
+            ?: run {
+                log.warn { "Fenced lock not acquired: $lockName (wait=${waitMs}ms)" }
+                return LockNotAcquired(lockName)
+            }
         try {
             val result = fencedResources.forResource(id).apply(token) {
                 val current = store.currentStock(id)
-                if (current < qty) InsufficientStock
+                if (current < qty) InsufficientStock(qty, current)
                 else Success(store.applyChange(id, -qty), token)
             }
-            return result ?: Rejected
+            return result ?: run {
+                log.warn { "Fenced token $token rejected for $lockName" }
+                Rejected(token)
+            }
         } finally {
-            runCatching { fLock.unlock() }  // non-suspend, safe to use runCatching
+            runCatching { fLock.unlock() }.onFailure { e ->
+                log.warn(e) { "Fenced unlock failed (lease may have expired): $lockName" }
+            }
         }
     }
 }
@@ -220,19 +277,34 @@ class FencedInventoryService(
 
 ### 6.3 펜스 거부 가드
 
+> **워크샵 범위 한계 (알려진 제약사항):**
+> - `FencedResource`는 JVM 인-메모리 CAS 가드다. JVM 재시작 시 `lastSeenToken`이 0으로 리셋된다.
+>   실 운영에서는 Redis나 DB에 토큰 상태를 영속화해야 하지만, 이 모듈의 범위를 벗어난다.
+> - `FencedResources.map`은 크기 제한이 없다. 워크샵의 고정된 자원 ID 세트에는 문제없지만,
+>   실 운영에서는 eviction 정책이 필요하다.
+> - **동일 토큰(equal token) 정책**: `token == current` (동일 임차자의 재진입)는 허용한다.
+>   즉, 같은 lease 내에서 동일 토큰으로 `apply`를 여러 번 호출할 수 있다 (멱등성 보장 시).
+>   `work()`는 반드시 멱등적이어야 한다.
+
 ```kotlin
 // FencedResource.kt
 class FencedResource(val resourceId: Long) {
     private val lastSeenToken = AtomicLong(0L)
     
+    /**
+     * Applies [work] if [token] is greater than or equal to the last seen token.
+     * - Returns `null` if [token] is stale (strictly less than current token).
+     * - Allows equal tokens for reentrant access within the same lease (work must be idempotent).
+     * - Thread-safe via CAS loop.
+     */
     fun <T : Any> apply(token: Long, work: () -> T): T? {
         while (true) {
             val current = lastSeenToken.get()
-            if (token < current) return null  // stale token → reject
+            if (token < current) return null  // stale token → reject (strictly less-than)
             if (lastSeenToken.compareAndSet(current, maxOf(current, token))) {
                 return work()
             }
-            // CAS lost, retry
+            // CAS lost to concurrent apply, retry
         }
     }
 }
@@ -240,6 +312,7 @@ class FencedResource(val resourceId: Long) {
 // FencedResources.kt
 @Component
 class FencedResources {
+    // Workshop scope: unbounded, in-memory, state lost on JVM restart
     private val map = ConcurrentHashMap<Long, FencedResource>()
     fun forResource(id: Long) = map.computeIfAbsent(id) { FencedResource(it) }
     fun reset(id: Long) { map.remove(id) }
@@ -247,6 +320,17 @@ class FencedResources {
 ```
 
 ### 6.4 코루틴 변형
+
+> **getLockId 수명주기 계약 (MUST — 위반 시 락 미해제):**
+> 1. `getLockId(lockName)` 는 락 이름당 호출 횟수가 아니라 **호출 시점의 현재 스레드/코루틴 컨텍스트**를 기반으로 안정적인 Long ID를 반환한다.
+> 2. 하나의 acquire/release 사이클에서 **반드시 `val lockId`를 한 번 결정하고 로컬 변수에 저장**한다.
+>    `tryLockAsync(..., lockId)`와 `unlockAsync(lockId)` 에 동일한 값을 사용해야 한다.
+> 3. acquire와 release 사이에 `getLockId`를 재호출하거나 다른 값으로 `unlockAsync`를 호출하면 락이 해제되지 않는다.
+>
+> **NonCancellable unlock 계약 (P0 — 위반 시 락 리크):**
+> 코루틴이 취소될 때 `finally` 블록 내 `await()`는 즉시 `CancellationException`을 던지고 Redis unlock 명령을 디스패치하지 않는다.
+> 모든 코루틴 측 Redisson unlock은 반드시 `withContext(NonCancellable) { ... }` 으로 감싸야 한다.
+> 이 패턴은 `bluetape4k-leader`의 `RedissonSuspendLeaderElector`에서 확립된 프로젝트 관례다.
 
 ```kotlin
 // SuspendingFencedInventoryService.kt
@@ -259,32 +343,57 @@ class SuspendingFencedInventoryService(
     companion object : KLoggingChannel()
     
     suspend fun deduct(id: Long, qty: Int, waitMs: Long = 2000L, leaseMs: Long = 5000L): DeductionResult {
+        qty.requirePositiveNumber("qty")
         val lockName = "inventory:sfenced:$id"
-        val lockId = redisson.getLockId(lockName)  // 코루틴 안전 정체성
+        
+        // [1] getLockId는 한 번만 결정하여 acquire와 release에 동일 값 사용 (수명주기 계약)
+        //     코루틴은 suspend 후 다른 스레드에서 재개될 수 있으므로 Thread.id 대신 안정적 lockId 사용
+        val lockId = redisson.getLockId(lockName)
         val fLock = redisson.getFencedLock(lockName)
         
+        // [2] tryLockAsync: lockId를 포함한 안전한 취득 (Redisson 4.4.0 RLockAsync)
+        //     tryLockAndGetTokenAsync는 threadId 파라미터를 지원하지 않으므로 코루틴에서는 두 단계 사용.
+        //     false이면 waitMs 내 획득 실패 → LockNotAcquired
         val acquired = fLock.tryLockAsync(waitMs, leaseMs, MILLISECONDS, lockId).await()
-        if (!acquired) return LockNotAcquired
+        if (!acquired) {
+            log.warn { "Suspending fenced lock not acquired: $lockName (wait=${waitMs}ms)" }
+            return LockNotAcquired(lockName)
+        }
+        
+        // [3] 취득 후 토큰 읽기 (getTokenAsync: 현재 보유 중인 fencing token 반환)
+        val token: Long = fLock.getTokenAsync().await()
         
         try {
-            val token = fLock.tokenAsync.await()
             val result = fencedResources.forResource(id).apply(token) {
                 val current = store.currentStock(id)
-                if (current < qty) InsufficientStock
+                if (current < qty) InsufficientStock(qty, current)
                 else Success(store.applyChange(id, -qty), token)
             }
-            return result ?: Rejected
+            return result ?: run {
+                log.warn { "Suspending fenced token $token rejected for $lockName" }
+                Rejected(token)
+            }
         } finally {
-            try {
-                fLock.unlockAsync(lockId).await()
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                log.warn(e) { "unlock failed for lockId=$lockId" }
+            // [4] withContext(NonCancellable): 코루틴 취소 시에도 Redis unlock 명령 디스패치 보장
+            //     이 패턴 없이 await()를 쓰면 취소 즉시 CancellationException이 throw되어 락이 리크됨
+            withContext(NonCancellable) {
+                try {
+                    fLock.unlockAsync(lockId).await()
+                } catch (e: Exception) {
+                    log.warn(e) { "Suspending fenced unlock failed (lease may have expired): lockId=$lockId, $lockName" }
+                }
             }
         }
     }
 }
+```
+
+> **설계 결정: 코루틴 변형은 두 단계 (tryLockAsync + getTokenAsync)를 사용한다.**
+>
+> `tryLockAndGetTokenAsync(waitMs, leaseMs, unit)` 는 원자적이지만 `lockId(threadId)` 파라미터를 지원하지 않는다.
+> 코루틴은 suspend 후 다른 스레드에서 재개되므로 Redisson 내부의 `Thread.currentThread().id` 가 unlock 시점과 불일치할 수 있다.
+> 따라서 코루틴 변형은 `tryLockAsync(..., lockId)` + `getTokenAsync()` 두 단계로 lockId 안전성을 유지한다.
+> (추가 RTT 1회는 코루틴 안전성 확보를 위한 필수 비용이다.)
 ```
 
 ---
@@ -360,7 +469,34 @@ fun `구 토큰으로 apply 시도 시 null 반환`() {
     val resource = FencedResource(1L)
     resource.apply(5L) { "ok" }.shouldNotBeNull()
     resource.apply(3L) { "should reject" }.shouldBeNull()
-    resource.apply(5L) { "same ok" }.shouldNotBeNull()  // equal token 허용
+    resource.apply(5L) { "same ok" }.shouldNotBeNull()  // equal token 허용 (동일 임차자 재진입)
+    resource.apply(4L) { "also reject" }.shouldBeNull()  // 이미 5 이상 — 4는 stale
+}
+```
+
+### 7.3-코루틴 취소 안전성 테스트 (SuspendFencedLockTest — P0 검증)
+
+> 이 테스트가 없으면 P0 (NonCancellable unlock) 수정은 검증 불가 상태다.
+
+```kotlin
+@Test
+fun `코루틴 취소 시 락이 정상 해제됨`() = runSuspendIO {
+    val lockName = "sfenced-cancel-test"
+    val fLock = redisson.getFencedLock(lockName)
+    store.register(Inventory(999L, "취소테스트", 100))
+    
+    val job = launch {
+        service.deduct(999L, 10, waitMs = 2000L, leaseMs = 5000L)
+        // suspend 내에서 실제 Redis 작업 수행 후 취소 도달
+        delay(100)  // 임계 구역 내에서 취소 트리거 기회를 줌
+    }
+    
+    delay(50)  // deduct 진입 후 취소
+    job.cancel()
+    job.join()
+    
+    // NonCancellable 덕분에 unlock이 Redis에 디스패치됨 → 락 해제 확인
+    fLock.isLocked shouldBeEqualTo false
 }
 ```
 
@@ -486,6 +622,37 @@ redis/distributed-lock/
 
 ## 11. 리뷰 이터레이션 로그 (Appendix)
 
-| 라운드 | Reviewer | P0/P1 | P2/P3 | 반영 커밋 |
+### Round 1 (Step 2-R) — 2026-05-23
+
+**Reviewers:** Security (Phase 1), Ops/SRE (Phase 1), UX/Caller (Phase 1), Developer (Phase 1), Opus Critic (Phase 2), Claude Code Advisor
+
+| Reviewer | P0 | P1 | P2 | P3 |
 |---|---|---|---|---|
-| Round 1 spec | (작성 중) | - | - | - |
+| Security | 0 | 1 | 1 | 1 |
+| Ops/SRE | 0 | 7 | 1 | 0 |
+| UX/Caller | 0 | 3 | 3 | 0 |
+| Developer | 1 | 3 | 1 | 0 |
+| Opus Critic (synthesized) | 1 | 9 | 9 | 3 |
+
+**P0 findings:**
+1. `SuspendingFencedInventoryService.finally` — `withContext(NonCancellable)` 누락 → 코루틴 취소 시 락 리크
+
+**P1 findings (10개):**
+1. `tryLockAsync` + `tokenAsync` 2단계 → `tryLockAndGetTokenAsync` 원자적 메서드로 교체
+2. `FencedResource.apply()` equal-token 정책 미정의 → 동일 토큰 허용(재진입) 문서화
+3. `DeductionResult` 서브타입 `serialVersionUID` 누락 → per-class 추가
+4. `qty.requirePositiveNumber("qty")` 누락 → 모든 deduct() 변형에 추가
+5. `getLockId` 수명주기 계약 미문서 → §6.4에 계약 명시
+6. Redis 불가용 동작 미정의 → Risk 6 추가
+7. `DeductionResult` 실패 타입 진단 컨텍스트 없음 → `data class`로 변환 + 필드 추가
+8. `FencedResource` JVM 재시작 시 상태 리셋 미문서 → §6.3에 명시
+9. 학습 경로 없음 → §0 추가
+10. P0 취소 안전성 검증 테스트 없음 → §7.3-코루틴 추가
+
+**반영:** 이 커밋 (Round 1 spec revision)
+
+**Round 1 후 카운트:**
+- P0: 1 → **0**
+- P1: 10 → **0**
+- P2: 9 (implementation 시점 처리)
+- P3: 3 (N/A or implementation-time)

--- a/redis/distributed-lock/README.ko.md
+++ b/redis/distributed-lock/README.ko.md
@@ -1,0 +1,224 @@
+# redis-distributed-lock
+
+Redisson을 사용한 분산 락 전략을 단계별로 시연합니다.
+비안전 공유 상태(oversell 발생)부터 스레드-안전 락, 펜싱 토큰 기반 락, 코루틴 네이티브 구현까지 다룹니다.
+
+---
+
+## 아키텍처
+
+```mermaid
+graph TD
+    subgraph 도메인
+        Inv[Inventory]
+        Store[InventoryStore]
+        DR[DeductionResult<br/>sealed interface]
+    end
+
+    subgraph 펜싱 가드
+        FR[FencedResource<br/>CAS 토큰 게이트]
+        FRS[FencedResources<br/>레지스트리]
+    end
+
+    subgraph 서비스
+        Unsafe[UnsafeInventoryService<br/>락 없음 — race 데모]
+        Locked[LockedInventoryService<br/>RLock / 블로킹]
+        Fenced[FencedInventoryService<br/>RFencedLock / 블로킹]
+        Suspend[SuspendingFencedInventoryService<br/>RFencedLock / 코루틴]
+    end
+
+    subgraph 테스트
+        BRT[BaselineRaceTest<br/>락 없이 oversell 발생 확인]
+        DLT[DistributedLockTest<br/>RLock이 oversell 방지]
+        FLT[FencedLockTest<br/>펜싱 가드가 stale holder 차단]
+        SFT[SuspendFencedLockTest<br/>코루틴 취소 안전성]
+        FSH[FencedStaleHolderTest smoke<br/>리스 만료 재락 시나리오]
+        LFT[LockFailureTest smoke<br/>tryLock 타임아웃 동작]
+    end
+
+    Store --> Unsafe
+    Store --> Locked
+    Store --> Fenced
+    Store --> Suspend
+    FRS  --> Fenced
+    FRS  --> Suspend
+    FR   --> FRS
+
+    Unsafe  --> BRT
+    Locked  --> DLT
+    Fenced  --> FLT
+    Suspend --> SFT
+    Fenced  --> FSH
+    Locked  --> LFT
+```
+
+---
+
+## 핵심 기능
+
+| 기능 | 클래스 | 핵심 API |
+|---|---|---|
+| 비안전 (race 데모) | `UnsafeInventoryService` | 락 없음; oversell 시연 |
+| 분산 락 | `LockedInventoryService` | `RLock.tryLock(wait, lease, unit)` |
+| 펜싱 락 (블로킹) | `FencedInventoryService` | `RFencedLock.tryLockAndGetToken(wait, lease, unit)` |
+| 펜싱 락 (코루틴) | `SuspendingFencedInventoryService` | `tryLockAsync` + `tokenAsync` + `NonCancellable` unlock |
+| 토큰 가드 | `FencedResource` | CAS `lastSeenToken`; stale holder 쓰기 거부 |
+
+---
+
+## 모듈 구조
+
+```
+redis/distributed-lock/
+├── src/main/kotlin/io/bluetape4k/workshop/lock/
+│   ├── DistributedLockApp.kt          # Spring Boot 진입점
+│   ├── domain/
+│   │   ├── DeductionResult.kt         # sealed interface: Success / InsufficientStock / LockTimeout / Error
+│   │   ├── Inventory.kt               # data class: id, name, stock
+│   │   └── InventoryStore.kt          # 인메모리 동시성 저장소
+│   ├── fenced/
+│   │   ├── FencedResource.kt          # 단일 리소스 CAS 토큰 게이트
+│   │   └── FencedResources.kt         # ConcurrentHashMap 레지스트리
+│   └── service/
+│       ├── UnsafeInventoryService.kt
+│       ├── LockedInventoryService.kt
+│       ├── FencedInventoryService.kt
+│       └── SuspendingFencedInventoryService.kt
+└── src/test/kotlin/io/bluetape4k/workshop/lock/
+    ├── AbstractDistributedLockTest.kt  # 공통 픽스처 (Testcontainers Redis)
+    ├── BaselineRaceTest.kt             # 락 없이 oversell 발생 증명
+    ├── DistributedLockTest.kt          # RLock이 oversell 방지
+    ├── FencedLockTest.kt               # 펜싱 가드; stale holder 거부
+    ├── SuspendFencedLockTest.kt        # 코루틴 안전성 + 취소 안전성
+    ├── FencedStaleHolderTest.kt        # [smoke] 리스 만료 재락 시나리오
+    └── LockFailureTest.kt              # [smoke] tryLock 타임아웃 동작
+```
+
+---
+
+## 사용 예시
+
+### 1. 비안전 — race condition 증명
+
+```kotlin
+// stock=100, qty=10, 동시 20개 코루틴
+// → oversell 발생: successCount > 10
+val result = unsafeService.deduct(inventoryId, 10)
+```
+
+### 2. 분산 락 (블로킹)
+
+```kotlin
+val result = lockedService.deduct(inventoryId, qty = 10, waitMs = 3000L, leaseMs = 3000L)
+when (result) {
+    is DeductionResult.Success           -> println("차감 완료 token=${result.token}")
+    is DeductionResult.InsufficientStock -> println("재고 부족")
+    is DeductionResult.LockTimeout       -> println("락 타임아웃")
+    is DeductionResult.Error             -> println("에러: ${result.message}")
+}
+```
+
+### 3. 펜싱 락 — stale holder 방지
+
+`FencedResource` CAS 게이트는 현재 `lastSeenToken`보다 오래된 토큰의 쓰기를 거부합니다.
+느리게 재개된 이전 홀더가 새 홀더가 작성한 데이터를 덮어쓰는 것을 방지합니다.
+
+```kotlin
+// FencedInventoryService 내부 동작:
+val token: Long = fLock.tryLockAndGetToken(waitMs, leaseMs, MILLISECONDS)
+val result: DeductionResult? = resource.apply(token) {
+    store.deduct(inventoryId, qty)
+}
+// null → stale holder가 거부됨
+```
+
+### 4. 코루틴 네이티브 펜싱 락
+
+```kotlin
+// 코루틴 안전: NonCancellable unlock이 Job.cancel() 후에도 락 해제 보장
+val result = suspendingService.deduct(inventoryId, qty = 10, waitMs = 3000L, leaseMs = 3000L)
+```
+
+#### 취소 안전성
+
+`SuspendingFencedInventoryService`는 `finally` 블록에서 `withContext(NonCancellable)`을 사용해
+코루틴이 취소되는 중에도 `unlockAsync(lockId).await()`가 반드시 완료되도록 보장합니다.
+
+```kotlin
+// 내부 패턴 요약
+val acquired = fLock.tryLockAsync(waitMs, leaseMs, MILLISECONDS, lockId).await()
+if (!acquired) return LockTimeout
+val token = fLock.tokenAsync.await()
+try {
+    /* 작업 수행 */
+} finally {
+    withContext(NonCancellable) {
+        fLock.unlockAsync(lockId).await()
+    }
+}
+```
+
+---
+
+## 테스트 실행
+
+```bash
+# 기본 (smoke 제외)
+./gradlew :redis-distributed-lock:test
+
+# 강제 재실행
+./gradlew :redis-distributed-lock:test --rerun-tasks
+
+# smoke 포함 (리스 만료 타이밍 테스트)
+./gradlew :redis-distributed-lock:test -Djunit.jupiter.execution.exclude.tags=
+
+# 특정 테스트 클래스
+./gradlew :redis-distributed-lock:test --tests "io.bluetape4k.workshop.lock.SuspendFencedLockTest"
+```
+
+> **Smoke 테스트** (`@Tag("smoke")`)는 리스 만료 및 타임아웃 시나리오를 실제 벽시계 딜레이로 검증합니다.
+> 기본 CI에서는 flakiness 방지를 위해 제외됩니다.
+
+---
+
+## 핵심 개념
+
+### 펜싱 토큰 프로토콜
+
+펜싱 토큰은 락 서버가 성공적인 락 획득마다 발행하는 단조 증가 번호입니다.
+리소스 업데이트는 반드시 토큰을 지참해야 하며, 리소스 가드(CAS `lastSeenToken`)는
+오래된 토큰의 쓰기를 거부합니다.
+
+이것은 "락 획득 후 GC 정지/네트워크 지연으로 리스가 만료된 후 쓰기 시도" 시나리오를 방지합니다:
+
+```
+클라이언트 A가 락 획득 → token=1
+클라이언트 A가 정지 (GC, 네트워크, 리스 만료)
+클라이언트 B가 락 획득 → token=2, token=2로 쓰기
+클라이언트 A가 재개 → FencedResource가 쓰기 거부 (1 < 2) ✅
+```
+
+### SuspendedJobTester 의미론
+
+`SuspendedJobTester.workers(N).rounds(R)`는 `N`개의 워커가 각각 `R`라운드의 `add { }` 블록을 실행합니다.
+`totalUnits = R × blockCount`.
+
+stock=100/qty=10 테스트의 경우:
+- `workers(20).rounds(20)` → 총 20번 시도 → 정확히 10번 성공
+
+### Smoke vs 기본 테스트
+
+| 태그 | 목적 | 타이밍 포함? | 기본 CI |
+|---|---|---|---|
+| _(없음)_ | 빠른 정확성 검증 | 아니오 (로직만) | ✅ 포함 |
+| `smoke` | 리스 만료, 타임아웃 | 예 (실제 벽시계) | ❌ 제외 |
+
+---
+
+## 의존성
+
+- **Redisson** — `RLock`, `RFencedLock`, 비동기 API
+- **bluetape4k-redisson** — `getLockId()` (Snowflake ID), `redissonClient {}` DSL
+- **bluetape4k-coroutines** — `awaitSuspending()`, `io.bluetape4k.logging.coroutines`
+- **bluetape4k-testcontainers** — `RedisServer.Launcher.redis` Testcontainers 싱글턴
+- **kotlinx.atomicfu** — `atomic(0L)` for `FencedResource.lastSeenToken`

--- a/redis/distributed-lock/README.md
+++ b/redis/distributed-lock/README.md
@@ -1,0 +1,227 @@
+# redis-distributed-lock
+
+Demonstrates distributed locking strategies using Redisson, from unsafe shared mutable state through
+thread-safe locks to fenced (token-based) locks and their coroutine-native counterpart.
+
+---
+
+## Architecture
+
+```mermaid
+graph TD
+    subgraph Domain
+        Inv[Inventory]
+        Store[InventoryStore]
+        DR[DeductionResult<br/>sealed interface]
+    end
+
+    subgraph Fenced Guard
+        FR[FencedResource<br/>CAS token gate]
+        FRS[FencedResources<br/>registry]
+    end
+
+    subgraph Services
+        Unsafe[UnsafeInventoryService<br/>no lock — race demo]
+        Locked[LockedInventoryService<br/>RLock / blocking]
+        Fenced[FencedInventoryService<br/>RFencedLock / blocking]
+        Suspend[SuspendingFencedInventoryService<br/>RFencedLock / coroutine]
+    end
+
+    subgraph Tests
+        BRT[BaselineRaceTest<br/>confirms oversell without lock]
+        DLT[DistributedLockTest<br/>RLock prevents oversell]
+        FLT[FencedLockTest<br/>fenced guard prevents stale holder]
+        SFT[SuspendFencedLockTest<br/>coroutine cancel-safety]
+        FSH[FencedStaleHolderTest smoke<br/>lease expiry re-lock scenario]
+        LFT[LockFailureTest smoke<br/>tryLock timeout behaviour]
+    end
+
+    Store --> Unsafe
+    Store --> Locked
+    Store --> Fenced
+    Store --> Suspend
+    FRS  --> Fenced
+    FRS  --> Suspend
+    FR   --> FRS
+
+    Unsafe  --> BRT
+    Locked  --> DLT
+    Fenced  --> FLT
+    Suspend --> SFT
+    Fenced  --> FSH
+    Locked  --> LFT
+```
+
+---
+
+## Core Features
+
+| Feature | Class | Key API |
+|---|---|---|
+| Unsafe (race demo) | `UnsafeInventoryService` | No lock; shows oversell |
+| Distributed lock | `LockedInventoryService` | `RLock.tryLock(wait, lease, unit)` |
+| Fenced lock (blocking) | `FencedInventoryService` | `RFencedLock.tryLockAndGetToken(wait, lease, unit)` |
+| Fenced lock (coroutine) | `SuspendingFencedInventoryService` | `tryLockAsync` + `tokenAsync` + `NonCancellable` unlock |
+| Token guard | `FencedResource` | CAS `lastSeenToken`; rejects stale-holder writes |
+
+---
+
+## Module Structure
+
+```
+redis/distributed-lock/
+├── src/main/kotlin/io/bluetape4k/workshop/lock/
+│   ├── DistributedLockApp.kt          # Spring Boot entry point
+│   ├── domain/
+│   │   ├── DeductionResult.kt         # sealed interface: Success / InsufficientStock / LockTimeout / Error
+│   │   ├── Inventory.kt               # data class: id, name, stock
+│   │   └── InventoryStore.kt          # in-memory concurrent store
+│   ├── fenced/
+│   │   ├── FencedResource.kt          # CAS token gate for one resource
+│   │   └── FencedResources.kt         # ConcurrentHashMap registry
+│   └── service/
+│       ├── UnsafeInventoryService.kt
+│       ├── LockedInventoryService.kt
+│       ├── FencedInventoryService.kt
+│       └── SuspendingFencedInventoryService.kt
+└── src/test/kotlin/io/bluetape4k/workshop/lock/
+    ├── AbstractDistributedLockTest.kt  # shared fixtures (Testcontainers Redis)
+    ├── BaselineRaceTest.kt             # proves oversell without lock
+    ├── DistributedLockTest.kt          # RLock prevents oversell
+    ├── FencedLockTest.kt               # fenced guard; stale-holder rejection
+    ├── SuspendFencedLockTest.kt        # coroutine safety + cancel-safety
+    ├── FencedStaleHolderTest.kt        # [smoke] lease expiry re-lock scenario
+    └── LockFailureTest.kt              # [smoke] tryLock timeout behaviour
+```
+
+---
+
+## Usage Examples
+
+### 1. Unsafe — proves race condition
+
+```kotlin
+// Stock = 100, qty = 10, 20 concurrent goroutines
+// → oversell: successCount > 10
+val result = unsafeService.deduct(inventoryId, 10)
+```
+
+### 2. Distributed Lock (blocking)
+
+```kotlin
+// RLock ensures exactly one deduction at a time
+val result = lockedService.deduct(inventoryId, qty = 10, waitMs = 3000L, leaseMs = 3000L)
+when (result) {
+    is DeductionResult.Success          -> println("deducted token=${result.token}")
+    is DeductionResult.InsufficientStock -> println("out of stock")
+    is DeductionResult.LockTimeout      -> println("lock timed out")
+    is DeductionResult.Error            -> println("error: ${result.message}")
+}
+```
+
+### 3. Fenced Lock — guards against stale holders
+
+The `FencedResource` CAS gate rejects any write whose fencing token is older than
+the current `lastSeenToken`, preventing a slow/restarted lock-holder from
+overwriting data written by a newer holder.
+
+```kotlin
+// FencedInventoryService internally:
+val token: Long = fLock.tryLockAndGetToken(waitMs, leaseMs, MILLISECONDS)
+val result: DeductionResult? = resource.apply(token) {
+    store.deduct(inventoryId, qty)
+}
+// null result → stale holder rejected
+```
+
+### 4. Coroutine-Native Fenced Lock
+
+```kotlin
+// Coroutine-safe: NonCancellable unlock prevents lock leak on Job.cancel()
+val result = suspendingService.deduct(inventoryId, qty = 10, waitMs = 3000L, leaseMs = 3000L)
+```
+
+#### Cancellation Safety
+
+The `SuspendingFencedInventoryService` uses a `withContext(NonCancellable)` block in its
+`finally` clause so that `unlockAsync(lockId).await()` always completes even when the
+calling coroutine is cancelled mid-flight.
+
+```kotlin
+// Simplified internal pattern
+val acquired = fLock.tryLockAsync(waitMs, leaseMs, MILLISECONDS, lockId).await()
+if (!acquired) return LockTimeout
+val token = fLock.tokenAsync.await()
+try {
+    /* work */
+} finally {
+    withContext(NonCancellable) {
+        fLock.unlockAsync(lockId).await()
+    }
+}
+```
+
+---
+
+## Running Tests
+
+```bash
+# All non-smoke tests (default)
+./gradlew :redis-distributed-lock:test
+
+# Force fresh run
+./gradlew :redis-distributed-lock:test --rerun-tasks
+
+# Include smoke tests (timing-sensitive: lease expiry scenarios)
+./gradlew :redis-distributed-lock:test -Djunit.jupiter.execution.exclude.tags=
+
+# Specific test class
+./gradlew :redis-distributed-lock:test --tests "io.bluetape4k.workshop.lock.SuspendFencedLockTest"
+```
+
+> **Smoke tests** (`@Tag("smoke")`) test lease-expiry and timeout scenarios with real
+> wall-clock delays. They are excluded from the default CI run to avoid flakiness.
+
+---
+
+## Key Concepts
+
+### Fencing Token Protocol
+
+A fencing token is a monotonically increasing number issued by the lock server on
+each successful lock acquisition. Any resource update must carry the token; the resource
+guard (CAS on `lastSeenToken`) rejects writes from older tokens.
+
+This prevents the classic "process paused after lock acquired but before write" race:
+
+```
+Client A acquires lock → token=1
+Client A pauses (GC, network delay, lease expires)
+Client B acquires lock → token=2, writes with token=2
+Client A resumes → FencedResource rejects write (1 < 2) ✅
+```
+
+### SuspendedJobTester Semantics
+
+`SuspendedJobTester.workers(N).rounds(R)` launches `N` workers each running `R` rounds
+of the `add { }` block. `totalUnits = R × blockCount`.
+
+For a stock-100/qty-10 test:
+- `workers(20).rounds(20)` → 20 total attempts → exactly 10 succeed
+
+### Smoke vs Default Tests
+
+| Tag | Purpose | Includes timing? | Default CI |
+|---|---|---|---|
+| _(none)_ | Fast correctness checks | No (logic only) | ✅ included |
+| `smoke` | Lease expiry, timeout | Yes (real wall-clock) | ❌ excluded |
+
+---
+
+## Dependencies
+
+- **Redisson** — `RLock`, `RFencedLock`, async API
+- **bluetape4k-redisson** — `getLockId()` (Snowflake ID), `redissonClient {}` DSL
+- **bluetape4k-coroutines** — `awaitSuspending()`, `io.bluetape4k.logging.coroutines`
+- **bluetape4k-testcontainers** — `RedisServer.Launcher.redis` Testcontainers singleton
+- **kotlinx.atomicfu** — `atomic(0L)` for `FencedResource.lastSeenToken`

--- a/redis/distributed-lock/build.gradle.kts
+++ b/redis/distributed-lock/build.gradle.kts
@@ -1,0 +1,49 @@
+plugins {
+    alias(libs.plugins.kotlin.spring)
+    alias(libs.plugins.spring.boot)
+}
+
+springBoot {
+    mainClass.set("io.bluetape4k.workshop.lock.DistributedLockAppKt")
+}
+
+configurations {
+    testImplementation.get().extendsFrom(compileOnly.get(), runtimeOnly.get())
+}
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(21))
+    }
+}
+
+dependencies {
+    // Logging
+    implementation(libs.bluetape4k.logging)
+
+    // Redisson
+    implementation(libs.bluetape4k.redis)
+    implementation(libs.bluetape4k.redisson)
+    implementation(libs.redisson.lib)
+    implementation(libs.redisson.spring.boot.starter)
+
+    // Coroutines
+    implementation(libs.bluetape4k.coroutines)
+    implementation(libs.kotlinx.coroutines.core.lib)
+
+    // Spring Boot
+    implementation(libs.spring.boot.autoconfigure.lib)
+    implementation(libs.spring.boot.starter.actuator)
+
+    // Tests
+    testImplementation(project(":shared"))
+    testImplementation(libs.bluetape4k.junit5)
+    testImplementation(libs.bluetape4k.testcontainers)
+    testImplementation(libs.bluetape4k.assertions)
+    testImplementation(libs.kotlinx.coroutines.test.lib)
+    testImplementation(libs.spring.boot.starter.test) {
+        exclude(group = "junit", module = "junit")
+        exclude(group = "org.junit.vintage", module = "junit-vintage-engine")
+        exclude(module = "mockito-core")
+    }
+}

--- a/redis/distributed-lock/build.gradle.kts
+++ b/redis/distributed-lock/build.gradle.kts
@@ -17,13 +17,22 @@ java {
     }
 }
 
+// Smoke tests are timing-sensitive (lease expiry) — exclude from default CI run.
+// To include: ./gradlew :redis-distributed-lock:test -Djunit.jupiter.execution.exclude.tags=
+tasks.named<Test>("test") {
+    useJUnitPlatform {
+        excludeTags("smoke")
+    }
+}
+
 dependencies {
     // Logging
     implementation(libs.bluetape4k.logging)
 
-    // Redisson
+    // Redisson (bluetape4k-redisson uses bluetape4k-idgenerators for getLockId; add explicitly)
     implementation(libs.bluetape4k.redis)
     implementation(libs.bluetape4k.redisson)
+    implementation(libs.bluetape4k.idgenerators)
     implementation(libs.redisson.lib)
     implementation(libs.redisson.spring.boot.starter)
 

--- a/redis/distributed-lock/src/main/kotlin/io/bluetape4k/workshop/lock/DistributedLockApp.kt
+++ b/redis/distributed-lock/src/main/kotlin/io/bluetape4k/workshop/lock/DistributedLockApp.kt
@@ -1,0 +1,27 @@
+package io.bluetape4k.workshop.lock
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
+
+/**
+ * Distributed Lock Workshop application.
+ *
+ * Demonstrates four concurrency control strategies using Redis/Redisson:
+ *
+ * 1. **Unsafe** — no synchronization; race condition demo
+ * 2. **Locked** — mutual exclusion via [org.redisson.api.RLock]
+ * 3. **Fenced** — fencing token guard via [org.redisson.api.RFencedLock] (blocking)
+ * 4. **Suspending Fenced** — coroutine-safe fenced lock with `NonCancellable` unlock
+ *
+ * ## Running
+ * ```
+ * ./gradlew :redis-distributed-lock:bootRun
+ * ./gradlew :redis-distributed-lock:test
+ * ```
+ */
+@SpringBootApplication
+class DistributedLockApp
+
+fun main(args: Array<String>) {
+    runApplication<DistributedLockApp>(*args)
+}

--- a/redis/distributed-lock/src/main/kotlin/io/bluetape4k/workshop/lock/domain/DeductionResult.kt
+++ b/redis/distributed-lock/src/main/kotlin/io/bluetape4k/workshop/lock/domain/DeductionResult.kt
@@ -1,0 +1,50 @@
+package io.bluetape4k.workshop.lock.domain
+
+import java.io.Serializable
+
+/**
+ * Sealed result hierarchy for an inventory deduction operation.
+ *
+ * ## Variants
+ * - [Success] — deduction succeeded; [remaining] is the stock after deduction.
+ *   [token] is set only when a fencing token was used (fenced lock paths).
+ * - [InsufficientStock] — not enough stock; [requested] > [available] at check time.
+ * - [Rejected] — a fencing guard rejected the write because the [token] was stale.
+ * - [LockNotAcquired] — the distributed lock could not be acquired within the wait timeout.
+ */
+sealed interface DeductionResult {
+
+    data class Success(
+        val remaining: Int,
+        val token: Long? = null,
+    ) : DeductionResult, Serializable {
+        companion object {
+            private const val serialVersionUID = 1L
+        }
+    }
+
+    data class InsufficientStock(
+        val requested: Int,
+        val available: Int,
+    ) : DeductionResult, Serializable {
+        companion object {
+            private const val serialVersionUID = 1L
+        }
+    }
+
+    data class Rejected(
+        val token: Long,
+    ) : DeductionResult, Serializable {
+        companion object {
+            private const val serialVersionUID = 1L
+        }
+    }
+
+    data class LockNotAcquired(
+        val lockName: String,
+    ) : DeductionResult, Serializable {
+        companion object {
+            private const val serialVersionUID = 1L
+        }
+    }
+}

--- a/redis/distributed-lock/src/main/kotlin/io/bluetape4k/workshop/lock/domain/Inventory.kt
+++ b/redis/distributed-lock/src/main/kotlin/io/bluetape4k/workshop/lock/domain/Inventory.kt
@@ -1,0 +1,31 @@
+package io.bluetape4k.workshop.lock.domain
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.support.requireNotBlank
+import io.bluetape4k.support.requirePositiveNumber
+import io.bluetape4k.support.requireZeroOrPositiveNumber
+import java.io.Serializable
+
+/**
+ * Represents an inventory item managed by the distributed lock workshop.
+ *
+ * ## Behavior / Contract
+ * - [id] must be positive; [name] must be non-blank; [initialStock] must be >= 0.
+ * - Equality and hashing are based on [id], [name], and [initialStock].
+ */
+data class Inventory(
+    val id: Long,
+    val name: String,
+    val initialStock: Int,
+) : Serializable {
+
+    init {
+        id.requirePositiveNumber("id")
+        name.requireNotBlank("name")
+        initialStock.requireZeroOrPositiveNumber("initialStock")
+    }
+
+    companion object : KLogging() {
+        private const val serialVersionUID = 1L
+    }
+}

--- a/redis/distributed-lock/src/main/kotlin/io/bluetape4k/workshop/lock/domain/InventoryStore.kt
+++ b/redis/distributed-lock/src/main/kotlin/io/bluetape4k/workshop/lock/domain/InventoryStore.kt
@@ -1,0 +1,40 @@
+package io.bluetape4k.workshop.lock.domain
+
+import io.bluetape4k.logging.KLogging
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * In-memory inventory store backed by a [ConcurrentHashMap].
+ *
+ * ## Behavior / Contract
+ * - [register] overwrites any existing stock for the given inventory id.
+ * - [applyChange] uses `addAndGet` (atomic), enabling intentional race demos in [UnsafeInventoryService].
+ * - [resetAll] clears all registered inventories; used in `@BeforeEach` for test isolation.
+ * - Accessing an unregistered id throws [IllegalArgumentException].
+ */
+class InventoryStore {
+
+    companion object : KLogging()
+
+    private val store = ConcurrentHashMap<Long, AtomicInteger>()
+
+    fun register(inventory: Inventory) {
+        store[inventory.id] = AtomicInteger(inventory.initialStock)
+    }
+
+    fun currentStock(id: Long): Int =
+        (store[id] ?: throw IllegalArgumentException("Inventory $id not registered")).get()
+
+    fun applyChange(id: Long, delta: Int): Int =
+        (store[id] ?: throw IllegalArgumentException("Inventory $id not registered")).addAndGet(delta)
+
+    fun reset(id: Long, value: Int) {
+        store[id]?.set(value) ?: throw IllegalArgumentException("Inventory $id not registered")
+    }
+
+    /** Clears all registered inventories. Used for `@BeforeEach` test isolation. */
+    fun resetAll() {
+        store.clear()
+    }
+}

--- a/redis/distributed-lock/src/main/kotlin/io/bluetape4k/workshop/lock/fenced/FencedResource.kt
+++ b/redis/distributed-lock/src/main/kotlin/io/bluetape4k/workshop/lock/fenced/FencedResource.kt
@@ -1,0 +1,46 @@
+package io.bluetape4k.workshop.lock.fenced
+
+import io.bluetape4k.logging.KLogging
+import kotlinx.atomicfu.atomic
+
+/**
+ * CAS-based fencing token guard for a single resource.
+ *
+ * ## Behavior / Contract
+ * - Tracks the highest fencing token ever seen via a CAS loop.
+ * - `apply(token, work)` returns `null` when `token < lastSeenToken` (stale holder).
+ * - Equal tokens (`token == lastSeenToken`) are **allowed** — modelling re-entry within
+ *   the same lease period (assumes [work] is idempotent).
+ * - This guard is **in-memory only**: state resets on JVM restart (workshop limitation).
+ *
+ * ## Usage
+ * ```kotlin
+ * val resource = FencedResource(inventoryId)
+ * val result = resource.apply(token) {
+ *     store.applyChange(id, -qty)
+ * }
+ * if (result == null) return Rejected(token)
+ * ```
+ */
+class FencedResource(val resourceId: Long) {
+
+    companion object : KLogging()
+
+    private val lastSeenToken = atomic(0L)
+
+    /**
+     * Applies [work] only if [token] is not stale (not strictly less than the last seen token).
+     *
+     * @return the result of [work], or `null` if [token] is stale.
+     */
+    fun <T : Any> apply(token: Long, work: () -> T): T? {
+        while (true) {
+            val current = lastSeenToken.value
+            if (token < current) return null  // stale: strict less-than check
+            if (lastSeenToken.compareAndSet(current, maxOf(current, token))) {
+                return work()
+            }
+            // CAS lost to a concurrent update; retry
+        }
+    }
+}

--- a/redis/distributed-lock/src/main/kotlin/io/bluetape4k/workshop/lock/fenced/FencedResources.kt
+++ b/redis/distributed-lock/src/main/kotlin/io/bluetape4k/workshop/lock/fenced/FencedResources.kt
@@ -1,0 +1,31 @@
+package io.bluetape4k.workshop.lock.fenced
+
+import io.bluetape4k.logging.KLogging
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Registry of [FencedResource] instances keyed by resource id.
+ *
+ * ## Behavior / Contract
+ * - [forResource] is idempotent — the same [FencedResource] is always returned for a given id.
+ * - [resetAll] removes all entries; used in `@BeforeEach` for test isolation.
+ * - This registry is **in-memory only** (workshop limitation):
+ *   the fencing token history is lost on JVM restart, and the map is unbounded.
+ */
+class FencedResources {
+
+    companion object : KLogging()
+
+    private val map = ConcurrentHashMap<Long, FencedResource>()
+
+    fun forResource(id: Long): FencedResource = map.computeIfAbsent(id) { FencedResource(it) }
+
+    fun reset(id: Long) {
+        map.remove(id)
+    }
+
+    /** Clears all fencing token state. Used for `@BeforeEach` test isolation. */
+    fun resetAll() {
+        map.clear()
+    }
+}

--- a/redis/distributed-lock/src/main/kotlin/io/bluetape4k/workshop/lock/service/FencedInventoryService.kt
+++ b/redis/distributed-lock/src/main/kotlin/io/bluetape4k/workshop/lock/service/FencedInventoryService.kt
@@ -1,6 +1,7 @@
 package io.bluetape4k.workshop.lock.service
 
 import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.warn
 import io.bluetape4k.support.requirePositiveNumber
 import io.bluetape4k.workshop.lock.domain.DeductionResult
 import io.bluetape4k.workshop.lock.domain.DeductionResult.InsufficientStock

--- a/redis/distributed-lock/src/main/kotlin/io/bluetape4k/workshop/lock/service/FencedInventoryService.kt
+++ b/redis/distributed-lock/src/main/kotlin/io/bluetape4k/workshop/lock/service/FencedInventoryService.kt
@@ -1,0 +1,58 @@
+package io.bluetape4k.workshop.lock.service
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.support.requirePositiveNumber
+import io.bluetape4k.workshop.lock.domain.DeductionResult
+import io.bluetape4k.workshop.lock.domain.DeductionResult.InsufficientStock
+import io.bluetape4k.workshop.lock.domain.DeductionResult.LockNotAcquired
+import io.bluetape4k.workshop.lock.domain.DeductionResult.Rejected
+import io.bluetape4k.workshop.lock.domain.DeductionResult.Success
+import io.bluetape4k.workshop.lock.domain.InventoryStore
+import io.bluetape4k.workshop.lock.fenced.FencedResources
+import org.redisson.api.RedissonClient
+import java.util.concurrent.TimeUnit.MILLISECONDS
+
+/**
+ * Inventory service that uses [org.redisson.api.RFencedLock] for fencing-token-based protection.
+ *
+ * ## Behavior / Contract
+ * - Uses the blocking `tryLockAndGetToken(waitMs, leaseMs, unit)` — safe to call from blocking threads.
+ * - Delegates guarded writes to [FencedResources]: if the token is stale, returns [Rejected].
+ * - The `finally` block wraps `unlock()` in `runCatching` to absorb `IllegalMonitorStateException`
+ *   when the lease has already expired.
+ */
+class FencedInventoryService(
+    private val redisson: RedissonClient,
+    private val store: InventoryStore,
+    private val fencedResources: FencedResources,
+) {
+
+    companion object : KLogging()
+
+    fun deduct(
+        id: Long,
+        qty: Int,
+        waitMs: Long = 2000L,
+        leaseMs: Long = 5000L,
+    ): DeductionResult {
+        qty.requirePositiveNumber("qty")
+        val lockName = "inventory:fenced:$id"
+        val fLock = redisson.getFencedLock(lockName)
+        val token: Long? = fLock.tryLockAndGetToken(waitMs, leaseMs, MILLISECONDS)
+        if (token == null) {
+            log.warn { "Failed to acquire fenced lock: $lockName" }
+            return LockNotAcquired(lockName)
+        }
+        try {
+            val current = store.currentStock(id)
+            if (current < qty) return InsufficientStock(qty, current)
+            return fencedResources.forResource(id).apply(token) {
+                val remaining = store.applyChange(id, -qty)
+                Success(remaining, token)
+            } ?: Rejected(token)
+        } finally {
+            runCatching { fLock.unlock() }
+                .onFailure { log.warn(it) { "Fenced unlock failed (lease may have expired): $lockName" } }
+        }
+    }
+}

--- a/redis/distributed-lock/src/main/kotlin/io/bluetape4k/workshop/lock/service/LockedInventoryService.kt
+++ b/redis/distributed-lock/src/main/kotlin/io/bluetape4k/workshop/lock/service/LockedInventoryService.kt
@@ -1,6 +1,7 @@
 package io.bluetape4k.workshop.lock.service
 
 import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.warn
 import io.bluetape4k.support.requirePositiveNumber
 import io.bluetape4k.workshop.lock.domain.DeductionResult
 import io.bluetape4k.workshop.lock.domain.DeductionResult.InsufficientStock

--- a/redis/distributed-lock/src/main/kotlin/io/bluetape4k/workshop/lock/service/LockedInventoryService.kt
+++ b/redis/distributed-lock/src/main/kotlin/io/bluetape4k/workshop/lock/service/LockedInventoryService.kt
@@ -1,0 +1,55 @@
+package io.bluetape4k.workshop.lock.service
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.support.requirePositiveNumber
+import io.bluetape4k.workshop.lock.domain.DeductionResult
+import io.bluetape4k.workshop.lock.domain.DeductionResult.InsufficientStock
+import io.bluetape4k.workshop.lock.domain.DeductionResult.LockNotAcquired
+import io.bluetape4k.workshop.lock.domain.DeductionResult.Success
+import io.bluetape4k.workshop.lock.domain.InventoryStore
+import org.redisson.api.RedissonClient
+import java.util.concurrent.TimeUnit.MILLISECONDS
+
+/**
+ * Inventory service that uses [org.redisson.api.RLock] for mutual exclusion.
+ *
+ * ## Behavior / Contract
+ * - Uses 3-argument `tryLock(waitMs, leaseMs, unit)` to disable the watchdog.
+ *   Without an explicit lease, Redisson's watchdog extends the lock indefinitely,
+ *   risking a never-expiring lock if the holder crashes.
+ * - Returns [LockNotAcquired] when the lock cannot be acquired within [waitMs].
+ * - The `finally` block releases the lock only if it is still held by the current thread.
+ */
+class LockedInventoryService(
+    private val redisson: RedissonClient,
+    private val store: InventoryStore,
+) {
+
+    companion object : KLogging()
+
+    fun deduct(
+        id: Long,
+        qty: Int,
+        waitMs: Long = 2000L,
+        leaseMs: Long = 5000L,
+    ): DeductionResult {
+        qty.requirePositiveNumber("qty")
+        val lockName = "inventory:lock:$id"
+        val lock = redisson.getLock(lockName)
+        val acquired = lock.tryLock(waitMs, leaseMs, MILLISECONDS)
+        if (!acquired) {
+            log.warn { "Failed to acquire lock: $lockName" }
+            return LockNotAcquired(lockName)
+        }
+        try {
+            val current = store.currentStock(id)
+            if (current < qty) return InsufficientStock(qty, current)
+            val remaining = store.applyChange(id, -qty)
+            return Success(remaining)
+        } finally {
+            if (lock.isHeldByCurrentThread) {
+                lock.unlock()
+            }
+        }
+    }
+}

--- a/redis/distributed-lock/src/main/kotlin/io/bluetape4k/workshop/lock/service/SuspendingFencedInventoryService.kt
+++ b/redis/distributed-lock/src/main/kotlin/io/bluetape4k/workshop/lock/service/SuspendingFencedInventoryService.kt
@@ -1,6 +1,7 @@
 package io.bluetape4k.workshop.lock.service
 
 import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.logging.warn
 import io.bluetape4k.redis.redisson.coroutines.getLockId
 import io.bluetape4k.support.requirePositiveNumber
 import io.bluetape4k.workshop.lock.domain.DeductionResult

--- a/redis/distributed-lock/src/main/kotlin/io/bluetape4k/workshop/lock/service/SuspendingFencedInventoryService.kt
+++ b/redis/distributed-lock/src/main/kotlin/io/bluetape4k/workshop/lock/service/SuspendingFencedInventoryService.kt
@@ -1,0 +1,80 @@
+package io.bluetape4k.workshop.lock.service
+
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.redis.redisson.coroutines.getLockId
+import io.bluetape4k.support.requirePositiveNumber
+import io.bluetape4k.workshop.lock.domain.DeductionResult
+import io.bluetape4k.workshop.lock.domain.DeductionResult.InsufficientStock
+import io.bluetape4k.workshop.lock.domain.DeductionResult.LockNotAcquired
+import io.bluetape4k.workshop.lock.domain.DeductionResult.Rejected
+import io.bluetape4k.workshop.lock.domain.DeductionResult.Success
+import io.bluetape4k.workshop.lock.domain.InventoryStore
+import io.bluetape4k.workshop.lock.fenced.FencedResources
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.future.await
+import kotlinx.coroutines.withContext
+import org.redisson.api.RedissonClient
+import java.util.concurrent.TimeUnit.MILLISECONDS
+
+/**
+ * Coroutine-safe inventory service using [org.redisson.api.RFencedLock] with explicit lock identity.
+ *
+ * ## Behavior / Contract
+ * - Uses [RedissonClient.getLockId] to obtain a stable, coroutine-safe lock identity
+ *   (Snowflake ID). This identity must be passed to both `tryLockAsync` and `unlockAsync`.
+ * - Two-step acquire: `tryLockAsync(lockId)` then `tokenAsync.await()`.
+ *   There is no `tryLockAndGetTokenAsync(lockId)` overload in Redisson 4.x.
+ * - The `finally` block runs `unlockAsync(lockId)` inside `withContext(NonCancellable)`.
+ *   Without this guard, coroutine cancellation causes the await to throw [kotlinx.coroutines.CancellationException]
+ *   before the unlock completes, leaking the lock until lease expiry.
+ * - [beforeWork] is a **test seam** — defaults to a no-op. Inject `suspend { delay(ms) }`
+ *   in tests to create a reliable cancellation window inside the lock-held section.
+ */
+class SuspendingFencedInventoryService(
+    private val redisson: RedissonClient,
+    private val store: InventoryStore,
+    private val fencedResources: FencedResources,
+    private val beforeWork: suspend () -> Unit = {},
+) {
+
+    companion object : KLoggingChannel()
+
+    suspend fun deduct(
+        id: Long,
+        qty: Int,
+        waitMs: Long = 2000L,
+        leaseMs: Long = 5000L,
+    ): DeductionResult {
+        qty.requirePositiveNumber("qty")
+        val lockName = "inventory:sfenced:$id"
+        val lockId = redisson.getLockId(lockName)
+        val fLock = redisson.getFencedLock(lockName)
+
+        val acquired = fLock.tryLockAsync(waitMs, leaseMs, MILLISECONDS, lockId).await()
+        if (!acquired) {
+            log.warn { "Failed to acquire suspending fenced lock: $lockName (lockId=$lockId)" }
+            return LockNotAcquired(lockName)
+        }
+
+        val token: Long = fLock.tokenAsync.await()
+        try {
+            beforeWork()  // test seam: default no-op; inject delay for cancellation tests
+            val current = store.currentStock(id)
+            if (current < qty) return InsufficientStock(qty, current)
+            return fencedResources.forResource(id).apply(token) {
+                val remaining = store.applyChange(id, -qty)
+                Success(remaining, token)
+            } ?: Rejected(token)
+        } finally {
+            // CRITICAL: NonCancellable prevents CancellationException from aborting the unlock.
+            // Without this, a cancelled coroutine leaks the lock until lease expiry.
+            withContext(NonCancellable) {
+                try {
+                    fLock.unlockAsync(lockId).await()
+                } catch (e: Exception) {
+                    log.warn(e) { "Suspending fenced unlock failed: $lockName (lockId=$lockId)" }
+                }
+            }
+        }
+    }
+}

--- a/redis/distributed-lock/src/main/kotlin/io/bluetape4k/workshop/lock/service/UnsafeInventoryService.kt
+++ b/redis/distributed-lock/src/main/kotlin/io/bluetape4k/workshop/lock/service/UnsafeInventoryService.kt
@@ -1,0 +1,31 @@
+package io.bluetape4k.workshop.lock.service
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.support.requirePositiveNumber
+import io.bluetape4k.workshop.lock.domain.DeductionResult
+import io.bluetape4k.workshop.lock.domain.DeductionResult.InsufficientStock
+import io.bluetape4k.workshop.lock.domain.DeductionResult.Success
+import io.bluetape4k.workshop.lock.domain.InventoryStore
+
+/**
+ * Intentionally unsafe inventory service — demonstrates a classic read-modify-write race.
+ *
+ * ## Behavior / Contract
+ * - Reads stock, sleeps for 1 ms to widen the race window, then writes — **without any lock**.
+ * - Multiple concurrent threads will observe over-sell (negative stock or success count > expected).
+ *
+ * **DO NOT use in production.**
+ */
+class UnsafeInventoryService(private val store: InventoryStore) {
+
+    companion object : KLogging()
+
+    fun deduct(id: Long, qty: Int): DeductionResult {
+        qty.requirePositiveNumber("qty")
+        val current = store.currentStock(id)
+        if (current < qty) return InsufficientStock(qty, current)
+        Thread.sleep(1)  // intentional race window
+        val remaining = store.applyChange(id, -qty)
+        return Success(remaining)
+    }
+}

--- a/redis/distributed-lock/src/main/resources/application.yaml
+++ b/redis/distributed-lock/src/main/resources/application.yaml
@@ -1,0 +1,13 @@
+spring:
+  application:
+    name: distributed-lock-workshop
+  main:
+    web-application-type: none
+  redisson:
+    config: classpath:redisson.yaml
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health

--- a/redis/distributed-lock/src/main/resources/redisson.yaml
+++ b/redis/distributed-lock/src/main/resources/redisson.yaml
@@ -1,0 +1,16 @@
+singleServerConfig:
+  idleConnectionTimeout: 10000
+  connectTimeout: 1000
+  timeout: 3000
+  retryAttempts: 3
+  retryInterval: 1500
+  password: null
+  subscriptionsPerConnection: 5
+  address: "redis://${REDIS_HOST:127.0.0.1}:${REDIS_PORT:6379}"
+  subscriptionConnectionMinimumIdleSize: 1
+  subscriptionConnectionPoolSize: 25
+  connectionMinimumIdleSize: 5
+  connectionPoolSize: 64
+  database: 0
+threads: 0
+useLinuxNativeEpoll: false

--- a/redis/distributed-lock/src/test/kotlin/io/bluetape4k/workshop/lock/AbstractDistributedLockTest.kt
+++ b/redis/distributed-lock/src/test/kotlin/io/bluetape4k/workshop/lock/AbstractDistributedLockTest.kt
@@ -1,0 +1,59 @@
+package io.bluetape4k.workshop.lock
+
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.testcontainers.storage.RedisServer
+import io.bluetape4k.workshop.lock.domain.InventoryStore
+import io.bluetape4k.workshop.lock.fenced.FencedResources
+import io.bluetape4k.workshop.lock.service.FencedInventoryService
+import io.bluetape4k.workshop.lock.service.LockedInventoryService
+import io.bluetape4k.workshop.lock.service.SuspendingFencedInventoryService
+import io.bluetape4k.workshop.lock.service.UnsafeInventoryService
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.TestInstance
+import org.redisson.Redisson
+import org.redisson.api.RedissonClient
+import org.redisson.config.Config
+import java.util.UUID
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+abstract class AbstractDistributedLockTest {
+
+    companion object : KLoggingChannel() {
+        val redis = RedisServer.Launcher.redis
+        val redisUrl: String get() = redis.url
+    }
+
+    protected val redisson: RedissonClient by lazy {
+        Redisson.create(
+            Config().apply {
+                useSingleServer().setAddress(redisUrl)
+            }
+        )
+    }
+
+    protected val store = InventoryStore()
+    protected val fencedResources = FencedResources()
+
+    protected val unsafeService: UnsafeInventoryService by lazy { UnsafeInventoryService(store) }
+    protected val lockedService: LockedInventoryService by lazy { LockedInventoryService(redisson, store) }
+    protected val fencedService: FencedInventoryService by lazy {
+        FencedInventoryService(redisson, store, fencedResources)
+    }
+    protected val suspendingService: SuspendingFencedInventoryService by lazy {
+        SuspendingFencedInventoryService(redisson, store, fencedResources)
+    }
+
+    @BeforeEach
+    fun resetState() {
+        store.resetAll()
+        fencedResources.resetAll()
+    }
+
+    @AfterAll
+    fun shutdown() {
+        runCatching { redisson.shutdown() }
+    }
+
+    protected fun randomName(prefix: String = "test") = "$prefix-${UUID.randomUUID()}"
+}

--- a/redis/distributed-lock/src/test/kotlin/io/bluetape4k/workshop/lock/AbstractDistributedLockTest.kt
+++ b/redis/distributed-lock/src/test/kotlin/io/bluetape4k/workshop/lock/AbstractDistributedLockTest.kt
@@ -8,12 +8,11 @@ import io.bluetape4k.workshop.lock.service.FencedInventoryService
 import io.bluetape4k.workshop.lock.service.LockedInventoryService
 import io.bluetape4k.workshop.lock.service.SuspendingFencedInventoryService
 import io.bluetape4k.workshop.lock.service.UnsafeInventoryService
+import io.bluetape4k.redis.redisson.redissonClient
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.TestInstance
-import org.redisson.Redisson
 import org.redisson.api.RedissonClient
-import org.redisson.config.Config
 import java.util.UUID
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -25,11 +24,9 @@ abstract class AbstractDistributedLockTest {
     }
 
     protected val redisson: RedissonClient by lazy {
-        Redisson.create(
-            Config().apply {
-                useSingleServer().setAddress(redisUrl)
-            }
-        )
+        redissonClient {
+            useSingleServer().setAddress(redisUrl)
+        }
     }
 
     protected val store = InventoryStore()

--- a/redis/distributed-lock/src/test/kotlin/io/bluetape4k/workshop/lock/BaselineRaceTest.kt
+++ b/redis/distributed-lock/src/test/kotlin/io/bluetape4k/workshop/lock/BaselineRaceTest.kt
@@ -1,0 +1,45 @@
+package io.bluetape4k.workshop.lock
+
+import io.bluetape4k.junit5.concurrency.MultithreadingTester
+import io.bluetape4k.workshop.lock.domain.DeductionResult.Success
+import io.bluetape4k.workshop.lock.domain.Inventory
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.RepeatedTest
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Demonstrates that [io.bluetape4k.workshop.lock.service.UnsafeInventoryService]
+ * produces a race condition (over-sell) under concurrent load.
+ *
+ * The test is `@RepeatedTest(3)` to improve reproducibility of the non-deterministic race.
+ */
+class BaselineRaceTest : AbstractDistributedLockTest() {
+
+    private val inventoryId = 1L
+
+    @BeforeEach
+    fun setupInventory() {
+        store.register(Inventory(inventoryId, "사과", 100))
+    }
+
+    @RepeatedTest(3)
+    fun `UnsafeInventoryService - 동시 차감 시 oversell 이 발생한다`() {
+        val successCount = AtomicInteger(0)
+
+        MultithreadingTester()
+            .workers(20)
+            .rounds(1)
+            .add {
+                val result = unsafeService.deduct(inventoryId, 10)
+                if (result is Success) successCount.incrementAndGet()
+            }
+            .run()
+
+        val currentStock = store.currentStock(inventoryId)
+        // Race condition: either more than 10 successes OR stock went negative
+        val raceObserved = successCount.get() > 10 || currentStock < 0
+        assert(raceObserved) {
+            "Expected race condition (oversell) but got: successCount=${successCount.get()}, currentStock=$currentStock"
+        }
+    }
+}

--- a/redis/distributed-lock/src/test/kotlin/io/bluetape4k/workshop/lock/BaselineRaceTest.kt
+++ b/redis/distributed-lock/src/test/kotlin/io/bluetape4k/workshop/lock/BaselineRaceTest.kt
@@ -1,5 +1,6 @@
 package io.bluetape4k.workshop.lock
 
+import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.junit5.concurrency.MultithreadingTester
 import io.bluetape4k.workshop.lock.domain.DeductionResult.Success
 import io.bluetape4k.workshop.lock.domain.Inventory
@@ -37,9 +38,9 @@ class BaselineRaceTest : AbstractDistributedLockTest() {
 
         val currentStock = store.currentStock(inventoryId)
         // Race condition: either more than 10 successes OR stock went negative
+        // Race must be observed: either more than 10 successes OR stock went negative.
+        // shouldBeTrue() from bluetape4k-assertions always throws (never gated on -ea).
         val raceObserved = successCount.get() > 10 || currentStock < 0
-        assert(raceObserved) {
-            "Expected race condition (oversell) but got: successCount=${successCount.get()}, currentStock=$currentStock"
-        }
+        raceObserved.shouldBeTrue()
     }
 }

--- a/redis/distributed-lock/src/test/kotlin/io/bluetape4k/workshop/lock/DistributedLockTest.kt
+++ b/redis/distributed-lock/src/test/kotlin/io/bluetape4k/workshop/lock/DistributedLockTest.kt
@@ -1,0 +1,59 @@
+package io.bluetape4k.workshop.lock
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeInstanceOf
+import io.bluetape4k.assertions.shouldBeLessThan
+import io.bluetape4k.junit5.concurrency.MultithreadingTester
+import io.bluetape4k.workshop.lock.domain.DeductionResult.InsufficientStock
+import io.bluetape4k.workshop.lock.domain.DeductionResult.Success
+import io.bluetape4k.workshop.lock.domain.Inventory
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.RepeatedTest
+import org.junit.jupiter.api.Test
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.assertFailsWith
+
+/**
+ * Verifies that [io.bluetape4k.workshop.lock.service.LockedInventoryService]
+ * prevents over-sell under concurrent load using [org.redisson.api.RLock].
+ */
+class DistributedLockTest : AbstractDistributedLockTest() {
+
+    private val inventoryId = 1L
+
+    @BeforeEach
+    fun setupInventory() {
+        store.register(Inventory(inventoryId, "사과", 100))
+    }
+
+    @RepeatedTest(3)
+    fun `LockedInventoryService - 동시 차감 시 oversell 이 발생하지 않는다`() {
+        val successCount = AtomicInteger(0)
+
+        MultithreadingTester()
+            .workers(20)
+            .rounds(1)
+            .add {
+                val result = lockedService.deduct(inventoryId, 10, waitMs = 3000L, leaseMs = 5000L)
+                if (result is Success) successCount.incrementAndGet()
+            }
+            .run()
+
+        successCount.get() shouldBeEqualTo 10
+        store.currentStock(inventoryId) shouldBeEqualTo 0
+    }
+
+    @Test
+    fun `qty 가 0 이하이면 IllegalArgumentException 을 던진다`() {
+        assertFailsWith<IllegalArgumentException> { lockedService.deduct(inventoryId, 0) }
+        assertFailsWith<IllegalArgumentException> { lockedService.deduct(inventoryId, -1) }
+    }
+
+    @Test
+    fun `재고 부족 시 InsufficientStock 을 반환한다`() {
+        val result = lockedService.deduct(inventoryId, 200)
+        result shouldBeInstanceOf InsufficientStock::class
+        (result as InsufficientStock).requested shouldBeEqualTo 200
+        (result as InsufficientStock).available shouldBeLessThan 200
+    }
+}

--- a/redis/distributed-lock/src/test/kotlin/io/bluetape4k/workshop/lock/DistributedLockTest.kt
+++ b/redis/distributed-lock/src/test/kotlin/io/bluetape4k/workshop/lock/DistributedLockTest.kt
@@ -5,11 +5,13 @@ import io.bluetape4k.assertions.shouldBeInstanceOf
 import io.bluetape4k.assertions.shouldBeLessThan
 import io.bluetape4k.junit5.concurrency.MultithreadingTester
 import io.bluetape4k.workshop.lock.domain.DeductionResult.InsufficientStock
+import io.bluetape4k.workshop.lock.domain.DeductionResult.LockNotAcquired
 import io.bluetape4k.workshop.lock.domain.DeductionResult.Success
 import io.bluetape4k.workshop.lock.domain.Inventory
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.RepeatedTest
 import org.junit.jupiter.api.Test
+import java.util.concurrent.TimeUnit.MILLISECONDS
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.assertFailsWith
 
@@ -53,7 +55,36 @@ class DistributedLockTest : AbstractDistributedLockTest() {
     fun `재고 부족 시 InsufficientStock 을 반환한다`() {
         val result = lockedService.deduct(inventoryId, 200)
         result shouldBeInstanceOf InsufficientStock::class
-        (result as InsufficientStock).requested shouldBeEqualTo 200
-        (result as InsufficientStock).available shouldBeLessThan 200
+        val insufficient = result as InsufficientStock
+        insufficient.requested shouldBeEqualTo 200
+        insufficient.available shouldBeLessThan 200
+    }
+
+    @Test
+    fun `락 획득 실패 시 LockNotAcquired 반환`() {
+        // RLock is reentrant — must hold from a DIFFERENT thread to block main-thread acquisition.
+        val lockName = "inventory:lock:$inventoryId"
+        val holderLock = redisson.getLock(lockName)
+        val acquireLatch = java.util.concurrent.CountDownLatch(1)
+        val releaseLatch = java.util.concurrent.CountDownLatch(1)
+
+        val holder = Thread {
+            val held = holderLock.tryLock(1000, 10_000, MILLISECONDS)
+            acquireLatch.countDown()
+            if (held) {
+                releaseLatch.await()
+                runCatching { if (holderLock.isHeldByCurrentThread) holderLock.unlock() }
+            }
+        }
+        holder.start()
+        acquireLatch.await()  // wait until holder thread has the lock
+
+        try {
+            val result = lockedService.deduct(inventoryId, 10, waitMs = 0L, leaseMs = 1000L)
+            result shouldBeInstanceOf LockNotAcquired::class
+        } finally {
+            releaseLatch.countDown()
+            holder.join(2000)
+        }
     }
 }

--- a/redis/distributed-lock/src/test/kotlin/io/bluetape4k/workshop/lock/FencedLockTest.kt
+++ b/redis/distributed-lock/src/test/kotlin/io/bluetape4k/workshop/lock/FencedLockTest.kt
@@ -1,0 +1,72 @@
+package io.bluetape4k.workshop.lock
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeGreaterThan
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.junit5.concurrency.MultithreadingTester
+import io.bluetape4k.workshop.lock.domain.DeductionResult.Success
+import io.bluetape4k.workshop.lock.domain.Inventory
+import io.bluetape4k.workshop.lock.fenced.FencedResource
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.util.concurrent.TimeUnit.MILLISECONDS
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Verifies [FencedResource] and [io.bluetape4k.workshop.lock.service.FencedInventoryService] behaviour.
+ */
+class FencedLockTest : AbstractDistributedLockTest() {
+
+    private val inventoryId = 1L
+
+    @BeforeEach
+    fun setupInventory() {
+        store.register(Inventory(inventoryId, "사과", 100))
+    }
+
+    @Test
+    fun `RFencedLock 토큰은 단조 증가한다`() {
+        val lockName = randomName("fenced")
+        val fLock = redisson.getFencedLock(lockName)
+        val tokens = mutableListOf<Long>()
+
+        repeat(5) {
+            val token = fLock.tryLockAndGetToken(1000, 5000, MILLISECONDS)
+            token.shouldNotBeNull()
+            tokens.add(token)
+            fLock.unlock()
+        }
+
+        tokens.zipWithNext().forEach { (a, b) ->
+            b shouldBeGreaterThan a
+        }
+    }
+
+    @Test
+    fun `FencedResource - 구 토큰으로 apply 시도 시 null 반환, 동일 토큰 재진입 허용`() {
+        val resource = FencedResource(99L)
+
+        resource.apply(5L) { "ok" }.shouldNotBeNull()
+        resource.apply(3L) { "should reject" }.shouldBeNull()     // stale: 3 < 5
+        resource.apply(5L) { "same ok" }.shouldNotBeNull()        // equal token allowed (re-entry)
+        resource.apply(4L) { "also reject" }.shouldBeNull()       // stale: 4 < 5
+    }
+
+    @Test
+    fun `FencedInventoryService - 동시 차감 시 oversell 이 발생하지 않는다`() {
+        val successCount = AtomicInteger(0)
+
+        MultithreadingTester()
+            .workers(20)
+            .rounds(1)
+            .add {
+                val result = fencedService.deduct(inventoryId, 10, waitMs = 3000L, leaseMs = 5000L)
+                if (result is Success) successCount.incrementAndGet()
+            }
+            .run()
+
+        successCount.get() shouldBeEqualTo 10
+        store.currentStock(inventoryId) shouldBeEqualTo 0
+    }
+}

--- a/redis/distributed-lock/src/test/kotlin/io/bluetape4k/workshop/lock/FencedLockTest.kt
+++ b/redis/distributed-lock/src/test/kotlin/io/bluetape4k/workshop/lock/FencedLockTest.kt
@@ -2,9 +2,12 @@ package io.bluetape4k.workshop.lock
 
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeGreaterThan
+import io.bluetape4k.assertions.shouldBeInstanceOf
 import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.assertions.shouldNotBeNull
 import io.bluetape4k.junit5.concurrency.MultithreadingTester
+import io.bluetape4k.workshop.lock.domain.DeductionResult.LockNotAcquired
+import io.bluetape4k.workshop.lock.domain.DeductionResult.Rejected
 import io.bluetape4k.workshop.lock.domain.DeductionResult.Success
 import io.bluetape4k.workshop.lock.domain.Inventory
 import io.bluetape4k.workshop.lock.fenced.FencedResource
@@ -68,5 +71,44 @@ class FencedLockTest : AbstractDistributedLockTest() {
 
         successCount.get() shouldBeEqualTo 10
         store.currentStock(inventoryId) shouldBeEqualTo 0
+    }
+
+    @Test
+    fun `FencedInventoryService - 구 토큰으로 차감 시도 시 Rejected 반환`() {
+        // Pre-seed the shared FencedResource with a very high token.
+        // Any new Redisson lock token (starting from 1) will be strictly less than 9999 → Rejected.
+        fencedResources.forResource(inventoryId).apply(9999L) { Unit }
+
+        val result = fencedService.deduct(inventoryId, 10, waitMs = 2000L, leaseMs = 5000L)
+
+        result shouldBeInstanceOf Rejected::class
+    }
+
+    @Test
+    fun `FencedInventoryService - 락 획득 실패 시 LockNotAcquired 반환`() {
+        // RFencedLock is reentrant — must hold from a DIFFERENT thread to block main-thread acquisition.
+        val lockName = "inventory:fenced:$inventoryId"
+        val holderLock = redisson.getFencedLock(lockName)
+        val acquireLatch = java.util.concurrent.CountDownLatch(1)
+        val releaseLatch = java.util.concurrent.CountDownLatch(1)
+
+        val holder = Thread {
+            val token = holderLock.tryLockAndGetToken(1000, 10_000, MILLISECONDS)
+            acquireLatch.countDown()
+            if (token != null) {
+                releaseLatch.await()
+                runCatching { holderLock.unlock() }
+            }
+        }
+        holder.start()
+        acquireLatch.await()  // wait until holder thread has the fenced lock
+
+        try {
+            val result = fencedService.deduct(inventoryId, 10, waitMs = 0L, leaseMs = 1000L)
+            result shouldBeInstanceOf LockNotAcquired::class
+        } finally {
+            releaseLatch.countDown()
+            holder.join(2000)
+        }
     }
 }

--- a/redis/distributed-lock/src/test/kotlin/io/bluetape4k/workshop/lock/FencedStaleHolderTest.kt
+++ b/redis/distributed-lock/src/test/kotlin/io/bluetape4k/workshop/lock/FencedStaleHolderTest.kt
@@ -1,0 +1,56 @@
+package io.bluetape4k.workshop.lock
+
+import io.bluetape4k.assertions.shouldBeGreaterThan
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.workshop.lock.fenced.FencedResource
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import java.util.concurrent.TimeUnit.MILLISECONDS
+import kotlin.test.assertFailsWith
+
+/**
+ * Smoke test — full stale-holder scenario demonstrating fencing token protection.
+ *
+ * **Excluded from default CI** via `junit.jupiter.execution.exclude.tags=smoke`
+ * (timing-sensitive: relies on 200ms lease expiry + 500ms sleep).
+ *
+ * Run with: `./gradlew :redis-distributed-lock:test -Djunit.jupiter.execution.exclude.tags=`
+ */
+@Tag("smoke")
+class FencedStaleHolderTest : AbstractDistributedLockTest() {
+
+    @Test
+    fun `stale holder A 의 write 는 fencing token 으로 거부된다`() {
+        val lockName = randomName("stale")
+        val fLock1 = redisson.getFencedLock(lockName)
+        val fLock2 = redisson.getFencedLock(lockName)
+        val resource = FencedResource(42L)
+
+        // Step 1: A acquires with a short lease
+        val token1 = fLock1.tryLockAndGetToken(1000, 200, MILLISECONDS)
+        token1.shouldNotBeNull()
+
+        // Step 2: Wait for A's lease to expire
+        Thread.sleep(500)
+
+        // Step 3: B acquires — gets a higher token
+        val token2 = fLock2.tryLockAndGetToken(1000, 5000, MILLISECONDS)
+        token2.shouldNotBeNull()
+        token2 shouldBeGreaterThan token1
+
+        // Step 4: B's write succeeds
+        resource.apply(token2) { "B wins" }.shouldNotBeNull()
+
+        // Step 5: A's write is rejected (token1 < token2)
+        resource.apply(token1) { "A is stale" }.shouldBeNull()
+
+        // Step 6: A cannot unlock (lease expired)
+        assertFailsWith<IllegalMonitorStateException> {
+            fLock1.unlock()
+        }
+
+        // Step 7: B unlocks normally
+        fLock2.unlock()
+    }
+}

--- a/redis/distributed-lock/src/test/kotlin/io/bluetape4k/workshop/lock/LockFailureTest.kt
+++ b/redis/distributed-lock/src/test/kotlin/io/bluetape4k/workshop/lock/LockFailureTest.kt
@@ -1,0 +1,34 @@
+package io.bluetape4k.workshop.lock
+
+import io.bluetape4k.assertions.shouldBeTrue
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import java.util.concurrent.TimeUnit.MILLISECONDS
+import kotlin.test.assertFailsWith
+
+/**
+ * Smoke tests for lock failure scenarios.
+ *
+ * **Excluded from default CI** via `junit.jupiter.execution.exclude.tags=smoke`
+ * because they rely on real-time lease expiry (timing-sensitive).
+ *
+ * Run with: `./gradlew :redis-distributed-lock:test -Djunit.jupiter.execution.exclude.tags=`
+ */
+@Tag("smoke")
+class LockFailureTest : AbstractDistributedLockTest() {
+
+    @Test
+    fun `lease 만료 후 unlock 시도 시 IllegalMonitorStateException 이 발생한다`() {
+        val lockName = randomName("failure")
+        val lock = redisson.getLock(lockName)
+
+        val acquired = lock.tryLock(1000, 200, MILLISECONDS)
+        acquired.shouldBeTrue()
+
+        Thread.sleep(500)  // wait for lease to expire (200ms lease)
+
+        assertFailsWith<IllegalMonitorStateException> {
+            lock.unlock()
+        }
+    }
+}

--- a/redis/distributed-lock/src/test/kotlin/io/bluetape4k/workshop/lock/SuspendFencedLockTest.kt
+++ b/redis/distributed-lock/src/test/kotlin/io/bluetape4k/workshop/lock/SuspendFencedLockTest.kt
@@ -1,0 +1,69 @@
+package io.bluetape4k.workshop.lock
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.junit5.coroutines.SuspendedJobTester
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.workshop.lock.domain.DeductionResult.Success
+import io.bluetape4k.workshop.lock.domain.Inventory
+import io.bluetape4k.workshop.lock.service.SuspendingFencedInventoryService
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.RepeatedTest
+import org.junit.jupiter.api.Test
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Verifies [SuspendingFencedInventoryService] correctness and cancellation safety.
+ */
+class SuspendFencedLockTest : AbstractDistributedLockTest() {
+
+    private val inventoryId = 1L
+
+    @BeforeEach
+    fun setupInventory() {
+        store.register(Inventory(inventoryId, "사과", 100))
+    }
+
+    @RepeatedTest(3)
+    fun `SuspendingFencedInventoryService - 동시 코루틴 차감 시 oversell 이 발생하지 않는다`() = runSuspendIO {
+        val successCount = AtomicInteger(0)
+
+        SuspendedJobTester()
+            .workers(20)
+            .rounds(1)
+            .add {
+                val result = suspendingService.deduct(inventoryId, 10, waitMs = 3000L, leaseMs = 5000L)
+                if (result is Success) successCount.incrementAndGet()
+            }
+            .run()
+
+        successCount.get() shouldBeEqualTo 10
+        store.currentStock(inventoryId) shouldBeEqualTo 0
+    }
+
+    @Test
+    fun `코루틴 취소 시 락이 정상 해제됨 (NonCancellable unlock 검증)`() = runSuspendIO {
+        store.register(Inventory(999L, "취소테스트", 100))
+        val lockName = "inventory:sfenced:999"
+        val fLock = redisson.getFencedLock(lockName)
+
+        // beforeWork seam: delay(500) fires inside the lock-held section,
+        // ensuring delay(50) cancel lands DURING the lock-held window — not after deduct() returns.
+        val slowService = SuspendingFencedInventoryService(
+            redisson = redisson,
+            store = store,
+            fencedResources = fencedResources,
+            beforeWork = { delay(500) },
+        )
+
+        val job = launch { slowService.deduct(999L, 10) }
+        delay(50)        // fires during the 500ms beforeWork window — lock is held
+        job.cancel()
+        job.join()
+
+        // NonCancellable ensures unlock completes even after cancel
+        fLock.isLocked.shouldBeFalse()
+    }
+}

--- a/redis/distributed-lock/src/test/kotlin/io/bluetape4k/workshop/lock/SuspendFencedLockTest.kt
+++ b/redis/distributed-lock/src/test/kotlin/io/bluetape4k/workshop/lock/SuspendFencedLockTest.kt
@@ -2,8 +2,11 @@ package io.bluetape4k.workshop.lock
 
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeInstanceOf
 import io.bluetape4k.junit5.coroutines.SuspendedJobTester
 import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.workshop.lock.domain.DeductionResult.LockNotAcquired
+import io.bluetape4k.workshop.lock.domain.DeductionResult.Rejected
 import io.bluetape4k.workshop.lock.domain.DeductionResult.Success
 import io.bluetape4k.workshop.lock.domain.Inventory
 import io.bluetape4k.workshop.lock.service.SuspendingFencedInventoryService
@@ -12,6 +15,7 @@ import kotlinx.coroutines.launch
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.RepeatedTest
 import org.junit.jupiter.api.Test
+import java.util.concurrent.TimeUnit.MILLISECONDS
 import java.util.concurrent.atomic.AtomicInteger
 
 /**
@@ -30,11 +34,13 @@ class SuspendFencedLockTest : AbstractDistributedLockTest() {
     fun `SuspendingFencedInventoryService - 동시 코루틴 차감 시 oversell 이 발생하지 않는다`() = runSuspendIO {
         val successCount = AtomicInteger(0)
 
+        // workers(20).rounds(20): totalUnits = rounds * blockCount = 20 * 1 = 20 attempts
+        // With stock=100, qty=10 → exactly 10 succeed, 10 get InsufficientStock
         SuspendedJobTester()
             .workers(20)
-            .rounds(1)
+            .rounds(20)
             .add {
-                val result = suspendingService.deduct(inventoryId, 10, waitMs = 3000L, leaseMs = 5000L)
+                val result = suspendingService.deduct(inventoryId, 10, waitMs = 5000L, leaseMs = 5000L)
                 if (result is Success) successCount.incrementAndGet()
             }
             .run()
@@ -65,5 +71,44 @@ class SuspendFencedLockTest : AbstractDistributedLockTest() {
 
         // NonCancellable ensures unlock completes even after cancel
         fLock.isLocked.shouldBeFalse()
+    }
+
+    @Test
+    fun `SuspendingFencedInventoryService - 구 토큰으로 차감 시도 시 Rejected 반환`() = runSuspendIO {
+        // Pre-seed the shared FencedResource with a very high token.
+        // Any new Redisson lock token (starting from 1) will be strictly less than 9999 → Rejected.
+        fencedResources.forResource(inventoryId).apply(9999L) { Unit }
+
+        val result = suspendingService.deduct(inventoryId, 10, waitMs = 2000L, leaseMs = 5000L)
+
+        result shouldBeInstanceOf Rejected::class
+    }
+
+    @Test
+    fun `SuspendingFencedInventoryService - 락 획득 실패 시 LockNotAcquired 반환`() = runSuspendIO {
+        // RFencedLock is reentrant — must hold from a DIFFERENT thread to block coroutine acquisition.
+        val lockName = "inventory:sfenced:$inventoryId"
+        val holderLock = redisson.getFencedLock(lockName)
+        val acquireLatch = java.util.concurrent.CountDownLatch(1)
+        val releaseLatch = java.util.concurrent.CountDownLatch(1)
+
+        val holder = Thread {
+            val token = holderLock.tryLockAndGetToken(1000, 10_000, MILLISECONDS)
+            acquireLatch.countDown()
+            if (token != null) {
+                releaseLatch.await()
+                runCatching { holderLock.unlock() }
+            }
+        }
+        holder.start()
+        acquireLatch.await()  // wait until holder thread has the lock
+
+        try {
+            val result = suspendingService.deduct(inventoryId, 10, waitMs = 0L, leaseMs = 1000L)
+            result shouldBeInstanceOf LockNotAcquired::class
+        } finally {
+            releaseLatch.countDown()
+            holder.join(2000)
+        }
     }
 }

--- a/redis/distributed-lock/src/test/resources/application.yaml
+++ b/redis/distributed-lock/src/test/resources/application.yaml
@@ -1,0 +1,5 @@
+spring:
+  application:
+    name: distributed-lock-test
+  main:
+    web-application-type: none

--- a/redis/distributed-lock/src/test/resources/junit-platform.properties
+++ b/redis/distributed-lock/src/test/resources/junit-platform.properties
@@ -1,0 +1,6 @@
+junit.jupiter.extensions.autodetection.enabled=true
+junit.jupiter.testinstance.lifecycle.default=per_class
+junit.jupiter.execution.parallel.enabled=false
+junit.jupiter.execution.parallel.mode.default=same_thread
+junit.jupiter.execution.parallel.mode.classes.default=concurrent
+junit.jupiter.execution.exclude.tags=smoke

--- a/redis/distributed-lock/src/test/resources/logback-test.xml
+++ b/redis/distributed-lock/src/test/resources/logback-test.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+    <springProperty scope="context" name="APP_NAME" source="spring.application.name"/>
+
+    <property name="CONSOLE_LOG_PATTERN"
+              value="%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %highlight(${LOG_LEVEL_PATTERN:-%5p}) %magenta(${PID:- }) %clr(---){faint} %clr([%25.25t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}"/>
+
+    <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>DEBUG</level>
+        </filter>
+        <encoder>
+            <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+            <charset>utf8</charset>
+        </encoder>
+    </appender>
+
+    <logger name="io.bluetape4k.workshop.lock" level="DEBUG"/>
+
+    <root level="INFO">
+        <appender-ref ref="console"/>
+    </root>
+</configuration>


### PR DESCRIPTION
## Summary

Implements the distributed/fenced lock workshop module demonstrating four concurrency strategies for inventory deduction, from unsafe shared state through token-based fencing to coroutine-native lock management.

Closes #101

---

## Changes

### New module: `redis/distributed-lock`

| Component | File | Description |
|---|---|---|
| **Domain** | `DeductionResult.kt` | Sealed interface: `Success` / `InsufficientStock` / `Rejected` / `LockNotAcquired` |
| | `Inventory.kt` | `data class` with `Serializable` + validation |
| | `InventoryStore.kt` | In-memory concurrent store with `ConcurrentHashMap` |
| **Fenced Guard** | `FencedResource.kt` | CAS token gate via `atomic(0L)` (kotlinx.atomicfu) |
| | `FencedResources.kt` | Registry; `forResource(id)` provides stable per-resource guard |
| **Services** | `UnsafeInventoryService` | No lock — proves oversell (race baseline) |
| | `LockedInventoryService` | `RLock.tryLock(wait, lease, unit)` with watchdog disabled |
| | `FencedInventoryService` | `RFencedLock.tryLockAndGetToken()` + `FencedResource` CAS gate |
| | `SuspendingFencedInventoryService` | Coroutine-native; `tryLockAsync` + `tokenAsync` + `NonCancellable` unlock |
| **Tests** | `BaselineRaceTest` | Confirms oversell without lock |
| | `DistributedLockTest` | `RLock` prevents oversell; `LockNotAcquired` path tested |
| | `FencedLockTest` | `RFencedLock` + fencing guard; `Rejected` + `LockNotAcquired` paths tested |
| | `SuspendFencedLockTest` | Coroutine safety; cancellation + `Rejected` + `LockNotAcquired` paths |
| | `FencedStaleHolderTest` | `[smoke]` Full stale-holder scenario with real lease expiry |
| | `LockFailureTest` | `[smoke]` `IllegalMonitorStateException` on post-expiry unlock |
| **Docs** | `README.md` / `README.ko.md` | Architecture Mermaid, examples, key concepts |

---

## Key Design Decisions

### 1. Fencing Token Protocol

`FencedResource` uses a CAS loop on `lastSeenToken` (atomicfu `atomic(0L)`).
Strict less-than (`token < current`) rejects stale holders; equal-token allows re-entry within the same lease period.

### 2. Coroutine-Safe Unlock via `NonCancellable`

```kotlin
finally {
    withContext(NonCancellable) {
        fLock.unlockAsync(lockId).await()  // survives coroutine cancellation
    }
}
```

### 3. Two-Step Acquire (Redisson 4.x)

`tryLockAndGetTokenAsync(lockId)` overload does not exist in Redisson 4.x.
Correct pattern: `tryLockAsync(wait, lease, unit, lockId)` then `fLock.tokenAsync.await()`.

### 4. `getLockId()` for Coroutine-Safe Identity

`redisson.getLockId(lockName)` from `bluetape4k-redisson` uses Snowflake ID.
Requires explicit `implementation(libs.bluetape4k.idgenerators)` in `build.gradle.kts`.

### 5. Smoke Tests Excluded from Default CI

`@Tag("smoke")` tests use real wall-clock delays.
Excluded via `tasks.named<Test>() { useJUnitPlatform { excludeTags("smoke") } }`.

---

## Test Results

```
Command: ./gradlew :redis-distributed-lock:test --rerun-tasks

BaselineRaceTest:       3 tests, 0 failures  (RepeatedTest × 3)
DistributedLockTest:    6 tests, 0 failures
FencedLockTest:         5 tests, 0 failures
SuspendFencedLockTest:  6 tests, 0 failures
─────────────────────────────────────────────
Total:                 20 tests, 0 failures, 0 errors, 0 skipped
Build time: ~12s
```

---

## Code Review (Step 6-R)

| Severity | Initial | Final |
|---|---|---|
| P0 (CRITICAL) | 0 | **0** |
| P1 (HIGH) | 2 | **0** |
| P2 (MEDIUM) | 3 | **0** |

---

## Bluetape4k Features Used

| Feature | Module | Benefit |
|---|---|---|
| `getLockId(lockName)` | `bluetape4k-redisson` | Snowflake ID — coroutine-safe lock identity |
| `redissonClient { }` DSL | `bluetape4k-redisson` | Concise Redisson client builder |
| `KLogging()` / `KLoggingChannel()` | `bluetape4k-logging` | Lazy lambda logging |
| `requirePositiveNumber()` | `bluetape4k-core` | Declarative argument validation |
| `RedisServer.Launcher.redis` | `bluetape4k-testcontainers` | Singleton Testcontainers Redis |
| `SuspendedJobTester` | `bluetape4k-junit5` | Coroutine race-condition harness |
| `MultithreadingTester` | `bluetape4k-junit5` | Thread-safety test harness |
| `shouldBeEqualTo` / `shouldBeInstanceOf` | `bluetape4k-assertions` | Type-safe assertions |