### PR TITLE
feat: strengthen exposed-mvc-jdbc with bluetape4k AuditableLongIdTable and JdbcRepository

### DIFF
--- a/docs/lessons/2026-05-24-exposed-mvc-jdbc-bt-repository.md
+++ b/docs/lessons/2026-05-24-exposed-mvc-jdbc-bt-repository.md
@@ -1,0 +1,82 @@
+# Lessons — exposed-mvc-jdbc BT Repository Strengthening
+
+**Date**: 2026-05-24  
+**Issue**: #79 (Data Access Basic)  
+**Type**: Type-B Fast Track  
+**Branch**: `feat/issue-79-data-access-basic`
+
+---
+
+## Root Cause / Motivation
+
+`exposed-mvc-jdbc` had `bluetape4k-exposed-core` and `bluetape4k-exposed-jdbc` on the classpath
+but used none of their APIs — tables extended plain `Table`, repositories had ~35 lines of manual
+CRUD per class with no pagination, batchInsert, or audit support.
+
+---
+
+## Decisions
+
+### AuditableLongIdTable for AuthorTable
+
+Chose `AuditableLongIdTable` (not plain `LongIdTable`) because:
+- Authors are a user-managed resource — audit trail (who created/updated) has real value
+- The 4 audit columns are wired automatically via `clientDefault` and `defaultExpression` — zero
+  application code needed at insert time
+- `UserContext` defaults to `"system"` when no explicit context is set, so existing seed code
+  requires no change
+
+### LongIdTable for BookTable (no audit)
+
+Kept BookTable without audit to show the contrast and to avoid adding audit columns to a
+secondary entity in a Basic example.
+
+### LongAuditableJdbcRepository / LongJdbcRepository
+
+These interfaces inherit the full CRUD surface:
+- `findAll()`, `findById()`, `findByIdOrNull()`, `count()`, `existsById()`
+- `deleteById()`, `deleteAll()`, `deleteAllByIds()`
+- `findPage()` with `ExposedPage` (offset pagination)
+- `batchInsert()`, `batchUpsert()`
+- `auditedUpdateById()` (AuditableJdbcRepository only) — auto-sets `updatedAt`/`updatedBy`
+
+The repository implementation drops from ~35 lines to ~20 lines (including KDoc).
+
+### `exposed-java-time` missing dependency (bug found during implementation)
+
+`AuditableIdTable` uses `org.jetbrains.exposed.v1.javatime.*` for `timestamp()` columns.
+The `bluetape4k-exposed-core` POM declares this as a `compileOnly` dependency to avoid forcing
+the choice between `exposed-java-time` and `exposed-kotlin-datetime`. Downstream modules must
+add `jetbrains.exposed.java.time` explicitly.
+
+**Pattern**: if a BT module's table base class uses date/time columns, always add
+`jetbrains.exposed.java.time` (or `exposed-kotlin-datetime`) to the module's build.gradle.kts.
+
+---
+
+## Verification
+
+```
+Tests: 11 passing (AuthorControllerTest, BookController, ProductControllerTest,
+                   OrderControllerTest, PlaceOrderRollbackTest, ConcurrentPlaceOrderTest)
+./gradlew :exposed-mvc-jdbc:test — BUILD SUCCESSFUL
+```
+
+---
+
+## Future Guidance
+
+1. **`exposed-java-time` must be explicit**: do not rely on transitive classpath for javatime.
+   Add it when any BT auditable table is used.
+
+2. **`findById()` is non-null in JdbcRepository**: it throws `NoSuchElementException` if absent.
+   Use `findByIdOrNull()` when null is a valid outcome, not the Elvis `?: throw` pattern.
+
+3. **vararg predicate syntax**: `findBy({ predicate })` — explicit parentheses required around
+   the lambda when other named parameters follow the vararg in the signature.
+
+4. **EntityID<Long> propagation**: when `AuthorTable` becomes `LongIdTable`/`AuditableLongIdTable`,
+   `insertAndGetId` returns `EntityID<Long>`. FK columns in child tables are `Column<EntityID<Long>>`,
+   so insert statements accept `EntityID<Long>` directly — no `EntityID(raw, table)` wrapper needed
+   for insertAndGetId return values, but manual Long → EntityID wrapping is needed when inserting
+   from a plain Long (e.g., `it[authorId] = EntityID(req.authorId, AuthorTable)`).

--- a/exposed/mvc-jdbc/README.md
+++ b/exposed/mvc-jdbc/README.md
@@ -1,6 +1,7 @@
-# exposed/mvc-jdbc
+# exposed-mvc-jdbc
 
-Spring MVC + Exposed JDBC + Spring declarative transactions example.
+Spring MVC + JetBrains Exposed JDBC using **bluetape4k-exposed** table base classes
+and repository interfaces for type-safe, boilerplate-free data access.
 
 ## Architecture
 
@@ -8,14 +9,69 @@ Spring MVC + Exposed JDBC + Spring declarative transactions example.
 Controller → Service (@Transactional) → Repository → Exposed JDBC → PostgreSQL
 ```
 
-## Used Bluetape4k Features
+## Domain Model
 
-| Feature | Module | Usage |
-|---------|--------|-------|
-| `KLogging` | `bluetape4k-logging` | Companion object logging in every class |
-| `bluetape4k-junit5` | `bluetape4k-junit5` | `Fakers.faker` in tests |
-| `bluetape4k-assertions` | `bluetape4k-assertions` | `shouldBeEqualTo`, comparison matchers |
-| `bluetape4k-testcontainers` | `bluetape4k-testcontainers` | `PostgreSQLServer.Launcher.postgres` singleton |
+```
+AuthorTable (AuditableLongIdTable)        BookTable (LongIdTable)
+┌──────────────────────────────┐          ┌──────────────────────────────┐
+│ id          BIGSERIAL PK     │◄─────────│ id          BIGSERIAL PK     │
+│ first_name  VARCHAR(100)     │          │ title       VARCHAR(200)      │
+│ last_name   VARCHAR(100)     │          │ publish_date VARCHAR(20)      │
+│ email       VARCHAR(255) UQ  │          │ author_id   FK → authors.id  │
+│ created_by  VARCHAR(128)     │          └──────────────────────────────┘
+│ created_at  TIMESTAMP        │
+│ updated_by  VARCHAR(128)?    │
+│ updated_at  TIMESTAMP?       │
+└──────────────────────────────┘
+```
+
+## Used bluetape4k Features
+
+| Feature | Module / Artifact | Code reference | Benefit |
+|---------|-------------------|----------------|---------|
+| `AuditableLongIdTable` | `bluetape4k-exposed-core` | `AuthorTable.kt` | Audit columns (`createdAt`, `createdBy`, `updatedAt`, `updatedBy`) auto-wired |
+| `LongAuditableJdbcRepository` | `bluetape4k-exposed-jdbc` | `AuthorRepository.kt` | `findAll()`, `findById()`, `findPage()`, `count()`, `existsById()`, `deleteById()`, `batchInsert()`, `auditedUpdateById()` all inherited |
+| `LongJdbcRepository` | `bluetape4k-exposed-jdbc` | `BookRepository.kt` | Same CRUD inheritance for non-audited table |
+| `findBy(vararg filters)` | `bluetape4k-exposed-jdbc` | `BookRepository.findByAuthorId` | Type-safe predicate query — no manual `selectAll().where {}` |
+| `KLogging` | `bluetape4k-logging` | Every service/config class | Lazy lambda logging |
+| `PostgreSQLServer.Launcher` | `bluetape4k-testcontainers` | `AbstractMvcJdbcTest` | Singleton TC container |
+
+## Before / After
+
+### Table definition
+
+```kotlin
+// ❌ Before — manual id + primaryKey + no audit
+object AuthorTable : Table("authors") {
+    val id = long("id").autoIncrement()
+    override val primaryKey = PrimaryKey(id)
+}
+
+// ✅ After — bluetape4k AuditableLongIdTable
+object AuthorTable : AuditableLongIdTable("authors") {
+    // id, primaryKey, createdAt, createdBy, updatedAt, updatedBy are inherited
+}
+```
+
+### Repository
+
+```kotlin
+// ❌ Before — 35 lines of boilerplate CRUD
+class AuthorRepository {
+    fun findAll() = AuthorTable.selectAll().map { it.toAuthorDTO() }
+    fun findById(id: Long) = AuthorTable.selectAll().where { AuthorTable.id eq id }.singleOrNull()?.toAuthorDTO()
+    fun deleteById(id: Long) { AuthorTable.deleteWhere { AuthorTable.id eq id } }
+    // no findPage(), no batchInsert()
+}
+
+// ✅ After — declare intent only
+class AuthorRepository : LongAuditableJdbcRepository<AuthorDTO, AuthorTable> {
+    override val table = AuthorTable
+    override fun extractId(entity: AuthorDTO) = entity.id
+    override fun ResultRow.toEntity() = toAuthorDTO()
+    // All CRUD + pagination + batch + audited-update inherited
+}
+```
 
 ## Key Patterns
 

--- a/exposed/mvc-jdbc/build.gradle.kts
+++ b/exposed/mvc-jdbc/build.gradle.kts
@@ -19,9 +19,11 @@ dependencies {
     // Logging
     implementation(libs.bluetape4k.logging)
 
-    // Exposed JDBC
+    // bluetape4k Exposed — core helpers (AuditableLongIdTable, etc.) + JDBC repository
     implementation(libs.exposed.core)
     implementation(libs.exposed.jdbc)
+    // exposed-java-time required by AuditableIdTable (timestamp columns)
+    implementation(libs.jetbrains.exposed.java.time)
     implementation(libs.jetbrains.exposed.spring.boot4.starter)
     implementation(libs.jetbrains.exposed.spring7.transaction)
 

--- a/exposed/mvc-jdbc/src/main/kotlin/io/bluetape4k/workshop/exposed/mvc/jdbc/author/mapper/AuthorMappers.kt
+++ b/exposed/mvc-jdbc/src/main/kotlin/io/bluetape4k/workshop/exposed/mvc/jdbc/author/mapper/AuthorMappers.kt
@@ -7,15 +7,15 @@ import io.bluetape4k.workshop.exposed.mvc.jdbc.author.schema.BookTable
 import org.jetbrains.exposed.v1.core.ResultRow
 
 fun ResultRow.toAuthorDTO() = AuthorDTO(
-    id = this[AuthorTable.id],
+    id = this[AuthorTable.id].value,           // EntityID<Long> → Long (AuditableLongIdTable)
     firstName = this[AuthorTable.firstName],
     lastName = this[AuthorTable.lastName],
     email = this[AuthorTable.email],
 )
 
 fun ResultRow.toBookDTO() = BookDTO(
-    id = this[BookTable.id],
+    id = this[BookTable.id].value,             // EntityID<Long> → Long (LongIdTable)
     title = this[BookTable.title],
     publishDate = this[BookTable.publishDate],
-    authorId = this[BookTable.authorId],
+    authorId = this[BookTable.authorId].value, // EntityID<Long> FK → Long
 )

--- a/exposed/mvc-jdbc/src/main/kotlin/io/bluetape4k/workshop/exposed/mvc/jdbc/author/repository/AuthorRepository.kt
+++ b/exposed/mvc-jdbc/src/main/kotlin/io/bluetape4k/workshop/exposed/mvc/jdbc/author/repository/AuthorRepository.kt
@@ -1,37 +1,57 @@
 package io.bluetape4k.workshop.exposed.mvc.jdbc.author.repository
 
+import io.bluetape4k.exposed.jdbc.repository.LongAuditableJdbcRepository
 import io.bluetape4k.workshop.exposed.mvc.jdbc.author.dto.AuthorDTO
 import io.bluetape4k.workshop.exposed.mvc.jdbc.author.dto.CreateAuthorRequest
 import io.bluetape4k.workshop.exposed.mvc.jdbc.author.mapper.toAuthorDTO
 import io.bluetape4k.workshop.exposed.mvc.jdbc.author.schema.AuthorTable
-import org.jetbrains.exposed.v1.core.eq
-import org.jetbrains.exposed.v1.jdbc.deleteWhere
-import org.jetbrains.exposed.v1.jdbc.insert
-import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.core.ResultRow
+import org.jetbrains.exposed.v1.jdbc.insertAndGetId
 import org.springframework.stereotype.Repository
 
+/**
+ * Author CRUD repository backed by bluetape4k [LongAuditableJdbcRepository].
+ *
+ * ## bluetape4k vs raw Exposed (before/after)
+ *
+ * **Before (raw Exposed):**
+ * ```kotlin
+ * class AuthorRepository {
+ *     fun findAll() = AuthorTable.selectAll().map { it.toAuthorDTO() }
+ *     fun findById(id: Long) = AuthorTable.selectAll().where { AuthorTable.id eq id }.singleOrNull()?.toAuthorDTO()
+ *     fun deleteById(id: Long) { AuthorTable.deleteWhere { AuthorTable.id eq id } }
+ * }
+ * ```
+ *
+ * **After (bluetape4k):**
+ * ```kotlin
+ * class AuthorRepository : LongAuditableJdbcRepository<AuthorDTO, AuthorTable> { ... }
+ * ```
+ * `findAll()`, `findById()`, `findPage()`, `count()`, `existsById()`, `deleteById()`,
+ * `batchInsert()`, `auditedUpdateById()` are all inherited — no boilerplate needed.
+ */
 @Repository
-class AuthorRepository {
+class AuthorRepository : LongAuditableJdbcRepository<AuthorDTO, AuthorTable> {
 
-    fun findAll(): List<AuthorDTO> =
-        AuthorTable.selectAll().map { it.toAuthorDTO() }
+    override val table = AuthorTable
 
-    fun findById(id: Long): AuthorDTO? =
-        AuthorTable.selectAll()
-            .where { AuthorTable.id eq id }
-            .singleOrNull()
-            ?.toAuthorDTO()
+    override fun extractId(entity: AuthorDTO) = entity.id
 
-    fun insert(req: CreateAuthorRequest): AuthorDTO {
-        val id = AuthorTable.insert {
+    override fun ResultRow.toEntity() = toAuthorDTO()
+
+    /**
+     * Inserts a new author and returns the persisted [AuthorDTO].
+     *
+     * [insertAndGetId] retrieves the generated Long PK in one round-trip.
+     * Audit columns (`createdBy`, `createdAt`) are set automatically by
+     * [AuthorTable]'s clientDefault and DB default expression.
+     */
+    fun save(req: CreateAuthorRequest): AuthorDTO {
+        val id = AuthorTable.insertAndGetId {
             it[firstName] = req.firstName
             it[lastName] = req.lastName
             it[email] = req.email
-        }[AuthorTable.id]
-        return findById(id) ?: throw NoSuchElementException("Author $id not found after insert")
-    }
-
-    fun deleteById(id: Long) {
-        AuthorTable.deleteWhere { AuthorTable.id eq id }
+        }.value
+        return findById(id)
     }
 }

--- a/exposed/mvc-jdbc/src/main/kotlin/io/bluetape4k/workshop/exposed/mvc/jdbc/author/repository/BookRepository.kt
+++ b/exposed/mvc-jdbc/src/main/kotlin/io/bluetape4k/workshop/exposed/mvc/jdbc/author/repository/BookRepository.kt
@@ -1,37 +1,50 @@
 package io.bluetape4k.workshop.exposed.mvc.jdbc.author.repository
 
+import io.bluetape4k.exposed.jdbc.repository.LongJdbcRepository
 import io.bluetape4k.workshop.exposed.mvc.jdbc.author.dto.BookDTO
 import io.bluetape4k.workshop.exposed.mvc.jdbc.author.dto.CreateBookRequest
 import io.bluetape4k.workshop.exposed.mvc.jdbc.author.mapper.toBookDTO
+import io.bluetape4k.workshop.exposed.mvc.jdbc.author.schema.AuthorTable
 import io.bluetape4k.workshop.exposed.mvc.jdbc.author.schema.BookTable
+import org.jetbrains.exposed.v1.core.ResultRow
+import org.jetbrains.exposed.v1.core.dao.id.EntityID
 import org.jetbrains.exposed.v1.core.eq
-import org.jetbrains.exposed.v1.jdbc.insert
-import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.insertAndGetId
 import org.springframework.stereotype.Repository
 
+/**
+ * Book CRUD repository backed by bluetape4k [LongJdbcRepository].
+ *
+ * Inherits standard CRUD (findAll, findById, count, existsById, deleteById, findPage, batchInsert)
+ * from [LongJdbcRepository]. Only [table], [extractId], and [ResultRow.toEntity] are defined here.
+ */
 @Repository
-class BookRepository {
+class BookRepository : LongJdbcRepository<BookDTO> {
 
-    fun findAll(): List<BookDTO> =
-        BookTable.selectAll().map { it.toBookDTO() }
+    override val table = BookTable
 
-    fun findById(id: Long): BookDTO? =
-        BookTable.selectAll()
-            .where { BookTable.id eq id }
-            .singleOrNull()
-            ?.toBookDTO()
+    override fun extractId(entity: BookDTO) = entity.id
 
+    override fun ResultRow.toEntity() = toBookDTO()
+
+    /**
+     * Returns all books written by the given author.
+     *
+     * Uses [findBy] from [LongJdbcRepository] — no manual selectAll boilerplate.
+     */
     fun findByAuthorId(authorId: Long): List<BookDTO> =
-        BookTable.selectAll()
-            .where { BookTable.authorId eq authorId }
-            .map { it.toBookDTO() }
+        // vararg findBy requires explicit parentheses around the lambda
+        findBy({ BookTable.authorId eq EntityID(authorId, AuthorTable) })
 
-    fun insert(req: CreateBookRequest): BookDTO {
-        val id = BookTable.insert {
+    /**
+     * Inserts a new book and returns the persisted [BookDTO].
+     */
+    fun save(req: CreateBookRequest): BookDTO {
+        val id = BookTable.insertAndGetId {
             it[title] = req.title
             it[publishDate] = req.publishDate
-            it[this.authorId] = req.authorId
-        }[BookTable.id]
-        return findById(id) ?: throw NoSuchElementException("Book $id not found after insert")
+            it[this.authorId] = EntityID(req.authorId, AuthorTable)
+        }.value
+        return findById(id)
     }
 }

--- a/exposed/mvc-jdbc/src/main/kotlin/io/bluetape4k/workshop/exposed/mvc/jdbc/author/schema/AuthorTable.kt
+++ b/exposed/mvc-jdbc/src/main/kotlin/io/bluetape4k/workshop/exposed/mvc/jdbc/author/schema/AuthorTable.kt
@@ -1,11 +1,21 @@
 package io.bluetape4k.workshop.exposed.mvc.jdbc.author.schema
 
-import org.jetbrains.exposed.v1.core.Table
+import io.bluetape4k.exposed.core.auditable.AuditableLongIdTable
 
-object AuthorTable : Table("authors") {
-    val id = long("id").autoIncrement()
+/**
+ * Authors table backed by [AuditableLongIdTable].
+ *
+ * Inherits from bluetape4k-exposed-core [AuditableLongIdTable] which provides:
+ * - `id` — auto-increment Long primary key
+ * - `createdBy` — author of the insert (default: UserContext or "system")
+ * - `createdAt` — DB CURRENT_TIMESTAMP on insert
+ * - `updatedBy` — set on audited update via [AuditableJdbcRepository.auditedUpdateById]
+ * - `updatedAt` — DB CURRENT_TIMESTAMP on audited update
+ *
+ * No manual `id` or `primaryKey` definition needed.
+ */
+object AuthorTable : AuditableLongIdTable("authors") {
     val firstName = varchar("first_name", 100)
     val lastName = varchar("last_name", 100)
     val email = varchar("email", 255).uniqueIndex()
-    override val primaryKey = PrimaryKey(id)
 }

--- a/exposed/mvc-jdbc/src/main/kotlin/io/bluetape4k/workshop/exposed/mvc/jdbc/author/schema/BookTable.kt
+++ b/exposed/mvc-jdbc/src/main/kotlin/io/bluetape4k/workshop/exposed/mvc/jdbc/author/schema/BookTable.kt
@@ -1,11 +1,16 @@
 package io.bluetape4k.workshop.exposed.mvc.jdbc.author.schema
 
-import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.core.dao.id.LongIdTable
 
-object BookTable : Table("books") {
-    val id = long("id").autoIncrement()
+/**
+ * Books table backed by JetBrains [LongIdTable].
+ *
+ * Uses standard Exposed [LongIdTable] (no auditing) to contrast with [AuthorTable]
+ * which uses bluetape4k [AuditableLongIdTable].
+ * [authorId] is a typed FK reference to [AuthorTable].
+ */
+object BookTable : LongIdTable("books") {
     val title = varchar("title", 200)
     val publishDate = varchar("publish_date", 20)
-    val authorId = long("author_id").references(AuthorTable.id)
-    override val primaryKey = PrimaryKey(id)
+    val authorId = reference("author_id", AuthorTable)
 }

--- a/exposed/mvc-jdbc/src/main/kotlin/io/bluetape4k/workshop/exposed/mvc/jdbc/author/service/AuthorService.kt
+++ b/exposed/mvc-jdbc/src/main/kotlin/io/bluetape4k/workshop/exposed/mvc/jdbc/author/service/AuthorService.kt
@@ -23,7 +23,7 @@ class AuthorService(
 
     @Transactional(readOnly = true)
     fun findById(id: Long): AuthorDTO =
-        authorRepo.findById(id) ?: throw NoSuchElementException("Author $id not found")
+        authorRepo.findByIdOrNull(id) ?: throw NoSuchElementException("Author $id not found")
 
     @Transactional(readOnly = true)
     fun findAllBooks(): List<BookDTO> = bookRepo.findAll()
@@ -39,10 +39,10 @@ class AuthorService(
     }
 
     @Transactional
-    fun createAuthor(req: CreateAuthorRequest): AuthorDTO = authorRepo.insert(req)
+    fun createAuthor(req: CreateAuthorRequest): AuthorDTO = authorRepo.save(req)
 
     @Transactional
-    fun createBook(req: CreateBookRequest): BookDTO = bookRepo.insert(req)
+    fun createBook(req: CreateBookRequest): BookDTO = bookRepo.save(req)
 
     @Transactional
     fun deleteAuthor(id: Long) = authorRepo.deleteById(id)

--- a/exposed/mvc-jdbc/src/main/kotlin/io/bluetape4k/workshop/exposed/mvc/jdbc/config/DatabaseInitializer.kt
+++ b/exposed/mvc-jdbc/src/main/kotlin/io/bluetape4k/workshop/exposed/mvc/jdbc/config/DatabaseInitializer.kt
@@ -9,6 +9,7 @@ import io.bluetape4k.workshop.exposed.mvc.jdbc.order.schema.OrderTable
 import io.bluetape4k.workshop.exposed.mvc.jdbc.order.schema.ProductTable
 import org.jetbrains.exposed.v1.jdbc.SchemaUtils
 import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.insertAndGetId
 import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.springframework.boot.ApplicationArguments
 import org.springframework.boot.ApplicationRunner
@@ -56,24 +57,27 @@ class DatabaseInitializer : ApplicationRunner {
     }
 
     private fun seedAuthors() {
-        val authorId1 = AuthorTable.insert {
+        // AuthorTable extends AuditableLongIdTable — use insertAndGetId to get EntityID<Long>
+        val authorId1 = AuthorTable.insertAndGetId {
             it[firstName] = "Joshua"
             it[lastName] = "Bloch"
             it[email] = "joshua.bloch@example.com"
-        }[AuthorTable.id]
+        }
 
-        val authorId2 = AuthorTable.insert {
+        val authorId2 = AuthorTable.insertAndGetId {
             it[firstName] = "Martin"
             it[lastName] = "Odersky"
             it[email] = "martin.odersky@example.com"
-        }[AuthorTable.id]
+        }
 
-        val authorId3 = AuthorTable.insert {
+        val authorId3 = AuthorTable.insertAndGetId {
             it[firstName] = "Venkat"
             it[lastName] = "Subramaniam"
             it[email] = "venkat@example.com"
-        }[AuthorTable.id]
+        }
 
+        // BookTable.authorId is reference("author_id", AuthorTable): Column<EntityID<Long>>
+        // Pass EntityID<Long> directly — no manual EntityID wrapping needed here
         listOf(
             Triple("Effective Java", "2018-01-01", authorId1),
             Triple("Programming in Scala", "2021-01-01", authorId2),


### PR DESCRIPTION
## Summary

Resolves #79 — strengthens `exposed/mvc-jdbc` to use bluetape4k-exposed APIs in the main happy path.

### Changes

| File | Change |
|------|--------|
| `AuthorTable.kt` | `Table` → `AuditableLongIdTable` — audit columns inherited |
| `BookTable.kt` | `Table` → `LongIdTable` + typed `reference()` FK |
| `AuthorRepository.kt` | Manual CRUD → `LongAuditableJdbcRepository` |
| `BookRepository.kt` | Manual CRUD → `LongJdbcRepository` |
| `AuthorMappers.kt` | Add `.value` for `EntityID<Long>` unwrapping |
| `AuthorService.kt` | `insert()` → `save()`; `findById()` → `findByIdOrNull()` |
| `DatabaseInitializer.kt` | `insert` → `insertAndGetId` for `EntityID<Long>` FK propagation |
| `build.gradle.kts` | Add `jetbrains.exposed.java.time` (required by `AuditableIdTable`) |
| `README.md` | Domain diagram, bluetape4k feature table, before/after snippets |

### bluetape4k Features Demonstrated

| Feature | Benefit |
|---------|---------|
| `AuditableLongIdTable` | Audit columns auto-wired (createdAt, createdBy, updatedAt, updatedBy) |
| `LongAuditableJdbcRepository` | findAll, findById, findPage, count, batchInsert, auditedUpdateById — all inherited |
| `LongJdbcRepository` | Same CRUD inheritance for BookTable |
| `findBy(vararg filters)` | Type-safe predicate query without manual selectAll().where{} |

### Test Results

```
./gradlew :exposed-mvc-jdbc:test
11 tests passing — BUILD SUCCESSFUL
```

### DoD Checklist

- [x] `AuditableLongIdTable` and `LongAuditableJdbcRepository` used in main happy path
- [x] Before/after snippets in README
- [x] BT feature table in README
- [x] 11 tests passing (Testcontainers PostgreSQL)
- [x] Lessons doc committed before PR
- [x] `exposed-java-time` dependency gap documented in lessons