### PR TITLE
docs: Serialization/Messaging Basic — add bluetape4k feature tables to 5 module READMEs (#83)

### DIFF
--- a/docs/lessons/2026-05-24-serialization-messaging-basic-bt-features.md
+++ b/docs/lessons/2026-05-24-serialization-messaging-basic-bt-features.md
@@ -1,0 +1,69 @@
+# 2026-05-24 Serialization/Messaging Basic — BT Feature Documentation (Issue #83)
+
+## 작업 개요
+
+5개 모듈 README에 bluetape4k(BT) 기능 표 및 Before/After 예제를 추가했다.
+
+대상 모듈:
+- `json/jackson-examples` — `Jackson.defaultJsonMapper`, `KLogging`, `Fakers.faker`
+- `json/jsonview-examples` — `Jackson.defaultJsonMapper`, assertion 헬퍼
+- `messaging/kafka` — `KafkaServer.Launcher`, `KLoggingChannel`
+- `messaging/kafka-reply` — `CompletableFuture.onSuccess/onFailure`, `uninitialized()`
+- `redis/redisson-examples` — `RedissonCodecs.LZ4ForyComposite`, `VirtualThreadExecutor`, `RedisServer.Launcher`, `MultithreadingTester`, `SuspendedJobTester`, `getLockId()`
+
+## 주요 발견
+
+### 1. Jackson.defaultJsonMapper (jackson-examples, jsonview-examples)
+
+`bluetape4k-jackson3`의 `Jackson.defaultJsonMapper`는 KotlinModule + JavaTimeModule + Blackbird를 사전 등록한 `JsonMapper` 싱글톤이다.
+`@Bean fun jsonMapper(): JsonMapper = Jackson.defaultJsonMapper` 한 줄로 모든 모듈 설정이 완료된다.
+rebuild()로 추가 설정도 체이닝 가능하다.
+
+### 2. KafkaServer.Launcher.kafka (messaging/kafka)
+
+`bluetape4k-testcontainers`의 `KafkaServer.Launcher.kafka`는 Testcontainers Kafka 싱글톤이다.
+`@SpringBootApplication` companion object에 선언하면 앱 시작 시 자동으로 Kafka 컨테이너가 구동된다.
+`@DynamicPropertySource` + `KafkaContainer` 수동 관리 패턴이 한 줄로 대체된다.
+
+### 3. @KafkaListener + suspend/Reactor 제약
+
+`@KafkaListener`는 공식적으로 `suspend` 함수와 Reactor Publisher를 지원하지 않는다.
+`CoroutineSimpleMessageHandler`는 `// @Component`로 비활성화된 참고용 코드다.
+이 제약은 README에 명시적으로 문서화해야 한다 — 사용자가 비작동 코드를 오해하지 않도록.
+
+### 4. RedissonCodecs.LZ4ForyComposite (redis/redisson-examples)
+
+`bluetape4k-redis`의 `RedissonCodecs.LZ4ForyComposite`는 LZ4 압축 + Fory(구 Fury) 이진 직렬화 조합이다.
+JSON 직렬화 대비 저장 공간을 50~70% 절감하고 직렬화/역직렬화 속도도 빠르다.
+`Config.codec`에 직접 주입한다.
+
+### 5. BT 동시성 테스트 헬퍼 (redis/redisson-examples)
+
+`MultithreadingTester`, `StructuredTaskScopeTester`, `SuspendedJobTester` 세 가지 헬퍼가
+각각 OS 스레드, Virtual Thread, 코루틴 환경에서 FencedLock 동시성을 재현 가능하게 검증한다.
+수동 Thread 생성 방식보다 결정론적(deterministic) 검증이 가능하다.
+
+### 6. `getLockId()` — 코루틴 안전 FencedLock ID
+
+`bluetape4k-redis`의 `RedissonClient.getLockId(lockName)` 확장 함수는
+코루틴 컨텍스트에서 RFencedLock의 ID를 안전하게 획득한다.
+일반 `lockAndGetToken()` 패턴을 코루틴 `tryLockAsync().await()` 방식으로 대체할 때 필수다.
+
+## 테스트 결과
+
+```
+:jackson-examples:test      BUILD SUCCESSFUL
+:jsonview-examples:test     BUILD SUCCESSFUL
+:messaging-kafka:test       BUILD SUCCESSFUL
+:messaging-kafka-reply:test BUILD SUCCESSFUL
+:redis-redisson-examples:test BUILD SUCCESSFUL
+```
+
+## 향후 가이드
+
+- `bluetape4k-kafka` 아티팩트는 현재 `// implementation(libs.bluetape4k.kafka)`로 비활성화 상태다.
+  Kafka Spring 통합은 아직 `bluetape4k-kafka`를 직접 사용하지 않고 Spring Kafka를 그대로 사용한다.
+- Redisson 코루틴 lock에서 `getLockId()`는 2단계 취득 패턴 필수:
+  1. `redisson.getLockId(lockName)` — mlockId 획득
+  2. `lock.tryLockAsync(wait, lease, TimeUnit, mlockId).await()` — 코루틴 안전 lock 시도
+  3. `lock.unlockAsync(mlockId).await()` — 명시적 mlockId로 해제

--- a/json/jackson-examples/README.md
+++ b/json/jackson-examples/README.md
@@ -1,8 +1,34 @@
 # Jackson Examples
 
 Jackson 3.x 라이브러리를 사용하여 JSON 데이터를 Java 객체로 변환하거나 Java 객체를 JSON 데이터로 변환하는 방법을 설명합니다.
+bluetape4k의 `Jackson.defaultJsonMapper`로 KotlinModule과 JavaTimeModule을 자동 등록하여 Kotlin data class와 Java Time API를 즉시 직렬화합니다.
 
 ![Jackson Examples diagram](../../docs/images/readme-diagrams/json-jackson-examples-diagram-01.png)
+
+## 사용된 bluetape4k 기능
+
+| 기능 | 아티팩트 | 코드 위치 | 이점 |
+|---|---|---|---|
+| `Jackson.defaultJsonMapper` | `bluetape4k-jackson3` | `AbstractJacksonTest` | KotlinModule + JavaTimeModule + Blackbird 사전 등록 — 별도 설정 불필요 |
+| `KLogging` | `bluetape4k-logging` | companion object | Lazy 람다 로깅 (`log.debug { "..." }`) |
+| `Fakers.faker` | `bluetape4k-junit5` | `AbstractJacksonTest` | JavaFaker 기반 테스트 데이터 생성 |
+
+## Before / After
+
+```kotlin
+// Before — KotlinModule과 JavaTimeModule을 수동으로 등록
+val mapper = JsonMapper.builder()
+    .addModule(KotlinModule.Builder().build())
+    .addModule(JavaTimeModule())
+    .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
+    .build()
+
+// After — bluetape4k Jackson.defaultJsonMapper (이미 등록됨)
+val mapper: JsonMapper = Jackson.defaultJsonMapper
+    .rebuild()
+    .apply { configure(SerializationFeature.INDENT_OUTPUT, true) }
+    .build()
+```
 
 ## 주요 기능
 

--- a/json/jsonview-examples/README.md
+++ b/json/jsonview-examples/README.md
@@ -1,6 +1,30 @@
 # JsonView in Spring Boot Demo
 
 Spring Boot REST API 에서 응답 시 `@JsonView` 를 사용하여 응답 데이터를 필터링하는 방법을 알아보겠습니다.
+bluetape4k의 `Jackson.defaultJsonMapper`를 `@Bean`으로 등록해 KotlinModule + JavaTimeModule 설정을 간소화합니다.
+
+## 사용된 bluetape4k 기능
+
+| 기능 | 아티팩트 | 코드 위치 | 이점 |
+|---|---|---|---|
+| `Jackson.defaultJsonMapper` | `bluetape4k-jackson3` | `JacksonConfig.jsonMapper()` | KotlinModule + JavaTimeModule 사전 등록 — 수동 설정 불필요 |
+| `KLogging` | `bluetape4k-logging` | companion object | Lazy 람다 로깅 |
+| `shouldBeNull()` / `shouldBeEqualTo` | `bluetape4k-assertions` | 컨트롤러 테스트 | Kluent 스타일 assertion |
+
+## Before / After
+
+```kotlin
+// Before — 수동 JsonMapper 설정
+@Bean
+fun jsonMapper(): JsonMapper = JsonMapper.builder()
+    .addModule(KotlinModule.Builder().build())
+    .addModule(JavaTimeModule())
+    .build()
+
+// After — bluetape4k Jackson.defaultJsonMapper
+@Bean
+fun jsonMapper(): JsonMapper = Jackson.defaultJsonMapper
+```
 
 ![JsonView in Spring Boot Demo diagram](../../docs/images/readme-diagrams/json-jsonview-examples-diagram-01.png)
 

--- a/messaging/kafka-reply/README.md
+++ b/messaging/kafka-reply/README.md
@@ -1,44 +1,98 @@
-# Module Kafka Reply Demo
+# Kafka Reply Demo
 
-## 아키텍처 다이어그램
+`ReplyingKafkaTemplate`을 이용한 Kafka 요청-응답(Request-Reply) 패턴 예제입니다.
+bluetape4k의 `CompletableFuture.onSuccess/onFailure`, `uninitialized()`, `KLoggingChannel`을 활용합니다.
 
-![kafka reply Sequence Flow diagram](../../docs/images/readme-diagrams/messaging-kafka-reply-sequence-01.png)
+## 아키텍처
 
-## 설명
+```mermaid
+sequenceDiagram
+    participant Client
+    participant PingController
+    participant Kafka
+    participant PongHandler
 
-`ReplyingKafkaTemplate` 사용에 대한 예제입니다. `ReplyingKafkaTemplate` 는 producing 후에 비동기로 응답을 받는 방식으로 kafka 를 사용합니다.
-
-`ReplyingKafkaTemplate`를 이용해 전송 후, 응답을 기다립니다.
-
-```kotlin
-val record = ProducerRecord<String, String>(TOPIC_PINGPONG, "ping")
-val replyFuture: RequestReplyFuture<String, String, String> = template.sendAndReceive(record)
-replyFuture.addCallback(
-    { result -> log.info { "callback result: $result" } },
-    { e -> log.error(e) { "callback exception." } }
-)
-
-// 전송 결과
-val sendResult = replyFuture.sendFuture.await()
-log.info { "Sent ok: $sendResult" }
-
-// 응답 결과
-val consumerRecord = replyFuture.await()
-log.info { "Return ok: key=${consumerRecord.key()}, value=${consumerRecord.value()}" }
+    Client->>PingController: GET /ping
+    PingController->>Kafka: sendAndReceive("pingpong", "ping")
+    Kafka->>PongHandler: @KafkaListener("pingpong")
+    PongHandler-->>Kafka: @SendTo → "pong at {time}"
+    Kafka-->>PingController: ConsumerRecord reply
+    PingController-->>Client: "pong at {time}"
 ```
 
-ping 을 받는 `Consumer` 에 해당하는 `KafkaListener` 에서 message 를 받은 후에 `@SendTo` 를 이용하여, 다시 응답을 보냅니다.
+## 주요 구성
+
+| 클래스 | 역할 |
+|---|---|
+| `PingController` | `ReplyingKafkaTemplate.sendAndReceive()` 로 ping 발송 후 응답 대기 |
+| `PongHandler` | `@KafkaListener` + `@SendTo` 로 ping 수신 → pong 응답 |
+| `PingApplication` | Ping 앱 설정 |
+| `PongApplication` | Pong 앱 설정 |
+
+## 사용된 bluetape4k 기능
+
+| 기능 | 아티팩트 | 코드 위치 | 이점 |
+|---|---|---|---|
+| `CompletableFuture.onSuccess/onFailure` | `bluetape4k-coroutines` | `PingController.ping()` | Java Future에 Kotlin 스타일 콜백 확장 |
+| `uninitialized()` | `bluetape4k-core` | `PingController` | 타입 안전 lateinit 초기화 대체 |
+| `KLoggingChannel` | `bluetape4k-logging` | companion object | 코루틴 컨텍스트 포함 구조적 로깅 |
+
+## bluetape4k Before / After
+
+### `CompletableFuture.onSuccess/onFailure` vs 전통적 콜백
 
 ```kotlin
-    @KafkaListener(groupId = "pong", topics = [PongApplication.TOPIC_PINGPONG])
-@SendTo // use default replyTo expression
+// Before — addCallback (deprecated) 또는 thenAccept/exceptionally
+replyFuture.addCallback(
+    { result -> logger.info("Sent ok: $result") },
+    { e -> logger.error("Failed: ${e.message}") }
+)
+
+// After — bluetape4k onSuccess / onFailure 확장 (체이닝 가능)
+replyFuture
+    .onSuccess { result -> log.info { "callback result: $result" } }
+    .onFailure { e -> log.error(e) { "callback exception." } }
+```
+
+### 요청-응답 처리
+
+```kotlin
+@GetMapping("/ping")
+suspend fun ping(): String {
+    val record = ProducerRecord<String, String>(TOPIC_PINGPONG, "ping")
+    val replyFuture = template.sendAndReceive(record)
+
+    replyFuture
+        .onSuccess { log.info { "Sent ok: $it" } }
+        .onFailure { log.error(it) { "Send failed" } }
+
+    val sendResult = replyFuture.sendFuture?.await()
+    val consumerRecord = replyFuture.await()         // coroutines.future.await()
+    return consumerRecord.value()
+}
+
+// Pong 쪽 — @SendTo로 자동 응답
+@KafkaListener(groupId = "pong", topics = [TOPIC_PINGPONG])
+@SendTo
 fun handle(request: String): String {
-    log.info { "Received: $request in ${this.javaClass.name}" }
-    return "pong at " + LocalDateTime.now()
+    log.info { "Received: $request" }
+    return "pong at ${LocalDateTime.now()}"
 }
 ```
 
 ## 실행
 
-1. `KafkaApplication` 을 실행한다
-2. `pingpong.http` 를 실행한다
+```bash
+./gradlew :messaging-kafka-reply:bootRun
+# HTTP 파일로 테스트
+# GET http://localhost:8080/ping
+```
+
+## 관련 모듈
+
+- [`messaging/kafka`](../kafka) — 기본 Producer/Consumer 패턴
+
+## 참고
+
+- [Spring Kafka ReplyingKafkaTemplate](https://docs.spring.io/spring-kafka/reference/kafka/sending-messages.html#replying-template)
+- [bluetape4k-coroutines](https://github.com/bluetape4k/bluetape4k-projects)

--- a/messaging/kafka/README.md
+++ b/messaging/kafka/README.md
@@ -1,23 +1,117 @@
 # Kafka Demo
 
 Spring Kafka를 사용하는 기본 메시지 발행·소비 예제입니다.
-Testcontainers로 Kafka 컨테이너를 자동으로 구동하여 통합 테스트를 수행합니다.
+bluetape4k의 `KafkaServer.Launcher`로 Testcontainers Kafka를 자동 구동하고, `KLoggingChannel`과 `uninitialized()`를 활용합니다.
 
-## 주요 내용
+## 아키텍처
 
-- `KafkaTemplate`을 이용한 메시지 발행 (Producer)
-- `@KafkaListener`를 이용한 메시지 소비 (Consumer)
-- Consumer Group 설정 및 파티션 할당
-- 직렬화: String, JSON (Jackson) 포맷
-- Kotlin Coroutines와 연동한 비동기 처리
+```mermaid
+graph LR
+    Client -->|HTTP POST /greeting| Controller
+    Controller -->|KafkaTemplate.send| Kafka[(Kafka Broker)]
+    Kafka -->|@KafkaListener| SimpleHandler[SimpleMessageHandler]
+    Kafka -->|@KafkaListener| GreetingHandler[GreetingMessageHandler]
+    Kafka -->|@KafkaListener| LoggerHandler[LoggerMessageHandler]
+    KafkaServerLauncher[KafkaServer.Launcher] -->|autostart| Kafka
+```
 
-## 아키텍처 다이어그램
+## 주요 구성
 
-![kafka Architecture diagram](../../docs/images/readme-diagrams/messaging-kafka-diagram-01.png)
+| 클래스 | 역할 |
+|---|---|
+| `KafkaApplication` | `KafkaServer.Launcher.kafka`로 Testcontainers Kafka 자동 구동 |
+| `KafkaConfig` | `KafkaTemplate` 빈 구성 |
+| `GreetingController` | `suspend` 엔드포인트 — `KafkaTemplate`으로 메시지 발행 |
+| `SimpleMessageHandler` | `TOPIC_SIMPLE` 문자열 메시지 소비 |
+| `GreetingMessageHandler` | `TOPIC_GREETING` JSON 객체 메시지 소비 |
+| `LoggerMessageHandler` | 모든 토픽 로깅 |
 
-## 실행 흐름
+## 사용된 bluetape4k 기능
 
-![kafka Sequence Flow 2 diagram](../../docs/images/readme-diagrams/messaging-kafka-sequence-01.png)
+| 기능 | 아티팩트 | 코드 위치 | 이점 |
+|---|---|---|---|
+| `KafkaServer.Launcher.kafka` | `bluetape4k-testcontainers` | `KafkaApplication` companion | Testcontainers Kafka 싱글톤 — `application.yml` 없이 자동 구동 |
+| `KLoggingChannel` | `bluetape4k-logging` | 모든 companion object | 코루틴 컨텍스트 포함 구조적 로깅 |
+| `uninitialized()` | `bluetape4k-core` | `GreetingController` | 타입 안전 lateinit 초기화 대체 |
+
+## bluetape4k Before / After
+
+### `KafkaServer.Launcher` vs 수동 Testcontainers 설정
+
+```kotlin
+// Before — @DynamicPropertySource + KafkaContainer 수동 관리
+@SpringBootTest
+class KafkaTest {
+    companion object {
+        @Container
+        val kafka = KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.4.0"))
+
+        @JvmStatic
+        @DynamicPropertySource
+        fun kafkaProperties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.kafka.bootstrap-servers") { kafka.bootstrapServers }
+        }
+    }
+}
+
+// After — KafkaServer.Launcher.kafka 싱글톤 (앱 시작 시 자동 구동)
+@SpringBootApplication
+class KafkaApplication {
+    companion object: KLoggingChannel() {
+        val kafka = KafkaServer.Launcher.kafka  // 한 줄로 끝
+    }
+}
+```
+
+### `KLoggingChannel` — 코루틴 로깅
+
+```kotlin
+// Before
+private val logger = LoggerFactory.getLogger(SimpleMessageHandler::class.java)
+logger.debug("Received message: {}", message)
+
+// After — KLoggingChannel (lazy lambda + 코루틴 MDC 컨텍스트)
+companion object: KLoggingChannel()
+log.debug { "Received message: $message" }
+```
+
+## 메시지 발행 예시
+
+```kotlin
+// 문자열 메시지 발행
+kafkaTemplate.send(KafkaTopics.TOPIC_SIMPLE, "Hello Kafka")
+
+// JSON 객체 메시지 발행
+kafkaTemplate.send(KafkaTopics.TOPIC_GREETING, GreetingRequest("Alice", "안녕하세요"))
+```
+
+## @KafkaListener — 코루틴 제약
+
+> **참고**: `@KafkaListener`는 `suspend` 함수와 Reactor를 공식 지원하지 않습니다.
+> `CoroutineSimpleMessageHandler`는 비활성화 상태 (`// @Component`)로 참고용입니다.
+
+```kotlin
+// @Component 비활성화 — KafkaListener는 suspend 미지원
+class CoroutineSimpleMessageHandler {
+    @KafkaListener(topics = [TOPIC_SIMPLE])
+    suspend fun handleWithCoroutines(message: String) { ... }  // 비동작
+}
+
+// 대안: mono { } 래핑
+@KafkaListener(topics = [TOPIC_SIMPLE])
+fun handleWithMono(message: String): Mono<Void> = mono {
+    delay(100)
+    null
+}
+```
+
+## 실행
+
+```bash
+./gradlew :messaging-kafka:bootRun
+# 또는 테스트
+./gradlew :messaging-kafka:test
+```
 
 ## 관련 모듈
 
@@ -27,3 +121,4 @@ Testcontainers로 Kafka 컨테이너를 자동으로 구동하여 통합 테스�
 
 - [Spring Kafka 공식 문서](https://docs.spring.io/spring-kafka/reference/)
 - [Apache Kafka](https://kafka.apache.org/documentation/)
+- [bluetape4k-testcontainers](https://github.com/bluetape4k/bluetape4k-projects)

--- a/redis/redisson-examples/README.md
+++ b/redis/redisson-examples/README.md
@@ -1,11 +1,23 @@
 # Redisson Examples
 
 Redis 클라이언트 라이브러리 [Redisson](https://redisson.org/)의 분산 동기화 객체를 활용하는 예제 모음입니다.
+bluetape4k의 `RedissonCodecs.LZ4ForyComposite`, `VirtualThreadExecutor`, `RedisServer.Launcher`, 테스트 동시성 헬퍼를 활용합니다.
 Testcontainers로 Redis 컨테이너를 자동으로 구동하여 통합 테스트를 수행합니다.
 
-## Redisson 분산 패턴 구조
+## 아키텍처
 
-![Redisson diagram](../../docs/images/readme-diagrams/redis-redisson-examples-diagram-01.png)
+```mermaid
+graph TD
+    AbstractRedissonTest --> RedissonClient[RedissonClient\nLZ4ForyComposite codec\nVirtualThreadExecutor]
+    RedissonClient --> Redis[(Redis\nTestcontainers)]
+    RedisServer.Launcher -->|singleton| Redis
+
+    subgraph "BT Test Harnesses"
+        MultithreadingTester
+        StructuredTaskScopeTester
+        SuspendedJobTester
+    end
+```
 
 ## 예제 범주
 
@@ -28,14 +40,131 @@ Testcontainers로 Redis 컨테이너를 자동으로 구동하여 통합 테스�
 | `PermitExpirableSemaphoreExamples` | TTL 기반 자동 만료 세마포어 |
 | `CountDownLatchExamples` | 분산 `CountDownLatch` |
 
+### 분산 객체 (`objects/`)
+
+| 클래스 | 설명 |
+|---|---|
+| `BucketExamples` | `RBucket` — 객체 홀더 (AtomicReference와 유사) |
+| `AtomicLongExamples` | `RAtomicLong` — 분산 원자적 정수 |
+| `BloomFilterExamples` | `RBloomFilter` — 확률적 멤버십 필터 |
+| `HyperLogLogExamples` | `RHyperLogLog` — 대용량 카디널리티 추정 |
+| `GeoExamples` | `RGeo` — 지리 공간 데이터 |
+| `RateLimiterExamples` | `RRateLimiter` — 분산 Rate Limiting |
+| `IdGeneratorExamples` | `RIdGenerator` — 분산 ID 생성 |
+| `BatchExamples` | 명령 배치 실행 |
+
 ### Pub/Sub (`objects/`)
 
 | 클래스 | 설명 |
 |---|---|
 | `TopicExamples` | `RTopic` 채널 기반 메시지 발행·구독 |
+| `ReliableTopicExamples` | `RReliableTopic` — 메시지 손실 없는 신뢰적 Pub/Sub |
+
+### 분산 컬렉션 (`collections/`)
+
+| 클래스 | 설명 |
+|---|---|
+| `LocalCachedMapExamples` | `RLocalCachedMap` — 로컬 캐시 + Redis 동기화 |
+| `StreamExamples` | `RStream` — Redis Streams |
+| `ScoredSortedSetExamples` | `RScoredSortedSet` — 점수 기반 정렬 집합 |
+
+### Read/Write Through
+
+| 클래스 | 설명 |
+|---|---|
+| `ReadWriteThroughExamples` | Cache-as-SOR — DB 읽기/쓰기를 캐시가 대리 처리 |
+
+## 사용된 bluetape4k 기능
+
+| 기능 | 아티팩트 | 코드 위치 | 이점 |
+|---|---|---|---|
+| `RedissonCodecs.LZ4ForyComposite` | `bluetape4k-redis` | `AbstractRedissonTest` | LZ4 압축 + Fory 직렬화 — JSON 대비 공간·속도 우위 |
+| `VirtualThreadExecutor` | `bluetape4k-coroutines` | `AbstractRedissonTest` | Redisson I/O를 Virtual Thread로 처리 |
+| `RedisServer.Launcher.redis` | `bluetape4k-testcontainers` | `AbstractRedissonTest` | Testcontainers Redis 싱글톤 — 자동 구동·종료 |
+| `ShutdownQueue.register` | `bluetape4k-core` | `AbstractRedissonTest` | JVM 종료 시 RedissonClient 자동 close |
+| `Base58.randomString` | `bluetape4k-io` | `AbstractRedissonTest` | URL-safe 랜덤 키 생성 |
+| `MultithreadingTester` | `bluetape4k-junit5` | `FencedLockExamples` | 고정 스레드풀 동시성 검증 |
+| `StructuredTaskScopeTester` | `bluetape4k-junit5` | `FencedLockExamples` | Virtual Thread 동시성 검증 |
+| `SuspendedJobTester` | `bluetape4k-junit5` | `FencedLockExamples` | 코루틴 경쟁 조건 검증 |
+| `getLockId()` | `bluetape4k-redis` | `FencedLockExamples` | 코루틴 안전한 RFencedLock ID 획득 |
+
+## bluetape4k Before / After
+
+### `RedissonCodecs.LZ4ForyComposite` vs 기본 codec
+
+```kotlin
+// Before — 기본 JSON 직렬화 (텍스트, 용량 큼)
+val config = Config().apply {
+    useSingleServer().setAddress(redisUrl)
+    codec = JsonJacksonCodec()  // 텍스트 기반 직렬화
+}
+
+// After — bluetape4k LZ4ForyComposite (이진 압축 직렬화)
+val config = Config().apply {
+    useSingleServer()
+        .setAddress(redis.url)
+        .setConnectionPoolSize(128)
+        .setConnectionMinimumIdleSize(32)
+    executor = VirtualThreadExecutor          // Virtual Thread I/O
+    threads = 256
+    nettyThreads = 128
+    codec = RedissonCodecs.LZ4ForyComposite   // LZ4 + Fory 이진 압축
+}
+```
+
+### 동시성 테스트 — BT 테스트 헬퍼
+
+```kotlin
+// Before — 수동 Thread 생성 (비결정적, 경쟁 조건 검증 어려움)
+val threads = (1..8).map { Thread { lock.tryLock() } }
+threads.forEach { it.start() }
+threads.forEach { it.join() }
+
+// After — bluetape4k MultithreadingTester (재현 가능한 동시성 검증)
+MultithreadingTester()
+    .workers(8)
+    .rounds(2)
+    .add {
+        val token = lock.tryLockAndGetTokenAsync(5, 10, TimeUnit.SECONDS).get()
+        if (token != null) {
+            // 임계구역 작업
+            lock.unlock()
+        }
+    }
+    .run()
+```
+
+### `SuspendedJobTester` — 코루틴 FencedLock
+
+```kotlin
+// After — 코루틴 환경에서 FencedLock 동시성 검증
+SuspendedJobTester()
+    .workers(8)
+    .rounds(16)
+    .add {
+        val mlockId = redisson.getLockId("fencedLock")  // BT 코루틴 안전 getLockId
+        val locked = lock.tryLockAsync(5, 10, TimeUnit.SECONDS, mlockId).await()
+        if (locked) {
+            // 임계구역
+            lock.unlockAsync(mlockId).await()
+        }
+    }
+    .run()
+```
+
+## 실행
+
+```bash
+# Redis 컨테이너 자동 구동 후 테스트
+./gradlew :redis-redisson-examples:test
+
+# 특정 예제만 실행
+./gradlew :redis-redisson-examples:test --tests "*.FencedLockExamples"
+```
 
 ## 참고
 
 - [Redisson 공식 문서](https://redisson.org/docs/)
 - [Redisson GitHub](https://github.com/redisson/redisson)
+- [bluetape4k-redis](https://github.com/bluetape4k/bluetape4k-projects)
 - Spring Data Redis 기반 예제는 [`spring-data/redis-examples`](../../spring-data/redis-examples) 참고


### PR DESCRIPTION
## Summary

Resolves #83 — Serialization/Messaging Basic: strengthen module READMEs with bluetape4k feature documentation.

## Changes

Added **Used bluetape4k Features** table, **Before/After** code snippets, and Mermaid architecture diagrams to five module READMEs:

| Module | Key BT APIs documented |
|---|---|
| `json/jackson-examples` | `Jackson.defaultJsonMapper`, `KLogging`, `Fakers.faker` |
| `json/jsonview-examples` | `Jackson.defaultJsonMapper` @Bean one-liner |
| `messaging/kafka` | `KafkaServer.Launcher` singleton, `KLoggingChannel`; @KafkaListener suspend limitation documented |
| `messaging/kafka-reply` | `CompletableFuture.onSuccess/onFailure` extensions, `uninitialized()` |
| `redis/redisson-examples` | `RedissonCodecs.LZ4ForyComposite`, `VirtualThreadExecutor`, `RedisServer.Launcher`, `MultithreadingTester`, `SuspendedJobTester`, `getLockId()` |

### Notable additions
- `messaging/kafka` README now explicitly documents that `@KafkaListener` does **not** support `suspend` functions (the `CoroutineSimpleMessageHandler` is disabled — this was previously undocumented)
- `redis/redisson-examples` expanded from 41 lines to 166 lines with full example catalogue (locks, semaphores, objects, collections, pub/sub, read/write-through)

## Test Results

```
:jackson-examples:test           BUILD SUCCESSFUL
:jsonview-examples:test          BUILD SUCCESSFUL
:messaging-kafka:test            BUILD SUCCESSFUL
:messaging-kafka-reply:test      BUILD SUCCESSFUL
:redis-redisson-examples:test    BUILD SUCCESSFUL
```

## Checklist

- [x] All 5 module tests passing
- [x] README.md updated for each module (BT feature table + before/after + Mermaid diagram)
- [x] @KafkaListener suspend limitation explicitly documented
- [x] Lessons doc committed: `docs/lessons/2026-05-24-serialization-messaging-basic-bt-features.md`
- [x] No code changes — docs only