### PR TITLE
fix: add PrometheusMetricsTest with correct Resilience4j 2.x metric names (#153)

### DIFF
--- a/docs/lessons/2026-05-24-resilience4j-2x-prometheus-timer-metric.md
+++ b/docs/lessons/2026-05-24-resilience4j-2x-prometheus-timer-metric.md
@@ -1,0 +1,60 @@
+# Resilience4j 2.x Prometheus Metric Name Change (Issue #153)
+
+**Date**: 2026-05-24  
+**Branch**: fix/issue-153-resilience4j-prometheus  
+**Module**: `spring-boot/resilience4j-coroutines`
+
+## Root Cause
+
+Resilience4j 2.x changed how `circuitbreaker.calls` is registered with Micrometer:
+
+| Metric | Resilience4j 1.x | Resilience4j 2.x |
+|--------|------------------|------------------|
+| `circuitbreaker.calls` | **Counter** → `_total` suffix | **Timer** → `_seconds_count` / `_seconds_sum` |
+| `circuitbreaker.not.permitted.calls` | Counter → `_total` | Counter → `_total` (unchanged) |
+| `circuitbreaker.state` | Gauge → no suffix | Gauge → no suffix (unchanged) |
+| `circuitbreaker.buffered.calls` | Gauge → no suffix | Gauge → no suffix (unchanged) |
+
+Test assertions were checking for the Resilience4j 1.x format
+(`resilience4j_circuitbreaker_calls_total`), which no longer exists in 2.x.
+
+## Fix
+
+Added `PrometheusMetricsTest` documenting the correct 2.x metric names:
+
+```kotlin
+// Resilience4j 2.x: calls → Timer
+body shouldContain "resilience4j_circuitbreaker_calls_seconds_count"
+body shouldContain "resilience4j_circuitbreaker_calls_seconds_sum"
+
+// Not-permitted stays Counter
+body shouldContain "resilience4j_circuitbreaker_not_permitted_calls_total"
+
+// State and buffered remain Gauges
+body shouldContain "resilience4j_circuitbreaker_state"
+body shouldContain "resilience4j_circuitbreaker_buffered_calls"
+```
+
+## Prometheus Metric Type Naming Rules
+
+| Micrometer Type | Prometheus suffix |
+|-----------------|-------------------|
+| Counter | `_total` |
+| Timer | `_seconds_count`, `_seconds_sum`, `_seconds_bucket` (histogram) |
+| Gauge | no suffix |
+| DistributionSummary | `_count`, `_sum`, `_bucket` |
+
+## Why Timer for `calls`?
+
+In Resilience4j 2.x, call duration tracking was merged into a single Timer metric
+(replacing separate Counter + Histogram). This gives latency percentiles per circuit
+breaker outcome without requiring a separate distribution summary.
+
+## Future Guidance
+
+When writing tests that assert on Prometheus metric names:
+- Use `_seconds_count` / `_seconds_sum` for anything that counts durations (Timers)
+- Use `_total` only for pure event counters (Counters)
+- Gauge metrics have no suffix
+- When upgrading Resilience4j 1.x → 2.x, search for `_total` assertions on `calls` metrics
+  and replace with `_seconds_count`

--- a/spring-boot/resilience4j-coroutines/src/test/kotlin/io/bluetape4k/workshop/resilience/actuator/PrometheusMetricsTest.kt
+++ b/spring-boot/resilience4j-coroutines/src/test/kotlin/io/bluetape4k/workshop/resilience/actuator/PrometheusMetricsTest.kt
@@ -1,0 +1,94 @@
+package io.bluetape4k.workshop.resilience.actuator
+
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.logging.debug
+import io.bluetape4k.workshop.resilience.AbstractResilienceTest
+import io.bluetape4k.assertions.shouldContain
+import io.bluetape4k.assertions.shouldNotBeNull
+import org.junit.jupiter.api.Test
+import org.springframework.test.web.reactive.server.expectBody
+
+/**
+ * Validates Prometheus metric names emitted by Resilience4j 2.x + Micrometer + Spring Boot 4.
+ *
+ * ## Key format change from Resilience4j 1.x → 2.x
+ *
+ * | Metric | Resilience4j 1.x (Counter) | Resilience4j 2.x (Timer) |
+ * |--------|---------------------------|--------------------------|
+ * | CB calls | `resilience4j_circuitbreaker_calls_total` | `resilience4j_circuitbreaker_calls_seconds_count` |
+ *
+ * In Resilience4j 2.x, `resilience4j.circuitbreaker.calls` is registered as a **Timer**,
+ * so the Prometheus scrape produces `_seconds_count`, `_seconds_sum`, and histogram bucket entries.
+ * The old `_total` suffix (Counter) no longer exists for this metric.
+ *
+ * `resilience4j.circuitbreaker.not.permitted.calls` remains a **Counter** → `_total` suffix.
+ *
+ * Resolves: Issue #153
+ */
+class PrometheusMetricsTest : AbstractResilienceTest() {
+
+    companion object : KLoggingChannel()
+
+    private fun fetchPrometheusBody(): String =
+        webClient.get()
+            .uri("/actuator/prometheus")
+            .exchange()
+            .expectStatus().is2xxSuccessful
+            .expectBody<String>()
+            .returnResult().responseBody
+            .shouldNotBeNull()
+
+    @Test
+    fun `Prometheus endpoint returns 200`() {
+        webClient.get()
+            .uri("/actuator/prometheus")
+            .exchange()
+            .expectStatus().is2xxSuccessful
+    }
+
+    @Test
+    fun `CircuitBreaker calls metric uses Timer format (seconds_count) not Counter (_total)`() {
+        // Trigger a few calls so that the timer is populated
+        repeat(3) {
+            webClient.get().uri("/$BACKEND_A/success").exchange()
+        }
+
+        val body = fetchPrometheusBody()
+        val cbLines = body.lines()
+            .filter { it.contains("resilience4j_circuitbreaker") }
+        log.debug { "resilience4j_circuitbreaker metrics:\n${cbLines.joinToString("\n")}" }
+
+        // Resilience4j 2.x: calls → Timer → _seconds_count suffix
+        body shouldContain "resilience4j_circuitbreaker_calls_seconds_count"
+        body shouldContain "resilience4j_circuitbreaker_calls_seconds_sum"
+    }
+
+    @Test
+    fun `CircuitBreaker state is exposed as a Gauge (no _total or _seconds suffix)`() {
+        val body = fetchPrometheusBody()
+
+        // Gauge emits no suffix
+        body shouldContain "resilience4j_circuitbreaker_state"
+    }
+
+    @Test
+    fun `CircuitBreaker buffered calls are exposed as Gauge`() {
+        val body = fetchPrometheusBody()
+        body shouldContain "resilience4j_circuitbreaker_buffered_calls"
+    }
+
+    @Test
+    fun `CircuitBreaker not-permitted calls retain Counter format (_total suffix)`() {
+        // Open the circuit breaker so subsequent calls are not permitted
+        transitionToOpenState(BACKEND_A)
+        repeat(3) {
+            webClient.get().uri("/$BACKEND_A/success").exchange()
+        }
+
+        val body = fetchPrometheusBody()
+        log.debug { "not_permitted metric lines:\n${body.lines().filter { it.contains("not_permitted") }.joinToString("\n")}" }
+
+        // not.permitted.calls is still a Counter → _total suffix
+        body shouldContain "resilience4j_circuitbreaker_not_permitted_calls_total"
+    }
+}


### PR DESCRIPTION
## Summary

Resolves #153 — Resilience4j 2.x changed `circuitbreaker.calls` from **Counter** to **Timer**.

## Problem

Tests asserted on Resilience4j 1.x Prometheus format (`_total`). In 2.x:
- `circuitbreaker.calls` → **Timer** → `_seconds_count` / `_seconds_sum`
- `circuitbreaker.not.permitted.calls` → Counter → `_total` (unchanged)

## Fix

Added `PrometheusMetricsTest` with correct assertions:

```kotlin
body shouldContain "resilience4j_circuitbreaker_calls_seconds_count"
body shouldContain "resilience4j_circuitbreaker_calls_seconds_sum"
body shouldContain "resilience4j_circuitbreaker_not_permitted_calls_total"
body shouldContain "resilience4j_circuitbreaker_state"
body shouldContain "resilience4j_circuitbreaker_buffered_calls"
```

## Test Results

```
Module: :spring-boot-resilience4j-coroutines
Result: 5 passing, 0 failed
Command: ./gradlew :spring-boot-resilience4j-coroutines:test --tests "*.actuator.PrometheusMetricsTest"
```