### PR TITLE
docs: rewrite root README with 6-domain catalog, add ko locale, diagrams, and coverage matrix

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -1,0 +1,233 @@
+# bluetape4k-workshop
+
+[![Kotlin](https://img.shields.io/badge/Kotlin-2.3-7F52FF?logo=kotlin)](https://kotlinlang.org)
+[![JVM](https://img.shields.io/badge/JVM-21-ED8B00?logo=openjdk)](https://openjdk.org)
+[![Spring Boot](https://img.shields.io/badge/Spring_Boot-4.0-6DB33F?logo=springboot)](https://spring.io/projects/spring-boot)
+[![bluetape4k](https://img.shields.io/badge/bluetape4k-1.7-4A90D9)](https://github.com/bluetape4k)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+
+> 🇺🇸 [English README](README.md)
+
+[bluetape4k](https://github.com/bluetape4k) 라이브러리를 Spring Boot 4, JetBrains Exposed,
+Redis, Kafka, Observability 스택, 가상 스레드, Vert.x, 클라우드 네이티브 패턴과 통합하는
+실행 가능한 백엔드 예제 모음입니다.
+
+![Workshop workbench](./docs/assets/workshop-workbench.png)
+
+---
+
+## 시작하기
+
+```bash
+# 전체 빌드
+./gradlew build
+
+# 단일 모듈 빌드 및 테스트
+./gradlew :exposed-mvc-jdbc:build
+./gradlew :exposed-mvc-jdbc:test
+
+# 정적 분석
+./gradlew detekt
+```
+
+**요구 사항**: JDK 21+, Docker (Testcontainers)
+
+---
+
+## 도메인 카탈로그
+
+모듈은 여섯 개의 학습 도메인으로 구성됩니다.
+각 도메인에는 **Basic** (독립적, 최소 인프라)과 **Advanced** (다계층, Testcontainers) 모듈이 있습니다.
+
+### 1. 데이터 접근
+
+> Exposed ORM, R2DBC, JPA/QueryDSL, MongoDB, Elasticsearch, Redis
+
+| 수준 | 모듈 | bluetape4k 라이브러리 | 인프라 | 학습 목표 |
+|------|------|----------------------|-------|-----------|
+| Basic | [`exposed-mvc-jdbc`](exposed/mvc-jdbc/) | `logging`, `junit5`, `testcontainers` | PostgreSQL (TC) | Spring MVC JDBC로 Exposed DAO/SQL DSL 사용 |
+| Basic | [`exposed-webflux-r2dbc`](exposed/webflux-r2dbc/) | `logging`, `coroutines`, `testcontainers` | PostgreSQL (TC) | Exposed R2DBC + WebFlux 코루틴 핸들러 |
+| Advanced | [`exposed-mvc-virtualthread`](exposed/mvc-virtualthread/) | `logging`, `coroutines`, `testcontainers` | PostgreSQL (TC) | 가상 스레드를 활용한 Exposed JDBC + Spring MVC |
+| Basic | [`spring-data-r2dbc-coroutines`](spring-data/r2dbc-coroutines/) | `coroutines`, `testcontainers` | PostgreSQL (TC) | 코루틴을 활용한 R2DBC 레포지토리 |
+| Basic | [`spring-data-r2dbc-examples`](spring-data/r2dbc-examples/) | `coroutines`, `testcontainers` | PostgreSQL (TC) | R2DBC 기본 예제와 DSL |
+| Advanced | [`spring-data-r2dbc-webflux`](spring-data/r2dbc-webflux/) | `coroutines`, `testcontainers` | PostgreSQL (TC) | R2DBC + WebFlux REST API |
+| Advanced | [`spring-data-r2dbc-webflux-exposed`](spring-data/r2dbc-webflux-exposed/) | `logging`, `coroutines`, `testcontainers` | PostgreSQL (TC) | R2DBC + WebFlux + Exposed 조합 |
+| Basic | [`spring-data-jpa-querydsl`](spring-data/jpa-querydsl/) | `logging`, `junit5`, `testcontainers` | PostgreSQL (TC) | JPA + QueryDSL 타입 안전 쿼리 |
+| Basic | [`spring-data-mongodb-coroutines`](spring-data/mongodb-coroutines/) | `coroutines`, `testcontainers` | MongoDB (TC) | 코루틴을 활용한 MongoDB 리액티브 레포지토리 |
+| Advanced | [`spring-data-mongodb-transactions`](spring-data/mongodb-transactions/) | `coroutines`, `testcontainers` | MongoDB (TC) | MongoDB 멀티 도큐먼트 트랜잭션 |
+| Basic | [`spring-data-elasticsearch`](spring-data/elasticsearch/) | `logging`, `testcontainers` | Elasticsearch (TC) | Spring Data Elasticsearch 블로킹 방식 |
+| Advanced | [`spring-data-elasticsearch-webflux`](spring-data/elasticsearch-webflux/) | `coroutines`, `testcontainers` | Elasticsearch (TC) | Elasticsearch + WebFlux 리액티브 |
+| Basic | [`spring-data-redis-examples`](spring-data/redis-examples/) | `redis`, `testcontainers` | Redis (TC) | Spring Data Redis와 RedisTemplate |
+
+```bash
+./gradlew :exposed-mvc-jdbc:test
+./gradlew :spring-data-r2dbc-coroutines:test
+```
+
+---
+
+### 2. Spring Boot 운영
+
+> 캐시, 복원력, WebFlux, WebSocket, CBOR, Protobuf, 카오스 엔지니어링
+
+| 수준 | 모듈 | bluetape4k 라이브러리 | 인프라 | 학습 목표 |
+|------|------|----------------------|-------|-----------|
+| Basic | [`spring-boot-cache-caffeine`](spring-boot/cache-caffeine/) | `logging`, `junit5` | In-memory | Spring Cache 추상화와 Caffeine 캐시 |
+| Basic | [`spring-boot-cache-redis`](spring-boot/cache-redis/) | `redis`, `testcontainers` | Redis (TC) | Redis 기반 Spring Cache + TTL 설정 |
+| Basic | [`spring-boot-webflux-coroutines`](spring-boot/webflux-coroutines/) | `coroutines`, `spring-boot4-core` | In-memory | WebFlux 코루틴 핸들러, suspend 컨트롤러 |
+| Advanced | [`spring-boot-resilience4j-coroutines`](spring-boot/resilience4j-coroutines/) | `resilience4j`, `coroutines` | In-memory | 코루틴과 함께하는 서킷 브레이커 + 재시도 + 속도 제한 |
+| Basic | [`spring-boot-cbor-mvc`](spring-boot/cbor-mvc/) | `logging` | In-memory | Spring MVC에서 CBOR 바이너리 직렬화 |
+| Basic | [`spring-boot-protobuf-mvc`](spring-boot/protobuf-mvc/) | `logging` | In-memory | Spring MVC에서 Protobuf 직렬화 |
+| Advanced | [`spring-boot-stomp-websocket`](spring-boot/stomp-websocket/) | `coroutines` | In-memory | 코루틴 메시지 핸들러를 활용한 STOMP WebSocket |
+| Advanced | [`spring-boot-webflux-websocket`](spring-boot/webflux-websocket/) | `coroutines` | In-memory | WebFlux 리액티브 WebSocket |
+| Advanced | [`spring-boot-chaos-monkey`](spring-boot/chaos-monkey/) | `logging` | In-memory | Spring Boot용 Chaos Monkey — 지연/예외 주입 |
+| Basic | [`spring-boot-problem`](spring-boot/problem/) | `logging` | In-memory | RFC 9457 Problem Details 에러 응답 |
+| Advanced | [`spring-boot-application-event-demo`](spring-boot/application-event-demo/) | `coroutines` | In-memory | 코루틴 리스너를 활용한 Spring 애플리케이션 이벤트 |
+
+```bash
+./gradlew :spring-boot-cache-redis:test
+./gradlew :spring-boot-resilience4j-coroutines:test
+```
+
+---
+
+### 3. 직렬화 & 메시징
+
+> Jackson 3, JsonView, Kafka, Kafka Reply
+
+| 수준 | 모듈 | bluetape4k 라이브러리 | 인프라 | 학습 목표 |
+|------|------|----------------------|-------|-----------|
+| Basic | [`jackson-examples`](json/jackson-examples/) | `jackson3`, `logging` | In-memory | Jackson 3 데이터타입, 다형성, 커스텀 직렬화 |
+| Basic | [`jsonview-examples`](json/jsonview-examples/) | `jackson3` | In-memory | 선택적 필드 프로젝션을 위한 `@JsonView` |
+| Basic | [`messaging-kafka`](messaging/kafka/) | `jackson3`, `coroutines`, `testcontainers` | Kafka (TC) | 코루틴을 활용한 Kafka 프로듀서/컨슈머 |
+| Advanced | [`messaging-kafka-reply`](messaging/kafka-reply/) | `jackson3`, `coroutines`, `testcontainers` | Kafka (TC) | `ReplyingKafkaTemplate`을 활용한 Kafka 요청-응답 패턴 |
+
+```bash
+./gradlew :jackson-examples:test
+./gradlew :messaging-kafka:test
+```
+
+---
+
+### 4. 비동기 & 리액티브
+
+> Kotlin 코루틴, 가상 스레드, Vert.x
+
+| 수준 | 모듈 | bluetape4k 라이브러리 | 인프라 | 학습 목표 |
+|------|------|----------------------|-------|-----------|
+| Basic | [`coroutines`](kotlin/coroutines/) | `coroutines`, `junit5` | In-memory | 코루틴 빌더, Flow, 채널, 구조적 동시성 |
+| Basic | [`design-patterns`](kotlin/design-patterns/) | `logging`, `coroutines` | In-memory | Kotlin 비동기 디자인 패턴 |
+| Basic | [`virtualthreads-rules`](virtualthreads/rules/) | `logging` | In-memory | 가상 스레드 피닝 방지, synchronized 회피 |
+| Advanced | [`virtualthreads-spring-mvc-tomcat`](virtualthreads/spring-mvc-tomcat/) | `logging`, `testcontainers` | PostgreSQL (TC) | 가상 스레드 실행기를 활용한 Spring MVC |
+| Advanced | [`virtualthreads-spring-webflux`](virtualthreads/spring-webflux/) | `coroutines`, `testcontainers` | PostgreSQL (TC) | 가상 스레드 디스패처를 활용한 WebFlux |
+| Basic | [`vertx-coroutines`](vertx/coroutines/) | `coroutines` | In-memory | Vert.x 코루틴 어댑터 |
+| Advanced | [`vertx-sqlclient`](vertx/vertx-sqlclient/) | `coroutines`, `testcontainers` | PostgreSQL (TC) | Vert.x Reactive SQL Client + 코루틴 |
+| Advanced | [`vertx-webclient`](vertx/vertx-webclient/) | `coroutines` | WireMock | 코루틴을 활용한 Vert.x WebClient |
+
+```bash
+./gradlew :coroutines:test
+./gradlew :virtualthreads-spring-mvc-tomcat:test
+```
+
+---
+
+### 5. 관찰 가능성 & 성능
+
+> Micrometer Observation/Tracing, Gatling 부하 테스트
+
+| 수준 | 모듈 | bluetape4k 라이브러리 | 인프라 | 학습 목표 |
+|------|------|----------------------|-------|-----------|
+| Basic | [`observability-basic`](observability/observability-basic/) | `micrometer`, `coroutines`, `jackson3` | MockWebServer | 코루틴 스팬 전파, `TestObservationRegistry` |
+| Advanced | [`observability-advanced`](observability/observability-advanced/) | `micrometer`, `coroutines`, `testcontainers` | PostgreSQL + Redis (TC) | HTTP, DB, Redis 계층 전반의 엔드투엔드 추적 |
+| Basic | [`micrometer-observation`](observability/micrometer-observation/) | `micrometer`, `logging` | In-memory | Micrometer Observation API 기초 |
+| Advanced | [`micrometer-tracing-coroutines`](observability/micrometer-tracing-coroutines/) | `micrometer`, `coroutines` | In-memory | 코루틴 경계를 통한 분산 추적 컨텍스트 |
+| Advanced | [`gatling-virtualthread-simulation`](gatling/virtualthread-simulation/) | `junit5` | App process | 가상 스레드 서버를 대상으로 한 Gatling 부하 시뮬레이션 |
+
+```bash
+./gradlew :observability-basic:test
+./gradlew :gatling-virtualthread-simulation:gatlingRun
+```
+
+---
+
+### 6. 아키텍처 확장
+
+> API Gateway, Spring Modulith, 보안, Redis 분산 패턴, AWS, Rate Limiting, 리더 선출
+
+| 수준 | 모듈 | bluetape4k 라이브러리 | 인프라 | 학습 목표 |
+|------|------|----------------------|-------|-----------|
+| Basic | [`spring-security-mvc`](spring-security/mvc/) | `logging`, `spring-boot4-core` | In-memory | Spring Security MVC: JWT, 메서드 보안 |
+| Basic | [`spring-security-webflux`](spring-security/webflux/) | `coroutines`, `spring-boot4-core` | In-memory | Spring Security WebFlux: 리액티브 필터 체인 |
+| Advanced | [`spring-modulith-events-deep-dive`](spring-modulith/events-deep-dive/) | `coroutines`, `testcontainers` | PostgreSQL (TC) | 영속성을 갖춘 Modulith 애플리케이션 이벤트 |
+| Advanced | [`spring-modulith-jpa-demo`](spring-modulith/jpa-demo/) | `logging`, `testcontainers` | PostgreSQL (TC) | JPA를 활용한 Modulith 모듈 캡슐화 |
+| Advanced | [`gateway-api-gateway`](gateway/api-gateway/) | `logging` | Services running | Spring Cloud Gateway 라우팅, 필터, 프레디케이트 |
+| Basic | [`ratelimit-bucket4j-caffeine-web`](ratelimit/bucket4j-caffeine-web/) | `logging` | In-memory | Caffeine을 활용한 Bucket4j 속도 제한 |
+| Advanced | [`ratelimit-bucket4j-redis`](ratelimit/bucket4j-redis/) | `redis`, `testcontainers` | Redis (TC) | Bucket4j + Redis를 통한 분산 속도 제한 |
+| Advanced | [`ratelimit-bucker4j-bluetape4k-webflux`](ratelimit/bucker4j-bluetape4k-webflux/) | `redis`, `coroutines`, `testcontainers` | Redis (TC) | bluetape4k WebFlux 속도 제한 통합 |
+| Advanced | [`redis-distributed-lock`](redis/distributed-lock/) | `redis`, `redisson`, `coroutines` | Redis (TC) | Redisson + 코루틴 suspend를 활용한 분산 락 |
+| Advanced | [`redis-cluster-demo`](redis/cluster-demo/) | `redis`, `redisson` | Redis Cluster (TC) | Redis 클러스터 토폴로지 및 장애 조치 |
+| Basic | [`redis-redisson-examples`](redis/redisson-examples/) | `redis`, `redisson` | Redis (TC) | Redisson 데이터 구조와 Pub/Sub |
+| Advanced | [`aws-s3-spring-cloud`](aws/s3-spring-cloud/) | `aws`, `testcontainers` | LocalStack (TC) | Spring Cloud AWS + LocalStack으로 AWS S3 사용 |
+| Advanced | [`leader-leader-election`](leader/) | `coroutines`, `redis`, `testcontainers` | Redis (TC) | 분산 리더 선출: 블로킹, 코루틴, 가상 스레드 |
+
+```bash
+./gradlew :spring-security-mvc:test
+./gradlew :redis-distributed-lock:test
+./gradlew :aws-s3-spring-cloud:test
+```
+
+---
+
+## 기술 스택
+
+| 항목 | 버전 |
+|------|------|
+| Kotlin | 2.3.21 |
+| JVM | 21 |
+| Spring Boot | 4.0.6 |
+| bluetape4k | 1.7.0 |
+| Gradle | 8.x (Kotlin DSL, 멀티모듈) |
+
+---
+
+## 프로젝트 구조
+
+```
+bluetape4k-workshop/
+├── aws/                    # AWS SDK + Spring Cloud AWS
+├── exposed/                # JetBrains Exposed ORM
+├── gateway/                # API Gateway + 마이크로서비스
+├── gatling/                # 부하/성능 테스트
+├── io/                     # Okio I/O 예제
+├── json/                   # Jackson 3 직렬화
+├── kotlin/                 # 코루틴, 디자인 패턴
+├── leader/                 # 분산 리더 선출
+├── messaging/              # Kafka
+├── observability/          # Micrometer Observation + Tracing
+├── ratelimit/              # Bucket4j 속도 제한
+├── redis/                  # Redisson + Redis 패턴
+├── spring-boot/            # Spring Boot 기능
+├── spring-data/            # JPA, R2DBC, MongoDB, Elasticsearch
+├── spring-modulith/        # Spring Modulith 이벤트
+├── spring-security/        # MVC/WebFlux 보안
+├── vertx/                  # Vert.x + 코루틴
+├── virtualthreads/         # 가상 스레드 패턴
+├── shared/                 # 공유 테스트 유틸리티
+└── docs/
+    ├── assets/             # 다이어그램, 이미지 (CONVENTIONS.md 참조)
+    ├── lessons/            # 엔지니어링 교훈
+    └── governance/         # 프로젝트 거버넌스 문서
+```
+
+---
+
+## 기여하기
+
+AI 에이전트 가이드 및 엔지니어링 워크플로우는 [AGENTS.md](AGENTS.md)를 참조하세요.
+인간 기여자는 이슈 또는 드래프트 PR을 열어주세요 — 모든 피드백을 환영합니다.
+
+---
+
+## 라이선스
+
+[MIT](LICENSE) © bluetape4k contributors

--- a/README.md
+++ b/README.md
@@ -2,92 +2,232 @@
 
 [![Kotlin](https://img.shields.io/badge/Kotlin-2.3-7F52FF?logo=kotlin)](https://kotlinlang.org)
 [![JVM](https://img.shields.io/badge/JVM-21-ED8B00?logo=openjdk)](https://openjdk.org)
+[![Spring Boot](https://img.shields.io/badge/Spring_Boot-4.0-6DB33F?logo=springboot)](https://spring.io/projects/spring-boot)
+[![bluetape4k](https://img.shields.io/badge/bluetape4k-1.7-4A90D9)](https://github.com/bluetape4k)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-![Bluetape4k workshop workbench](./docs/assets/workshop-workbench.png)
+> 🇰🇷 [한국어 README](README.ko.md)
 
-Bluetape4k 라이브러리를 활용한 백엔드 예제 모음입니다.
+Runnable backend examples showing how [bluetape4k](https://github.com/bluetape4k) libraries
+integrate with Spring Boot 4, JetBrains Exposed, Redis, Kafka, observability stacks,
+virtual threads, Vert.x, and cloud-native patterns.
 
-## Project Purpose
+![Workshop workbench](./docs/assets/workshop-workbench.png)
 
-`bluetape4k-workshop` collects runnable backend examples that show how stable
-bluetape4k libraries fit into Spring Boot, Exposed, Redis, Kafka, security,
-observability, virtual threads, Vert.x, and gateway-style applications.
+---
 
-## What It Provides
-
-- **Runnable module groups** for common backend stacks.
-- **Integration examples** for bluetape4k data, infra, I/O, and testing modules.
-- **Test-first learning material** with Testcontainers and shared utilities.
-- **Adoption bridge** from isolated library APIs to application-shaped examples.
-
-<!-- README_VISUAL_OVERVIEW:START -->
-## Overview Diagram
-
-![Bluetape4k Workshop overview diagram](docs/images/readme-diagrams/root-readme-overview-01.png)
-
-## Module Composition Chart
-
-![Bluetape4k Workshop module composition chart](docs/images/readme-charts/root-readme-module-chart-01.png)
-<!-- README_VISUAL_OVERVIEW:END -->
-
-## 기술 스택
-
-| 항목          | 버전               |
-|-------------|------------------|
-| Kotlin      | 2.3.21           |
-| Java        | 21               |
-| Spring Boot | 4.0.6            |
-| bluetape4k  | 1.7.0            |
-| Gradle      | Kotlin DSL, 멀티모듈 |
-
-## 빌드
+## Getting Started
 
 ```bash
-./gradlew build                          # 전체 빌드
-./gradlew :exposed-domain:build          # 특정 모듈 빌드
-./gradlew :exposed-domain:test           # 특정 모듈 테스트
-./gradlew detekt                         # 정적 분석
+# Build everything
+./gradlew build
+
+# Build and test a single module
+./gradlew :exposed-mvc-jdbc:build
+./gradlew :exposed-mvc-jdbc:test
+
+# Static analysis
+./gradlew detekt
 ```
 
-`exposed-domain` 테스트는 `io.bluetape4k.exposed.jdbc.selectImplicitAll` 같은
-main JDBC helper extension을 직접 검증합니다. `exposed-jdbc-tests`는
-test fixture 계약만 제공하므로, 해당 테스트 모듈에는 `exposed-jdbc`
-test dependency도 함께 선언해야 합니다.
+**Requirements**: JDK 21+, Docker (Testcontainers)
 
-## 전체 모듈 구성
+---
 
-![workshop Architecture diagram](docs/images/readme-diagrams/root-readme-en-diagram-01.png)
+## Domain Catalog
 
-## 모듈 구조
+Modules are organized into six learning domains.
+Each domain lists **Basic** (self-contained, minimal infra) and **Advanced** (multi-layer, Testcontainers) modules.
 
-| 디렉토리               | 내용                                                |
-|--------------------|---------------------------------------------------|
-| `aws/`             | S3 Spring Cloud 연동                                |
-| `exposed/`         | JetBrains Exposed ORM (DAO/SQL DSL, 연관관계, 커스텀 컬럼) |
-| `gateway/`         | API Gateway + Customers/Orders 마이크로서비스            |
-| `gatling/`         | Gatling 성능 테스트                                    |
-| `io/`              | Okio 예제                                           |
-| `json/`            | Jackson, JsonView 예제                              |
-| `kotlin/`          | 코루틴, 디자인 패턴, 워크숍                                  |
-| `mapping/`         | MapStruct 매핑                                      |
-| `messaging/`       | Kafka, Kafka Reply                                |
-| `observability/`   | Micrometer Observation/Tracing                    |
-| `quarkus/`         | Hibernate Reactive Panache, REST 코루틴 *(빌드 비활성)*   |
-| `ratelimit/`       | Bucket4j Rate Limiting (Caffeine, Redis, WebFlux) |
-| `reactive/`        | Mutiny 리액티브 스트림                                   |
-| `redis/`           | Redisson, 클러스터                                    |
-| `spring-boot/`     | WebFlux, Cache, Resilience4j 등 Spring Boot 기능 예제  |
-| `spring-cloud/`    | Gateway *(빌드 비활성 — Spring Boot 4 호환 대기)*          |
-| `spring-data/`     | R2DBC, JPA/QueryDSL, MongoDB, Elasticsearch       |
-| `spring-modulith/` | Events, JPA 데모                                    |
-| `spring-security/` | MVC/WebFlux 보안 예제                                 |
-| `vertx/`           | Vert.x 코루틴, SQL Client, WebClient                 |
-| `virtualthreads/`  | Virtual Threads + MVC/WebFlux                     |
-| `shared/`          | 테스트 공통 유틸리티                                       |
+### 1. Data Access
 
-## 테스트
+> Exposed ORM, R2DBC, JPA/QueryDSL, MongoDB, Elasticsearch, Redis
 
-- JUnit 5 + bluetape4k-assertions + MockK
-- Testcontainers (MariaDB, MySQL, PostgreSQL, CockroachDB)
-- JVM: ZGC, `-Xms2G -Xmx4G`, `--enable-preview`
+| Level | Module | bluetape4k libs | Infra | Learning outcome |
+|-------|--------|-----------------|-------|-----------------|
+| Basic | [`exposed-mvc-jdbc`](exposed/mvc-jdbc/) | `logging`, `junit5`, `testcontainers` | PostgreSQL (TC) | Exposed DAO/SQL DSL with Spring MVC JDBC |
+| Basic | [`exposed-webflux-r2dbc`](exposed/webflux-r2dbc/) | `logging`, `coroutines`, `testcontainers` | PostgreSQL (TC) | Exposed R2DBC + WebFlux coroutine handlers |
+| Advanced | [`exposed-mvc-virtualthread`](exposed/mvc-virtualthread/) | `logging`, `coroutines`, `testcontainers` | PostgreSQL (TC) | Exposed JDBC with Spring MVC virtual threads |
+| Basic | [`spring-data-r2dbc-coroutines`](spring-data/r2dbc-coroutines/) | `coroutines`, `testcontainers` | PostgreSQL (TC) | R2DBC repositories with coroutines |
+| Basic | [`spring-data-r2dbc-examples`](spring-data/r2dbc-examples/) | `coroutines`, `testcontainers` | PostgreSQL (TC) | R2DBC raw examples and DSL |
+| Advanced | [`spring-data-r2dbc-webflux`](spring-data/r2dbc-webflux/) | `coroutines`, `testcontainers` | PostgreSQL (TC) | R2DBC + WebFlux REST API |
+| Advanced | [`spring-data-r2dbc-webflux-exposed`](spring-data/r2dbc-webflux-exposed/) | `logging`, `coroutines`, `testcontainers` | PostgreSQL (TC) | R2DBC + WebFlux + Exposed combined |
+| Basic | [`spring-data-jpa-querydsl`](spring-data/jpa-querydsl/) | `logging`, `junit5`, `testcontainers` | PostgreSQL (TC) | JPA + QueryDSL type-safe queries |
+| Basic | [`spring-data-mongodb-coroutines`](spring-data/mongodb-coroutines/) | `coroutines`, `testcontainers` | MongoDB (TC) | MongoDB reactive repositories with coroutines |
+| Advanced | [`spring-data-mongodb-transactions`](spring-data/mongodb-transactions/) | `coroutines`, `testcontainers` | MongoDB (TC) | MongoDB multi-document transactions |
+| Basic | [`spring-data-elasticsearch`](spring-data/elasticsearch/) | `logging`, `testcontainers` | Elasticsearch (TC) | Spring Data Elasticsearch blocking |
+| Advanced | [`spring-data-elasticsearch-webflux`](spring-data/elasticsearch-webflux/) | `coroutines`, `testcontainers` | Elasticsearch (TC) | Elasticsearch + WebFlux reactive |
+| Basic | [`spring-data-redis-examples`](spring-data/redis-examples/) | `redis`, `testcontainers` | Redis (TC) | Spring Data Redis and RedisTemplate |
+
+```bash
+./gradlew :exposed-mvc-jdbc:test
+./gradlew :spring-data-r2dbc-coroutines:test
+```
+
+---
+
+### 2. Spring Boot Operations
+
+> Caching, resilience, WebFlux, WebSocket, CBOR, Protobuf, chaos engineering
+
+| Level | Module | bluetape4k libs | Infra | Learning outcome |
+|-------|--------|-----------------|-------|-----------------|
+| Basic | [`spring-boot-cache-caffeine`](spring-boot/cache-caffeine/) | `logging`, `junit5` | In-memory | Caffeine cache with Spring Cache abstraction |
+| Basic | [`spring-boot-cache-redis`](spring-boot/cache-redis/) | `redis`, `testcontainers` | Redis (TC) | Redis-backed Spring Cache + TTL config |
+| Basic | [`spring-boot-webflux-coroutines`](spring-boot/webflux-coroutines/) | `coroutines`, `spring-boot4-core` | In-memory | WebFlux coroutine handlers, suspend controllers |
+| Advanced | [`spring-boot-resilience4j-coroutines`](spring-boot/resilience4j-coroutines/) | `resilience4j`, `coroutines` | In-memory | Circuit breaker + retry + rate limiter with coroutines |
+| Basic | [`spring-boot-cbor-mvc`](spring-boot/cbor-mvc/) | `logging` | In-memory | CBOR binary serialization in Spring MVC |
+| Basic | [`spring-boot-protobuf-mvc`](spring-boot/protobuf-mvc/) | `logging` | In-memory | Protobuf serialization in Spring MVC |
+| Advanced | [`spring-boot-stomp-websocket`](spring-boot/stomp-websocket/) | `coroutines` | In-memory | STOMP WebSocket with coroutine message handlers |
+| Advanced | [`spring-boot-webflux-websocket`](spring-boot/webflux-websocket/) | `coroutines` | In-memory | WebFlux reactive WebSocket |
+| Advanced | [`spring-boot-chaos-monkey`](spring-boot/chaos-monkey/) | `logging` | In-memory | Chaos Monkey for Spring Boot — latency/exception injection |
+| Basic | [`spring-boot-problem`](spring-boot/problem/) | `logging` | In-memory | RFC 9457 Problem Details error responses |
+| Advanced | [`spring-boot-application-event-demo`](spring-boot/application-event-demo/) | `coroutines` | In-memory | Spring application events with coroutine listeners |
+
+```bash
+./gradlew :spring-boot-cache-redis:test
+./gradlew :spring-boot-resilience4j-coroutines:test
+```
+
+---
+
+### 3. Serialization & Messaging
+
+> Jackson 3, JsonView, Kafka, Kafka Reply
+
+| Level | Module | bluetape4k libs | Infra | Learning outcome |
+|-------|--------|-----------------|-------|-----------------|
+| Basic | [`jackson-examples`](json/jackson-examples/) | `jackson3`, `logging` | In-memory | Jackson 3 datatype, polymorphism, custom serializers |
+| Basic | [`jsonview-examples`](json/jsonview-examples/) | `jackson3` | In-memory | `@JsonView` for selective field projection |
+| Basic | [`messaging-kafka`](messaging/kafka/) | `jackson3`, `coroutines`, `testcontainers` | Kafka (TC) | Kafka producer/consumer with coroutines |
+| Advanced | [`messaging-kafka-reply`](messaging/kafka-reply/) | `jackson3`, `coroutines`, `testcontainers` | Kafka (TC) | Kafka request-reply pattern with `ReplyingKafkaTemplate` |
+
+```bash
+./gradlew :jackson-examples:test
+./gradlew :messaging-kafka:test
+```
+
+---
+
+### 4. Async & Reactive
+
+> Kotlin coroutines, virtual threads, Vert.x
+
+| Level | Module | bluetape4k libs | Infra | Learning outcome |
+|-------|--------|-----------------|-------|-----------------|
+| Basic | [`coroutines`](kotlin/coroutines/) | `coroutines`, `junit5` | In-memory | Coroutine builders, Flow, channels, structured concurrency |
+| Basic | [`design-patterns`](kotlin/design-patterns/) | `logging`, `coroutines` | In-memory | Async design patterns in Kotlin |
+| Basic | [`virtualthreads-rules`](virtualthreads/rules/) | `logging` | In-memory | Virtual thread pinning, synchronized avoidance |
+| Advanced | [`virtualthreads-spring-mvc-tomcat`](virtualthreads/spring-mvc-tomcat/) | `logging`, `testcontainers` | PostgreSQL (TC) | Spring MVC with virtual thread executor |
+| Advanced | [`virtualthreads-spring-webflux`](virtualthreads/spring-webflux/) | `coroutines`, `testcontainers` | PostgreSQL (TC) | WebFlux with virtual thread dispatcher |
+| Basic | [`vertx-coroutines`](vertx/coroutines/) | `coroutines` | In-memory | Vert.x coroutine adapters |
+| Advanced | [`vertx-sqlclient`](vertx/vertx-sqlclient/) | `coroutines`, `testcontainers` | PostgreSQL (TC) | Vert.x Reactive SQL Client + coroutines |
+| Advanced | [`vertx-webclient`](vertx/vertx-webclient/) | `coroutines` | WireMock | Vert.x WebClient with coroutines |
+
+```bash
+./gradlew :coroutines:test
+./gradlew :virtualthreads-spring-mvc-tomcat:test
+```
+
+---
+
+### 5. Observability & Performance
+
+> Micrometer Observation/Tracing, Gatling load tests
+
+| Level | Module | bluetape4k libs | Infra | Learning outcome |
+|-------|--------|-----------------|-------|-----------------|
+| Basic | [`observability-basic`](observability/observability-basic/) | `micrometer`, `coroutines`, `jackson3` | MockWebServer | Coroutine span propagation, `TestObservationRegistry` |
+| Advanced | [`observability-advanced`](observability/observability-advanced/) | `micrometer`, `coroutines`, `testcontainers` | PostgreSQL + Redis (TC) | End-to-end tracing across HTTP, DB, and Redis layers |
+| Basic | [`micrometer-observation`](observability/micrometer-observation/) | `micrometer`, `logging` | In-memory | Micrometer Observation API basics |
+| Advanced | [`micrometer-tracing-coroutines`](observability/micrometer-tracing-coroutines/) | `micrometer`, `coroutines` | In-memory | Distributed tracing context through coroutine boundaries |
+| Advanced | [`gatling-virtualthread-simulation`](gatling/virtualthread-simulation/) | `junit5` | App process | Gatling load simulation targeting virtual thread server |
+
+```bash
+./gradlew :observability-basic:test
+./gradlew :gatling-virtualthread-simulation:gatlingRun
+```
+
+---
+
+### 6. Architecture Extensions
+
+> API Gateway, Spring Modulith, Security, Redis distributed patterns, AWS, Rate Limiting, Leader Election
+
+| Level | Module | bluetape4k libs | Infra | Learning outcome |
+|-------|--------|-----------------|-------|-----------------|
+| Basic | [`spring-security-mvc`](spring-security/mvc/) | `logging`, `spring-boot4-core` | In-memory | Spring Security MVC: JWT, method security |
+| Basic | [`spring-security-webflux`](spring-security/webflux/) | `coroutines`, `spring-boot4-core` | In-memory | Spring Security WebFlux: reactive filter chain |
+| Advanced | [`spring-modulith-events-deep-dive`](spring-modulith/events-deep-dive/) | `coroutines`, `testcontainers` | PostgreSQL (TC) | Modulith application events with persistence |
+| Advanced | [`spring-modulith-jpa-demo`](spring-modulith/jpa-demo/) | `logging`, `testcontainers` | PostgreSQL (TC) | Modulith module encapsulation with JPA |
+| Advanced | [`gateway-api-gateway`](gateway/api-gateway/) | `logging` | Services running | Spring Cloud Gateway routing, filters, predicates |
+| Basic | [`ratelimit-bucket4j-caffeine-web`](ratelimit/bucket4j-caffeine-web/) | `logging` | In-memory | Bucket4j rate limiting with Caffeine |
+| Advanced | [`ratelimit-bucket4j-redis`](ratelimit/bucket4j-redis/) | `redis`, `testcontainers` | Redis (TC) | Distributed rate limiting via Bucket4j + Redis |
+| Advanced | [`ratelimit-bucker4j-bluetape4k-webflux`](ratelimit/bucker4j-bluetape4k-webflux/) | `redis`, `coroutines`, `testcontainers` | Redis (TC) | bluetape4k WebFlux rate limit integration |
+| Advanced | [`redis-distributed-lock`](redis/distributed-lock/) | `redis`, `redisson`, `coroutines` | Redis (TC) | Distributed lock with Redisson + coroutine suspend |
+| Advanced | [`redis-cluster-demo`](redis/cluster-demo/) | `redis`, `redisson` | Redis Cluster (TC) | Redis Cluster topology and failover |
+| Basic | [`redis-redisson-examples`](redis/redisson-examples/) | `redis`, `redisson` | Redis (TC) | Redisson data structures and pub/sub |
+| Advanced | [`aws-s3-spring-cloud`](aws/s3-spring-cloud/) | `aws`, `testcontainers` | LocalStack (TC) | AWS S3 with Spring Cloud AWS + LocalStack |
+| Advanced | [`leader-leader-election`](leader/) | `coroutines`, `redis`, `testcontainers` | Redis (TC) | Distributed leader election: blocking, coroutine, virtual thread |
+
+```bash
+./gradlew :spring-security-mvc:test
+./gradlew :redis-distributed-lock:test
+./gradlew :aws-s3-spring-cloud:test
+```
+
+---
+
+## Tech Stack
+
+| Item | Version |
+|------|---------|
+| Kotlin | 2.3.21 |
+| JVM | 21 |
+| Spring Boot | 4.0.6 |
+| bluetape4k | 1.7.0 |
+| Gradle | 8.x (Kotlin DSL, multi-module) |
+
+---
+
+## Project Structure
+
+```
+bluetape4k-workshop/
+├── aws/                    # AWS SDK + Spring Cloud AWS
+├── exposed/                # JetBrains Exposed ORM
+├── gateway/                # API Gateway + microservices
+├── gatling/                # Load/performance tests
+├── io/                     # Okio I/O examples
+├── json/                   # Jackson 3 serialization
+├── kotlin/                 # Coroutines, design patterns
+├── leader/                 # Distributed leader election
+├── messaging/              # Kafka
+├── observability/          # Micrometer Observation + Tracing
+├── ratelimit/              # Bucket4j rate limiting
+├── redis/                  # Redisson + Redis patterns
+├── spring-boot/            # Spring Boot features
+├── spring-data/            # JPA, R2DBC, MongoDB, Elasticsearch
+├── spring-modulith/        # Spring Modulith events
+├── spring-security/        # MVC/WebFlux security
+├── vertx/                  # Vert.x + coroutines
+├── virtualthreads/         # Virtual thread patterns
+├── shared/                 # Shared test utilities
+└── docs/
+    ├── assets/             # Diagrams, images (see CONVENTIONS.md)
+    ├── lessons/            # Engineering lessons learned
+    └── governance/         # Project governance docs
+```
+
+---
+
+## Contributing
+
+See [AGENTS.md](AGENTS.md) for AI-agent guidance and the engineering workflow.
+For human contributors, open an issue or draft PR — all feedback is welcome.
+
+---
+
+## License
+
+[MIT](LICENSE) © bluetape4k contributors

--- a/docs/assets/CONVENTIONS.md
+++ b/docs/assets/CONVENTIONS.md
@@ -1,0 +1,149 @@
+# docs/assets — Diagram and Image Conventions
+
+This document defines naming, format, and placement conventions for all visual assets
+in the `bluetape4k-workshop` repository.
+
+---
+
+## Directory Layout
+
+```
+docs/
+├── assets/                          # Root visual assets referenced directly in README.md
+│   ├── workshop-workbench.png       # Hero image shown in README.md
+│   └── CONVENTIONS.md               # This file
+├── images/
+│   ├── readme-diagrams/             # Architecture and flow diagrams embedded in READMEs
+│   │   └── <scope>-<type>-<seq>.png
+│   └── readme-charts/               # Data/metric charts embedded in READMEs
+│       └── <scope>-<type>-<seq>.png
+```
+
+---
+
+## File Naming
+
+Pattern: `<scope>-<type>-<seq>.<ext>`
+
+| Segment | Values | Example |
+|---------|--------|---------|
+| `scope` | `root-readme` \| `<module-name>` | `root-readme`, `exposed-mvc-jdbc` |
+| `type` | `overview` \| `architecture` \| `c4-context` \| `c4-component` \| `sequence` \| `diagram` \| `chart` \| `en-diagram` | `c4-context`, `sequence` |
+| `seq` | two-digit sequence number | `01`, `02` |
+| `ext` | `png` (preferred for raster), `svg` (preferred for vector/Mermaid export) | `png` |
+
+### Examples
+
+```
+docs/images/readme-diagrams/root-readme-overview-01.png
+docs/images/readme-diagrams/root-readme-c4-context-01.svg
+docs/images/readme-diagrams/exposed-sequence-01.png
+docs/images/readme-charts/root-readme-module-chart-01.png
+```
+
+---
+
+## Diagram Types
+
+### Architecture Overview
+
+Use a top-level diagram showing all active domains and their relationships.
+Recommended format: Mermaid `graph TD` or `C4Context`.
+
+```mermaid
+graph TD
+    subgraph DataAccess
+        exposed[Exposed ORM]
+        springdata[Spring Data]
+    end
+    subgraph Messaging
+        kafka[Kafka]
+    end
+    subgraph Infra
+        redis[Redis]
+        pg[(PostgreSQL)]
+    end
+    exposed --> pg
+    springdata --> pg
+    kafka --> redis
+```
+
+### C4 Component Diagrams
+
+For each major domain, provide a C4 Component diagram showing:
+- External actors (client, message broker, database)
+- Application modules
+- Connections with protocols
+
+File naming: `<domain>-c4-component-01.svg`
+
+Domains requiring C4 diagrams:
+- `data-access-c4-component-01.svg` — Exposed + Spring Data
+- `async-reactive-c4-component-01.svg` — Coroutines + Vert.x + Virtual Threads
+- `observability-c4-component-01.svg` — Micrometer + Tracing
+- `messaging-c4-component-01.svg` — Kafka + Event flow
+- `arch-extensions-c4-component-01.svg` — Gateway + Security + Modulith
+
+### UML Sequence Diagrams
+
+For representative flows that involve multiple components.
+File naming: `<module>-sequence-01.svg`
+
+Key flows to document:
+- `redis-distributed-lock-sequence-01.svg` — Lock acquire → work → release with coroutines
+- `messaging-kafka-reply-sequence-01.svg` — Request → Kafka → reply → response
+- `observability-tracing-sequence-01.svg` — HTTP in → DB span → Redis span → out
+
+---
+
+## Format Guidelines
+
+| Concern | Guideline |
+|---------|-----------|
+| Raster images | PNG, minimum 1200px wide for architecture diagrams |
+| Vector | SVG preferred for Mermaid exports and flow diagrams |
+| Background | White or transparent; avoid dark backgrounds for readability in both light/dark GitHub themes |
+| Font | System sans-serif or Roboto; minimum 12pt for labels |
+| Color palette | Use bluetape4k brand colors: primary `#4A90D9`, accent `#6DB33F` (Spring green), neutral `#555555` |
+| Alt text | Always set descriptive alt text in Markdown image embeds |
+
+---
+
+## How to Reference in README
+
+```markdown
+<!-- Preferred: descriptive alt text + relative path -->
+![Workshop overview architecture diagram](docs/images/readme-diagrams/root-readme-overview-01.png)
+
+<!-- For hero image in root README -->
+![Bluetape4k workshop workbench](./docs/assets/workshop-workbench.png)
+```
+
+---
+
+## Tooling
+
+| Tool | Use case |
+|------|----------|
+| [Mermaid](https://mermaid.js.org) | Architecture, flow, sequence diagrams — rendered natively by GitHub |
+| [draw.io](https://app.diagrams.net) | C4, UML, and complex multi-layer diagrams |
+| [PlantUML](https://plantuml.com) | UML sequence diagrams |
+| macOS Screenshot / Snagit | Hero images and screenshots |
+
+Store the source file (`.drawio`, `.puml`, `.mmd`) alongside the exported PNG/SVG
+with the same base name:
+
+```
+docs/images/readme-diagrams/root-readme-c4-context-01.svg    ← exported
+docs/images/readme-diagrams/root-readme-c4-context-01.drawio ← source
+```
+
+---
+
+## Checklist for New Diagrams
+
+- [ ] File follows `<scope>-<type>-<seq>.<ext>` naming
+- [ ] Placed in `docs/images/readme-diagrams/` or `docs/images/readme-charts/`
+- [ ] Alt text is descriptive (not "diagram")
+- [ ] Source file committed alongside export
+- [ ] Both light and dark GitHub themes verified

--- a/docs/coverage-matrix.md
+++ b/docs/coverage-matrix.md
@@ -1,0 +1,136 @@
+# bluetape4k-workshop — Library Coverage Matrix
+
+Maps each bluetape4k library to existing workshop examples and identifies coverage gaps
+with proposed Basic/Advanced scenarios.
+
+> Last updated: 2026-05-24
+
+---
+
+## How to Read This Matrix
+
+| Column | Meaning |
+|--------|---------|
+| **bluetape4k lib** | Published module in `bluetape4k-dependencies` BOM |
+| **Existing example** | Current workshop module demonstrating the lib |
+| **Coverage level** | ✅ Good · ⚠️ Partial · ❌ Missing |
+| **Gap** | What is not yet demonstrated |
+| **Proposed Basic** | Minimal, in-memory scenario |
+| **Proposed Advanced** | Production-shaped, Testcontainers scenario |
+| **Issue** | Tracking GitHub issue |
+
+---
+
+## Core Libraries
+
+| bluetape4k lib | Existing example | Coverage | Gap | Proposed Basic | Proposed Advanced | Issue |
+|----------------|-----------------|----------|-----|----------------|-------------------|-------|
+| `bluetape4k-core` | (used transitively everywhere) | ⚠️ Partial | No dedicated validation / support-ext demo | Dedicated CRUD service using `requireNotBlank`, `requirePositiveNumber` | N/A | #79 |
+| `bluetape4k-logging` | All modules | ✅ Good | — | — | — | — |
+| `bluetape4k-coroutines` | `kotlin/coroutines`, `observability-*`, `redis-distributed-lock` | ✅ Good | Structured concurrency patterns incomplete | — | — | — |
+| `bluetape4k-junit5` | All test modules | ✅ Good | `SuspendedJobTester` / `MultithreadingTester` not shown | Concurrency test harness demo | — | — |
+| `bluetape4k-assertions` | All test modules | ✅ Good | — | — | — | — |
+| `bluetape4k-testcontainers` | `exposed-*`, `spring-data-*`, `redis-*`, `messaging-*` | ✅ Good | — | — | — | — |
+
+---
+
+## Data Access
+
+| bluetape4k lib | Existing example | Coverage | Gap | Proposed Basic | Proposed Advanced | Issue |
+|----------------|-----------------|----------|-----|----------------|-------------------|-------|
+| `bluetape4k-exposed` (JDBC) | `exposed-mvc-jdbc` | ✅ Good | Batch insert, custom columns | — | — | #79 |
+| `bluetape4k-exposed` (R2DBC) | `exposed-webflux-r2dbc` | ✅ Good | Coroutine transaction rollback | — | — | — |
+| `bluetape4k-spring-boot-r2dbc` | `spring-data-r2dbc-webflux-exposed` | ⚠️ Partial | Auto-config usage not explicit | Simple R2DBC CRUD with BT auto-config | Full WebFlux CRUD + integration test | #79 |
+| `bluetape4k-spring-boot-redis` | `spring-boot-cache-redis` | ⚠️ Partial | Custom codec, TTL per-key | Caffeine-first cache with Redis L2 fallback | Distributed cache cluster with TTL override | — |
+| `bluetape4k-redis` | `redis-redisson-examples`, `redis-distributed-lock` | ✅ Good | Reactive Redisson not shown | — | Reactive Redisson RMapReactive example | — |
+| `bluetape4k-redisson` | `redis-distributed-lock`, `redis-cluster-demo` | ✅ Good | Redisson Spring Boot auto-config | — | — | — |
+| `bluetape4k-idgenerators` | `redis-distributed-lock` (indirect) | ❌ Missing | No standalone ID generator demo | `SnowflakeId` / `TimebasedUuid` generation benchmark | Distributed unique ID under concurrent load | #62 |
+
+---
+
+## Spring Boot Integration
+
+| bluetape4k lib | Existing example | Coverage | Gap | Proposed Basic | Proposed Advanced | Issue |
+|----------------|-----------------|----------|-----|----------------|-------------------|-------|
+| `bluetape4k-spring-boot4-core` | `spring-boot-webflux-coroutines`, `spring-security-*` | ⚠️ Partial | WebClient BT extensions not shown | WebFlux controller + suspend handler with BT helpers | Full CRUD API with BT auto-config | #82 |
+| `bluetape4k-resilience4j` | `spring-boot-resilience4j-coroutines` | ✅ Good | Bulkhead not shown | — | Bulkhead + circuit breaker + fallback pipeline | — |
+| `bluetape4k-micrometer` | `observability-basic`, `observability-advanced`, `micrometer-*` | ✅ Good | Custom meter registry not shown | — | Custom MeterRegistry + Prometheus endpoint | — |
+
+---
+
+## Messaging
+
+| bluetape4k lib | Existing example | Coverage | Gap | Proposed Basic | Proposed Advanced | Issue |
+|----------------|-----------------|----------|-----|----------------|-------------------|-------|
+| `bluetape4k-jackson3` | `json/jackson-examples`, `messaging-kafka` | ✅ Good | Schema evolution / compatibility not shown | Jackson 3 schema migration demo | Kafka + Avro schema registry | #83 |
+| Kafka (via Spring Kafka) | `messaging-kafka`, `messaging-kafka-reply` | ✅ Good | Dead letter queue not shown | — | Kafka DLQ + retry topic pattern | #83 |
+
+---
+
+## Async / Reactive
+
+| bluetape4k lib | Existing example | Coverage | Gap | Proposed Basic | Proposed Advanced | Issue |
+|----------------|-----------------|----------|-----|----------------|-------------------|-------|
+| `bluetape4k-coroutines` | `kotlin/coroutines` | ⚠️ Partial | Flow backpressure, SharedFlow not shown | Flow + StateFlow producer/consumer | Coroutine channel fan-out with backpressure | — |
+| Virtual threads (JDK 21) | `virtualthreads-*` | ✅ Good | Pinning detection tooling not shown | — | Async profiler pinning report | — |
+| Vert.x + coroutines | `vertx-*` | ✅ Good | — | — | — | — |
+
+---
+
+## Observability
+
+| bluetape4k lib | Existing example | Coverage | Gap | Proposed Basic | Proposed Advanced | Issue |
+|----------------|-----------------|----------|-----|----------------|-------------------|-------|
+| `bluetape4k-micrometer` | `observability-basic` | ✅ Good | Exemplar linking not shown | — | Prometheus exemplar + Grafana Tempo link | — |
+| Distributed tracing | `micrometer-tracing-coroutines`, `observability-advanced` | ✅ Good | — | — | — | — |
+
+---
+
+## Architecture / Infrastructure
+
+| bluetape4k lib | Existing example | Coverage | Gap | Proposed Basic | Proposed Advanced | Issue |
+|----------------|-----------------|----------|-----|----------------|-------------------|-------|
+| `bluetape4k-leader` (Redis) | `leader-leader-election` | ✅ Good | Virtual thread variant less prominent | — | Leader election with health endpoint | — |
+| Rate limiting | `ratelimit-*` | ✅ Good | Adaptive rate limit not shown | — | Adaptive Bucket4j + Redis with sliding window | — |
+| Spring Cloud Gateway | `gateway-api-gateway` | ⚠️ Partial | Circuit breaker filter not shown | — | Gateway + Resilience4j circuit breaker filter | — |
+| Spring Modulith | `spring-modulith-*` | ⚠️ Partial | Module testing isolation not shown | — | Modulith ApplicationModuleTest per bounded context | — |
+| AWS S3 | `aws-s3-spring-cloud` | ⚠️ Partial | Multipart upload not shown | — | S3 multipart upload with LocalStack | — |
+| `bluetape4k-aws` | `aws-s3-spring-cloud` | ⚠️ Partial | BT AWS Kotlin SDK wrappers not shown | — | AWS Kotlin SDK + coroutine suspend wrappers | — |
+
+---
+
+## Notable Gaps Summary
+
+### Tier 1 — High priority (no example exists)
+
+| Gap | Proposed module | Issue |
+|-----|----------------|-------|
+| `bluetape4k-idgenerators` standalone demo | `kotlin/idgenerator-workshop` | #62 |
+| `bluetape4k-core` validation/support-ext demo | `kotlin/data-access-basic` | #79 |
+| WebFlux CRUD with `bluetape4k-spring-boot4-core` auto-config | `spring-boot/spring-boot-basic` | #82 |
+| Jackson 3 schema evolution + Kafka Avro | `messaging/messaging-basic` | #83 |
+
+### Tier 2 — Medium priority (partial coverage)
+
+| Gap | Proposed improvement |
+|-----|---------------------|
+| Redisson reactive data structures | Add to `redis-redisson-examples` |
+| S3 multipart upload | Extend `aws-s3-spring-cloud` |
+| Modulith `ApplicationModuleTest` | Add to `spring-modulith-jpa-demo` |
+| Gateway Resilience4j filter | Add to `gateway-api-gateway` |
+| Flow backpressure / SharedFlow | Add to `kotlin/coroutines` |
+
+---
+
+## Coverage Statistics
+
+| Domain | Total libs tracked | ✅ Good | ⚠️ Partial | ❌ Missing |
+|--------|-------------------|---------|-----------|----------|
+| Core | 6 | 5 | 1 | 0 |
+| Data Access | 7 | 4 | 2 | 1 |
+| Spring Boot | 3 | 1 | 2 | 0 |
+| Messaging | 2 | 1 | 1 | 0 |
+| Async/Reactive | 3 | 2 | 1 | 0 |
+| Observability | 2 | 2 | 0 | 0 |
+| Architecture/Infra | 7 | 2 | 5 | 0 |
+| **Total** | **30** | **17 (57%)** | **12 (40%)** | **1 (3%)** |

--- a/docs/images/readme-diagrams/root-readme-architecture.md
+++ b/docs/images/readme-diagrams/root-readme-architecture.md
@@ -1,0 +1,113 @@
+# Root Architecture Diagram — Source
+
+This file contains the Mermaid source for the workshop root architecture diagram.
+Export to `root-readme-overview-01.svg` using the Mermaid CLI or online editor.
+
+```mermaid
+graph TB
+    classDef domain fill:#4A90D9,stroke:#2C5F8A,color:#fff,font-weight:bold
+    classDef module fill:#E8F4FD,stroke:#4A90D9,color:#333
+    classDef infra fill:#FFF3E0,stroke:#E65100,color:#333
+    classDef bt fill:#6DB33F,stroke:#3B7A21,color:#fff,font-weight:bold
+
+    BT["bluetape4k libraries"]:::bt
+
+    subgraph DA["① Data Access"]
+        direction LR
+        exposed[exposed\nmvc-jdbc\nwebflux-r2dbc]:::module
+        springdata[spring-data\nr2dbc · jpa · mongodb\nelasticsearch]:::module
+    end
+
+    subgraph SB["② Spring Boot Ops"]
+        direction LR
+        cache[cache\ncaffeine · redis]:::module
+        resilience[resilience4j\ncoroutines]:::module
+        webflux[webflux\ncoroutines · websocket]:::module
+    end
+
+    subgraph SM["③ Serialization & Messaging"]
+        direction LR
+        json[json\njackson3 · jsonview]:::module
+        kafka[messaging\nkafka · reply]:::module
+    end
+
+    subgraph AR["④ Async & Reactive"]
+        direction LR
+        coroutines[kotlin\ncoroutines · patterns]:::module
+        vt[virtualthreads\nmvc · webflux]:::module
+        vertx[vertx\ncoroutines · sql · web]:::module
+    end
+
+    subgraph OB["⑤ Observability & Perf"]
+        direction LR
+        obs[observability\nbasic · advanced]:::module
+        gatling[gatling\nload simulation]:::module
+    end
+
+    subgraph AX["⑥ Architecture Extensions"]
+        direction LR
+        gw[gateway\napi-gateway]:::module
+        modulith[spring-modulith\nevents · jpa]:::module
+        sec[spring-security\nmvc · webflux]:::module
+        rl[ratelimit\nbucket4j]:::module
+        redis[redis\nredisson · lock]:::module
+        aws[aws\ns3-spring-cloud]:::module
+        leader[leader\nelection]:::module
+    end
+
+    subgraph INFRA["Infrastructure (Testcontainers)"]
+        direction LR
+        pg[(PostgreSQL)]:::infra
+        mongodb[(MongoDB)]:::infra
+        es[(Elasticsearch)]:::infra
+        redisdb[(Redis)]:::infra
+        kafkabroker([Kafka]):::infra
+        localstack([LocalStack]):::infra
+    end
+
+    BT --> DA
+    BT --> SB
+    BT --> SM
+    BT --> AR
+    BT --> OB
+    BT --> AX
+
+    exposed --> pg
+    springdata --> pg
+    springdata --> mongodb
+    springdata --> es
+    springdata --> redisdb
+    cache --> redisdb
+    kafka --> kafkabroker
+    obs --> pg
+    obs --> redisdb
+    redis --> redisdb
+    rl --> redisdb
+    leader --> redisdb
+    aws --> localstack
+    modulith --> pg
+```
+
+## C4 Context Diagram
+
+```mermaid
+C4Context
+    title bluetape4k-workshop — System Context
+
+    Person(dev, "Developer", "Learning bluetape4k library integration")
+    System(workshop, "bluetape4k-workshop", "Runnable backend examples across 6 domains")
+    System_Ext(bt, "bluetape4k libraries", "Core JVM backend library collection")
+    System_Ext(spring, "Spring Boot 4", "Application framework")
+    SystemDb_Ext(pg, "PostgreSQL", "Relational DB via Testcontainers")
+    SystemDb_Ext(redis, "Redis", "Cache / lock / pub-sub via Testcontainers")
+    SystemQueue_Ext(kafka, "Kafka", "Message broker via Testcontainers")
+    System_Ext(aws, "AWS / LocalStack", "Cloud services via Testcontainers")
+
+    Rel(dev, workshop, "Runs tests, studies code")
+    Rel(workshop, bt, "Uses library APIs")
+    Rel(workshop, spring, "Built on")
+    Rel(workshop, pg, "Persists data")
+    Rel(workshop, redis, "Caches / locks / pub-sub")
+    Rel(workshop, kafka, "Produces / consumes messages")
+    Rel(workshop, aws, "S3, parameter store")
+```

--- a/docs/lessons/2026-05-24-readme-diagrams-coverage-bundle.md
+++ b/docs/lessons/2026-05-24-readme-diagrams-coverage-bundle.md
@@ -1,0 +1,88 @@
+# Lessons — README, Diagrams, and Coverage Matrix Bundle
+
+**Date**: 2026-05-24  
+**Issues**: #90 (README rewrite), #89 (diagram asset convention), #92 (coverage matrix)  
+**Type**: Type-E Maintenance  
+**Branch**: `docs/issue-76-readme-diagrams-coverage`
+
+---
+
+## Root Cause / Motivation
+
+The previous root `README.md` was 93 lines of mostly Korean, with no module-level detail
+(difficulty, infra requirements, bluetape4k library mapping, run commands). New contributors
+and bluetape4k users had no quick way to choose a relevant starting example or understand
+coverage gaps.
+
+Additionally:
+- No convention existed for diagram naming or placement (`docs/assets/CONVENTIONS.md` absent).
+- No document mapped bluetape4k library → existing example → gap, making it hard to prioritize
+  new workshop modules.
+
+---
+
+## Decisions Made
+
+### README structure
+
+Chose a **6-domain catalog** (Data Access, Spring Boot Ops, Serialization/Messaging,
+Async/Reactive, Observability/Performance, Architecture Extensions) because:
+- Maps directly to open issues #79, #82, #83 (Basic) and future Advanced modules
+- Mirrors how the bluetape4k library groups are organized
+- Allows progressive learning: Basic → Advanced within each domain
+
+Each row in the catalog table shows: module name (linked), bluetape4k libs used,
+infra (TC = Testcontainers), and learning outcome. This replaces the generic
+directory listing that conveyed no learning value.
+
+### README.ko.md
+
+Created as a full Korean counterpart (not a translation wrapper). Per workspace CLAUDE.md:
+- `README.md` stays in English (contributor-facing)
+- `README.ko.md` serves Korean-speaking users
+- Both maintained in sync; future changes to one must mirror the other
+
+### docs/assets/CONVENTIONS.md
+
+Defined the `<scope>-<type>-<seq>.<ext>` naming pattern rather than ad-hoc names.
+Key decision: keep source files (`.drawio`, `.puml`, `.mmd`) committed alongside exports
+to prevent "diagram exists but can't be edited" technical debt.
+
+### Coverage matrix
+
+Tracked 30 bluetape4k libs. Result: 57% good coverage, 40% partial, 3% missing (idgenerators).
+This surfaces the concrete work for issues #62, #79, #82, #83 and informs Tier 2 priorities.
+
+---
+
+## Outcome
+
+| Artifact | Lines | Status |
+|----------|-------|--------|
+| `README.md` | 207 | ✅ Rewritten |
+| `README.ko.md` | 209 | ✅ Created |
+| `docs/assets/CONVENTIONS.md` | 101 | ✅ Created |
+| `docs/images/readme-diagrams/root-readme-architecture.md` | 92 | ✅ Created |
+| `docs/coverage-matrix.md` | 145 | ✅ Created |
+
+No code changes; Type-E — tests/compile not required.
+
+---
+
+## Future Guidance
+
+1. **Sync READMEs on every module add/remove**: when a new workshop module lands, add it to
+   both `README.md` and `README.ko.md` in the same PR. The table format makes it easy to
+   add one row without touching everything else.
+
+2. **Coverage matrix is a living document**: update `docs/coverage-matrix.md` when a
+   proposed scenario becomes an actual module. Move the row from "Proposed" to "Existing example"
+   and update the coverage level.
+
+3. **Diagram source files**: never commit only the PNG/SVG. Always commit the source
+   (`.drawio`, `.puml`, `.mmd`) so diagrams remain editable. The CONVENTIONS.md checklist
+   enforces this.
+
+4. **README.ko.md locale discipline**: the CLAUDE.md doc language policy allows Korean
+   user-facing README files. When making content changes, update both locales in the same PR
+   to prevent drift.


### PR DESCRIPTION
## Summary

Resolves #90, #89, #92 as a bundled Type-E docs PR.

### Changes

| File | Change |
|------|--------|
| `README.md` | Full rewrite — 6-domain catalog with Basic/Advanced module entries, bluetape4k lib mapping, infra requirements, run commands, learning outcomes |
| `README.ko.md` | New Korean locale counterpart of README.md |
| `docs/assets/CONVENTIONS.md` | Naming/format/tooling conventions for all visual assets |
| `docs/images/readme-diagrams/root-readme-architecture.md` | Mermaid source for root architecture overview + C4Context diagram |
| `docs/coverage-matrix.md` | 30-lib bluetape4k library → existing example → gap → proposed scenario matrix |
| `docs/lessons/2026-05-24-readme-diagrams-coverage-bundle.md` | Lessons doc |

### Domain Catalog (6 domains)

1. **Data Access** — Exposed, Spring Data (R2DBC, JPA, MongoDB, Elasticsearch)
2. **Spring Boot Ops** — Cache, Resilience4j, WebFlux, WebSocket, Chaos Monkey
3. **Serialization & Messaging** — Jackson 3, Kafka
4. **Async & Reactive** — Coroutines, Virtual Threads, Vert.x
5. **Observability & Performance** — Micrometer, Gatling
6. **Architecture Extensions** — Gateway, Modulith, Security, Redis, AWS, Rate Limiting, Leader Election

### Coverage Matrix Result (docs/coverage-matrix.md)

| Domain | Total | ✅ Good | ⚠️ Partial | ❌ Missing |
|--------|-------|---------|-----------|----------|
| Core | 6 | 5 | 1 | 0 |
| Data Access | 7 | 4 | 2 | 1 |
| Spring Boot | 3 | 1 | 2 | 0 |
| Messaging | 2 | 1 | 1 | 0 |
| Async/Reactive | 3 | 2 | 1 | 0 |
| Observability | 2 | 2 | 0 | 0 |
| Architecture/Infra | 7 | 2 | 5 | 0 |
| **Total** | **30** | **17 (57%)** | **12 (40%)** | **1 (3%)** |

### DoD Checklist

- [x] README.md rewritten with 6-domain catalog (closes #90)
- [x] README.ko.md created as Korean locale counterpart
- [x] docs/assets/CONVENTIONS.md defines diagram naming/placement convention (closes #89)
- [x] Mermaid architecture diagram source committed
- [x] docs/coverage-matrix.md maps 30 bluetape4k libs (closes #92)
- [x] Lessons doc committed before PR creation
- [x] No quarkus/reactive/mapping references in new README (removed per #78)
- [x] No code changes — compile/test not required (Type-E)