### PR TITLE
feat: add spring-boot/idgenerator workshop module (#62)

### DIFF
--- a/docs/lessons/2026-05-24-idgenerator-workshop.md
+++ b/docs/lessons/2026-05-24-idgenerator-workshop.md
@@ -1,0 +1,72 @@
+# 2026-05-24 idgenerator Workshop 예제 추가 (Issue #62)
+
+## 작업 개요
+
+`spring-boot/idgenerator` 모듈을 신규 생성했다.
+bluetape4k-idgenerators의 4가지 알고리즘(Snowflake, ULID, KSUID, Hashids)을 Spring Boot WebFlux REST API로 노출한다.
+
+## 구현 결정
+
+### 범위 선정
+
+issue #62의 7개 예제 후보 중 Basic 레벨에 맞게 REST API + 역파싱을 우선 구현했다.
+
+| 후보 | 이번 구현 여부 | 이유 |
+|---|---|---|
+| Snowflake REST API | ✅ | 핵심 — 역파싱 포함 |
+| ULID/KSUID REST API | ✅ | 단순 구현 |
+| Hashids 인코딩/디코딩 | ✅ | 단순 구현 |
+| Redis 기반 worker-id allocation | ❌ | 별도 인프라 필요, 후속 작업 |
+| Kafka event ID generation | ❌ | messaging 모듈과 연관 |
+| OpenTelemetry tracing | ❌ | observability 모듈과 연관 |
+| 벤치마크 | ❌ | gatling 모듈 활용 권장 |
+
+### Snowflakers.Default vs 명시적 machineId
+
+`Snowflakers.Default`는 MAC 기반으로 머신ID를 자동 결정한다.
+단일 NIC 환경에서는 편리하지만, Pod/Container 환경에서는 네트워크 인터페이스가 동적으로 변하므로
+`Snowflakers.default(machineId = N)` 명시적 지정이 안전하다.
+README에 운영 주의사항으로 문서화했다.
+
+### nextIds() 반환 타입
+
+`Snowflake.nextIds(size: Int)` 는 `Sequence<Long>`을 반환한다 — `List<Long>` 아님.
+컨트롤러에서 `.map { }.toList()` 호출이 필수다.
+
+### WebTestClient 설정 — Spring Boot 4 패턴
+
+Spring Boot 4 WebFlux 통합 테스트에서 `@AutoConfigureWebTestClient` 대신:
+```kotlin
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
+@EnableWebFlux
+abstract class AbstractTest {
+    @Autowired
+    protected val context: ApplicationContext = uninitialized()
+
+    protected val client: WebTestClient by lazy {
+        WebTestClient.bindToApplicationContext(context).configureClient().build()
+    }
+}
+```
+패턴이 정상 동작한다. `@AutoConfigureWebTestClient`는 Spring Boot 4.x에서 패키지 구조 변경으로 `NoClassDefFoundError`가 발생할 수 있다.
+
+## 테스트 결과
+
+```
+:spring-boot-idgenerator:test  BUILD SUCCESSFUL
+Tests: 10 passing
+```
+
+## Hashids 운영 주의사항
+
+Hashids는 암호화가 아닌 난독화 알고리즘이다.
+보안 목적 ID에 절대 사용 금지 — salt 설정 필수:
+```kotlin
+val hashids = Hashids(salt = "프로젝트-고유-secret", minHashLength = 8)
+```
+
+## 향후 작업 (issue #62 연계)
+
+- Redis 기반 worker-id 동적 할당: Redisson `RAtomicLong` incrementAndGet + TTL 패턴
+- Kafka outbox event ID 생성 예제
+- Exposed DB 저장 E2E 흐름

--- a/spring-boot/idgenerator/README.md
+++ b/spring-boot/idgenerator/README.md
@@ -1,0 +1,154 @@
+# ID Generator Workshop
+
+`bluetape4k-idgenerators`의 4가지 분산 ID 생성기를 Spring Boot WebFlux REST API로 노출하는 통합 예제입니다.
+Snowflake, ULID, KSUID, Hashids 각 알고리즘의 특성과 운영 시 주의사항을 다룹니다.
+
+## 아키텍처
+
+```mermaid
+graph LR
+    Client -->|HTTP GET| Router[Spring WebFlux Router]
+    Router --> Controller[IdGeneratorController]
+    Controller --> SF[Snowflakers.Default\nSnowflake Long ID]
+    Controller --> UL[UlidGenerator\n26-char Crockford Base32]
+    Controller --> KS[KsuidGenerator\n27-char Base62]
+    Controller --> HI[Hashids\nURL-safe obfuscation]
+```
+
+## API 엔드포인트
+
+| 메서드 | 경로 | 설명 |
+|---|---|---|
+| `GET` | `/ids/snowflake` | Snowflake Long ID 생성 + 파싱된 구성요소 |
+| `GET` | `/ids/snowflake/parse/{id}` | 기존 Snowflake ID 역파싱 |
+| `GET` | `/ids/snowflake/batch?count=N` | Snowflake ID N개 일괄 생성 (최대 1000) |
+| `GET` | `/ids/ulid` | ULID 생성 (26자 Crockford Base32) |
+| `GET` | `/ids/ulid/batch?count=N` | ULID N개 일괄 생성 |
+| `GET` | `/ids/ksuid` | KSUID 생성 (27자 Base62) |
+| `GET` | `/ids/ksuid/batch?count=N` | KSUID N개 일괄 생성 |
+| `GET` | `/ids/hashids/encode?numbers=1,2,3` | 숫자 배열 → Hashids 인코딩 |
+| `GET` | `/ids/hashids/decode/{hash}` | Hashids 문자열 → 숫자 배열 디코딩 |
+
+## ID 알고리즘 비교
+
+| 알고리즘 | 타입 | 길이 | 정렬성 | 특징 |
+|---|---|---|---|---|
+| **Snowflake** | `Long` | 64-bit | 시간순 | 머신ID 포함, 역파싱 가능, 초당 4096개/노드 |
+| **ULID** | `String` | 26자 | 사전순 = 시간순 | 밀리초 정밀도, UUID 호환 |
+| **KSUID** | `String` | 27자 | 사전순 = 시간순 | 초 정밀도, 128-bit 랜덤 페이로드 |
+| **Hashids** | `String` | 가변 | ❌ | 숫자 난독화(obfuscation), 역산 가능 |
+
+## 사용된 bluetape4k 기능
+
+| 기능 | 아티팩트 | 코드 위치 | 이점 |
+|---|---|---|---|
+| `Snowflakers.Default` | `bluetape4k-idgenerators` | `IdGeneratorController` | 싱글톤 DefaultSnowflake — 머신ID 자동 결정 |
+| `Snowflake.parse(id)` | `bluetape4k-idgenerators` | `parseSnowflakeId()` | Long ID → timestamp/machineId/sequence 역파싱 |
+| `Snowflake.nextIds(size)` | `bluetape4k-idgenerators` | `snowflakeBatch()` | Sequence 기반 일괄 생성 |
+| `UlidGenerator` | `bluetape4k-idgenerators` | `IdGeneratorController` | 단조 증가 ULID, StatefulMonotonic 내장 |
+| `KsuidGenerator` | `bluetape4k-idgenerators` | `IdGeneratorController` | 초 기반 정렬 가능 ID |
+| `Hashids` | `bluetape4k-idgenerators` | `IdGeneratorController` | salt + minLength 설정으로 난독화 강도 조정 |
+| `KLogging` | `bluetape4k-logging` | companion object | Lazy 람다 로깅 |
+
+## bluetape4k Before / After
+
+### Snowflake ID 생성
+
+```kotlin
+// Before — Twitter Snowflake 직접 구현 또는 외부 라이브러리
+val snowflake = SnowflakeIdWorker(workerId = 1, datacenterId = 1)
+val id: Long = snowflake.nextId()
+
+// After — bluetape4k Snowflakers.Default (머신ID 자동, 싱글톤)
+val id: Long = Snowflakers.Default.nextId()
+val parsed: SnowflakeId = Snowflakers.Default.parse(id)
+// parsed.timestamp, parsed.machineId, parsed.sequence 접근 가능
+```
+
+### ULID 생성
+
+```kotlin
+// Before — UlidCreator 외부 라이브러리
+val id = UlidCreator.getUlid().toString()
+
+// After — bluetape4k UlidGenerator (StatefulMonotonic 내장)
+val generator = UlidGenerator()
+val id: String = generator.nextId()   // 26자, 동일 밀리초 내 단조 증가 보장
+```
+
+## 운영 주의사항
+
+### Snowflake — Machine ID 관리
+
+```
+⚠️ 동일 머신 ID를 가진 두 노드가 동시에 실행되면 ID 충돌이 발생합니다.
+
+Snowflakers.Default: 네트워크 인터페이스 MAC 기반 자동 결정 (단일 NIC 환경 권장)
+Snowflakers.default(machineId = N): 명시적 지정 — Pod/Container 환경에서 권장
+
+Redis 기반 worker-id 동적 할당: Redisson RAtomicLong 또는 SET NX/EXPIRE로 구현 가능
+(해당 패턴은 issue #62 후속 작업에서 다룹니다)
+```
+
+### Snowflake — Clock Rollback
+
+```
+⚠️ 서버 시간이 뒤로 돌아가면 ID 중복이 발생할 수 있습니다.
+
+DefaultSnowflake은 clock rollback 감지 시 IllegalStateException을 발생시킵니다.
+NTP 동기화와 클라우드 인스턴스 재시작 시 특히 주의가 필요합니다.
+```
+
+### Hashids — 보안 주의
+
+```
+⚠️ Hashids는 암호화 알고리즘이 아닙니다. 난독화(obfuscation) 전용입니다.
+
+salt 없이 사용하면 공개 Hashids 참조 구성과 동일하여 trivially reversible합니다.
+보안 토큰, 인증 ID, 민감한 식별자에 절대 사용하지 마세요.
+실제 사용 시: Hashids(salt = "프로젝트 고유 secret", minHashLength = 8)
+```
+
+### ULID vs KSUID 선택 기준
+
+| 상황 | 권장 |
+|---|---|
+| UUID 대체, DB 인덱스 효율 (밀리초 정밀도) | **ULID** |
+| 초(seconds) 정밀도로 충분, 더 짧은 랜덤 페이로드 | **KSUID** |
+| Long 타입 필요, 분산 노드 식별, 역파싱 필요 | **Snowflake** |
+| URL에 숫자 ID 노출 방지 (PKs, 시퀀스) | **Hashids** |
+
+## 실행
+
+```bash
+./gradlew :spring-boot-idgenerator:bootRun
+
+# Snowflake ID 생성
+curl http://localhost:8080/ids/snowflake
+
+# Snowflake 10개 일괄 생성
+curl "http://localhost:8080/ids/snowflake/batch?count=10"
+
+# ULID 생성
+curl http://localhost:8080/ids/ulid
+
+# KSUID 생성
+curl http://localhost:8080/ids/ksuid
+
+# Hashids 인코딩
+curl "http://localhost:8080/ids/hashids/encode?numbers=1,2,3"
+```
+
+## 테스트
+
+```bash
+./gradlew :spring-boot-idgenerator:test
+```
+
+## 참고
+
+- [bluetape4k-idgenerators](https://github.com/bluetape4k/bluetape4k-projects)
+- [Snowflake ID (Twitter)](https://blog.twitter.com/engineering/en_us/a/2010/announcing-snowflake)
+- [ULID Specification](https://github.com/ulid/spec)
+- [KSUID](https://github.com/segmentio/ksuid)
+- [Hashids](https://hashids.org/)

--- a/spring-boot/idgenerator/build.gradle.kts
+++ b/spring-boot/idgenerator/build.gradle.kts
@@ -1,0 +1,47 @@
+plugins {
+    alias(libs.plugins.kotlin.spring)
+    alias(libs.plugins.spring.boot)
+}
+
+springBoot {
+    mainClass.set("io.bluetape4k.workshop.idgenerator.IdGeneratorApplicationKt")
+}
+
+configurations {
+    testImplementation.get().extendsFrom(compileOnly.get(), runtimeOnly.get())
+}
+
+dependencies {
+    // bluetape4k
+    implementation(libs.bluetape4k.idgenerators)
+    implementation(libs.bluetape4k.jackson3)
+    implementation(libs.bluetape4k.coroutines)
+    testImplementation(libs.bluetape4k.junit5)
+
+    // Spring Boot
+    implementation(libs.spring.boot.autoconfigure.lib)
+    annotationProcessor(libs.spring.boot.autoconfigure.processor)
+    annotationProcessor(libs.spring.boot.configuration.processor)
+    runtimeOnly(libs.spring.boot.devtools)
+
+    implementation(libs.spring.boot.starter.actuator)
+    implementation(libs.spring.boot.starter.webflux.lib)
+    testImplementation(libs.spring.boot.starter.webflux.test)
+    testImplementation(libs.spring.boot.starter.test) {
+        exclude(group = "junit", module = "junit")
+        exclude(group = "org.junit.vintage", module = "junit-vintage-engine")
+        exclude(module = "mockito-core")
+    }
+
+    // Coroutines
+    implementation(libs.kotlinx.coroutines.core.lib)
+    implementation(libs.kotlinx.coroutines.reactor)
+    testImplementation(libs.kotlinx.coroutines.test.lib)
+
+    // Reactor
+    implementation(libs.reactor.kotlin.extensions)
+    testImplementation(libs.reactor.test)
+
+    // SpringDoc - OpenAPI
+    implementation(libs.springdoc.openapi.starter.webflux.ui)
+}

--- a/spring-boot/idgenerator/src/main/kotlin/io/bluetape4k/workshop/idgenerator/IdGeneratorApplication.kt
+++ b/spring-boot/idgenerator/src/main/kotlin/io/bluetape4k/workshop/idgenerator/IdGeneratorApplication.kt
@@ -1,0 +1,14 @@
+package io.bluetape4k.workshop.idgenerator
+
+import io.bluetape4k.logging.KLogging
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
+
+@SpringBootApplication(proxyBeanMethods = false)
+class IdGeneratorApplication {
+    companion object : KLogging()
+}
+
+fun main(args: Array<String>) {
+    runApplication<IdGeneratorApplication>(*args)
+}

--- a/spring-boot/idgenerator/src/main/kotlin/io/bluetape4k/workshop/idgenerator/controller/IdGeneratorController.kt
+++ b/spring-boot/idgenerator/src/main/kotlin/io/bluetape4k/workshop/idgenerator/controller/IdGeneratorController.kt
@@ -1,0 +1,169 @@
+package io.bluetape4k.workshop.idgenerator.controller
+
+import io.bluetape4k.idgenerators.hashids.Hashids
+import io.bluetape4k.idgenerators.ksuid.KsuidGenerator
+import io.bluetape4k.idgenerators.snowflake.Snowflakers
+import io.bluetape4k.idgenerators.ulid.UlidGenerator
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import io.bluetape4k.workshop.idgenerator.model.BatchIdResponse
+import io.bluetape4k.workshop.idgenerator.model.HashidsResponse
+import io.bluetape4k.workshop.idgenerator.model.SnowflakeResponse
+import io.bluetape4k.workshop.idgenerator.model.StringIdResponse
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * bluetape4k-idgenerators 의 4가지 ID 생성기를 REST API로 노출합니다.
+ *
+ * - Snowflake: Long 형 시간 기반 분산 ID (Twitter 알고리즘)
+ * - ULID: 26자 Crockford Base32, 시간순 정렬 가능 문자열 ID
+ * - KSUID: 27자 Base62, 초(seconds) 기반 정렬 가능 문자열 ID
+ * - Hashids: 숫자 배열을 URL-safe 문자열로 인코딩/디코딩
+ */
+@RestController
+@RequestMapping("/ids")
+class IdGeneratorController {
+
+    companion object : KLogging() {
+        private val snowflake = Snowflakers.Default
+        private val ulidGenerator = UlidGenerator()
+        private val ksuidGenerator = KsuidGenerator()
+        private val hashids = Hashids(salt = "bluetape4k-workshop", minHashLength = 8)
+    }
+
+    // ── Snowflake ──────────────────────────────────────────────────────────
+
+    /**
+     * Snowflake ID 하나를 생성합니다.
+     *
+     * Long 값과 파싱된 구성 요소(timestamp, machineId, sequence)를 함께 반환합니다.
+     */
+    @GetMapping("/snowflake")
+    suspend fun snowflakeId(): SnowflakeResponse {
+        val id = snowflake.nextId()
+        val parsed = snowflake.parse(id)
+        log.debug { "Generated Snowflake id=$id, machineId=${parsed.machineId}" }
+        return SnowflakeResponse(
+            id = id,
+            idAsString = snowflake.nextIdAsString(),
+            timestamp = parsed.timestamp,
+            machineId = parsed.machineId,
+            sequence = parsed.sequence,
+        )
+    }
+
+    /**
+     * 기존 Snowflake Long ID를 파싱하여 구성 요소를 반환합니다.
+     */
+    @GetMapping("/snowflake/parse/{id}")
+    suspend fun parseSnowflakeId(@PathVariable id: Long): SnowflakeResponse {
+        val parsed = snowflake.parse(id)
+        log.debug { "Parsed Snowflake id=$id → $parsed" }
+        return SnowflakeResponse(
+            id = id,
+            idAsString = id.toString(36),
+            timestamp = parsed.timestamp,
+            machineId = parsed.machineId,
+            sequence = parsed.sequence,
+        )
+    }
+
+    /**
+     * Snowflake ID를 [count]개 일괄 생성합니다. (최대 1000개)
+     */
+    @GetMapping("/snowflake/batch")
+    suspend fun snowflakeBatch(
+        @RequestParam(defaultValue = "10") count: Int,
+    ): BatchIdResponse {
+        val safeCount = count.coerceIn(1, 1000)
+        val ids = snowflake.nextIds(safeCount).map { it.toString() }.toList()
+        log.debug { "Generated $safeCount Snowflake IDs" }
+        return BatchIdResponse(type = "snowflake", count = safeCount, ids = ids)
+    }
+
+    // ── ULID ───────────────────────────────────────────────────────────────
+
+    /**
+     * ULID를 생성합니다.
+     *
+     * 26자 Crockford Base32 인코딩, 사전순 정렬 시 시간 순서가 보장됩니다.
+     */
+    @GetMapping("/ulid")
+    suspend fun ulidId(): StringIdResponse {
+        val id = ulidGenerator.nextId()
+        log.debug { "Generated ULID id=$id" }
+        return StringIdResponse(type = "ulid", id = id)
+    }
+
+    /**
+     * ULID를 [count]개 일괄 생성합니다. (최대 1000개)
+     */
+    @GetMapping("/ulid/batch")
+    suspend fun ulidBatch(
+        @RequestParam(defaultValue = "10") count: Int,
+    ): BatchIdResponse {
+        val safeCount = count.coerceIn(1, 1000)
+        val ids = List(safeCount) { ulidGenerator.nextId() }
+        return BatchIdResponse(type = "ulid", count = safeCount, ids = ids)
+    }
+
+    // ── KSUID ──────────────────────────────────────────────────────────────
+
+    /**
+     * KSUID를 생성합니다.
+     *
+     * 27자 Base62 인코딩, 초(seconds) 기반으로 정렬 가능합니다.
+     */
+    @GetMapping("/ksuid")
+    suspend fun ksuidId(): StringIdResponse {
+        val id = ksuidGenerator.nextId()
+        log.debug { "Generated KSUID id=$id" }
+        return StringIdResponse(type = "ksuid", id = id)
+    }
+
+    /**
+     * KSUID를 [count]개 일괄 생성합니다. (최대 1000개)
+     */
+    @GetMapping("/ksuid/batch")
+    suspend fun ksuidBatch(
+        @RequestParam(defaultValue = "10") count: Int,
+    ): BatchIdResponse {
+        val safeCount = count.coerceIn(1, 1000)
+        val ids = List(safeCount) { ksuidGenerator.nextId() }
+        return BatchIdResponse(type = "ksuid", count = safeCount, ids = ids)
+    }
+
+    // ── Hashids ────────────────────────────────────────────────────────────
+
+    /**
+     * 숫자를 Hashids로 인코딩합니다.
+     *
+     * [numbers] 쿼리 파라미터에 콤마로 구분된 Long 값을 전달합니다.
+     * 예: `/ids/hashids/encode?numbers=1,2,3`
+     */
+    @GetMapping("/hashids/encode")
+    suspend fun hashidsEncode(
+        @RequestParam numbers: List<Long>,
+    ): HashidsResponse {
+        val encoded = hashids.encode(*numbers.toLongArray())
+        val decoded = hashids.decode(encoded).toList()
+        log.debug { "Hashids encode $numbers → $encoded" }
+        return HashidsResponse(numbers = numbers, encoded = encoded, decoded = decoded)
+    }
+
+    /**
+     * Hashids 문자열을 디코딩합니다.
+     *
+     * 예: `/ids/hashids/decode/xBNRkG3A`
+     */
+    @GetMapping("/hashids/decode/{hash}")
+    suspend fun hashidsDecode(@PathVariable hash: String): HashidsResponse {
+        val decoded = hashids.decode(hash).toList()
+        log.debug { "Hashids decode $hash → $decoded" }
+        return HashidsResponse(numbers = decoded, encoded = hash, decoded = decoded)
+    }
+}

--- a/spring-boot/idgenerator/src/main/kotlin/io/bluetape4k/workshop/idgenerator/model/IdResponses.kt
+++ b/spring-boot/idgenerator/src/main/kotlin/io/bluetape4k/workshop/idgenerator/model/IdResponses.kt
@@ -1,0 +1,40 @@
+package io.bluetape4k.workshop.idgenerator.model
+
+import java.io.Serializable
+
+/**
+ * Snowflake ID 응답 — Long ID와 파싱된 구성요소 포함.
+ */
+data class SnowflakeResponse(
+    val id: Long,
+    val idAsString: String,
+    val timestamp: Long,
+    val machineId: Int,
+    val sequence: Int,
+) : Serializable
+
+/**
+ * String ID (ULID / KSUID) 응답.
+ */
+data class StringIdResponse(
+    val type: String,
+    val id: String,
+) : Serializable
+
+/**
+ * Hashids 인코딩 응답.
+ */
+data class HashidsResponse(
+    val numbers: List<Long>,
+    val encoded: String,
+    val decoded: List<Long>,
+) : Serializable
+
+/**
+ * 일괄 ID 생성 응답.
+ */
+data class BatchIdResponse(
+    val type: String,
+    val count: Int,
+    val ids: List<String>,
+) : Serializable

--- a/spring-boot/idgenerator/src/test/kotlin/io/bluetape4k/workshop/idgenerator/AbstractIdGeneratorTest.kt
+++ b/spring-boot/idgenerator/src/test/kotlin/io/bluetape4k/workshop/idgenerator/AbstractIdGeneratorTest.kt
@@ -1,0 +1,26 @@
+package io.bluetape4k.workshop.idgenerator
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.support.uninitialized
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.ApplicationContext
+import org.springframework.test.web.reactive.server.WebTestClient
+import org.springframework.web.reactive.config.EnableWebFlux
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
+@EnableWebFlux
+abstract class AbstractIdGeneratorTest {
+
+    companion object : KLogging()
+
+    @Autowired
+    protected val context: ApplicationContext = uninitialized()
+
+    protected val client: WebTestClient by lazy {
+        WebTestClient
+            .bindToApplicationContext(context)
+            .configureClient()
+            .build()
+    }
+}

--- a/spring-boot/idgenerator/src/test/kotlin/io/bluetape4k/workshop/idgenerator/controller/IdGeneratorControllerTest.kt
+++ b/spring-boot/idgenerator/src/test/kotlin/io/bluetape4k/workshop/idgenerator/controller/IdGeneratorControllerTest.kt
@@ -1,0 +1,187 @@
+package io.bluetape4k.workshop.idgenerator.controller
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeGreaterThan
+import io.bluetape4k.assertions.shouldBePositive
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldHaveSize
+import io.bluetape4k.assertions.shouldNotBeEmpty
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.workshop.idgenerator.AbstractIdGeneratorTest
+import io.bluetape4k.workshop.idgenerator.model.BatchIdResponse
+import io.bluetape4k.workshop.idgenerator.model.HashidsResponse
+import io.bluetape4k.workshop.idgenerator.model.SnowflakeResponse
+import io.bluetape4k.workshop.idgenerator.model.StringIdResponse
+import org.junit.jupiter.api.Test
+import org.springframework.test.web.reactive.server.returnResult
+import reactor.kotlin.core.publisher.toMono
+
+class IdGeneratorControllerTest : AbstractIdGeneratorTest() {
+
+    companion object : KLogging()
+
+
+    // ── Snowflake ──────────────────────────────────────────────────────────
+
+    @Test
+    fun `snowflake id 생성`() {
+        val result = client.get().uri("/ids/snowflake")
+            .exchange()
+            .expectStatus().isOk
+            .returnResult<SnowflakeResponse>()
+            .responseBody
+            .toMono()
+            .block()!!
+
+        result.id.shouldBePositive()
+        result.timestamp.shouldBeGreaterThan(0L)
+        result.machineId.shouldBeGreaterThan(-1)
+        result.sequence.shouldBeGreaterThan(-1)
+    }
+
+    @Test
+    fun `snowflake id 파싱`() {
+        // 먼저 ID 생성
+        val generated = client.get().uri("/ids/snowflake")
+            .exchange()
+            .expectStatus().isOk
+            .returnResult<SnowflakeResponse>()
+            .responseBody.toMono().block()!!
+
+        // 생성된 ID를 파싱
+        val parsed = client.get().uri("/ids/snowflake/parse/${generated.id}")
+            .exchange()
+            .expectStatus().isOk
+            .returnResult<SnowflakeResponse>()
+            .responseBody.toMono().block()!!
+
+        parsed.id shouldBeEqualTo generated.id
+        parsed.timestamp shouldBeEqualTo generated.timestamp
+        parsed.machineId shouldBeEqualTo generated.machineId
+    }
+
+    @Test
+    fun `snowflake batch 생성`() {
+        val count = 20
+        val result = client.get().uri("/ids/snowflake/batch?count=$count")
+            .exchange()
+            .expectStatus().isOk
+            .returnResult<BatchIdResponse>()
+            .responseBody.toMono().block()!!
+
+        result.type shouldBeEqualTo "snowflake"
+        result.count shouldBeEqualTo count
+        result.ids shouldHaveSize count
+        // 모두 유일한 값인지 확인
+        result.ids.toSet().size shouldBeEqualTo count
+    }
+
+    // ── ULID ───────────────────────────────────────────────────────────────
+
+    @Test
+    fun `ulid 생성`() {
+        val result = client.get().uri("/ids/ulid")
+            .exchange()
+            .expectStatus().isOk
+            .returnResult<StringIdResponse>()
+            .responseBody.toMono().block()!!
+
+        result.type shouldBeEqualTo "ulid"
+        result.id.length shouldBeEqualTo 26  // ULID는 항상 26자
+        result.id.shouldNotBeEmpty()
+    }
+
+    @Test
+    fun `ulid는 단조 증가한다`() {
+        val ids = (1..5).map {
+            client.get().uri("/ids/ulid")
+                .exchange()
+                .expectStatus().isOk
+                .returnResult<StringIdResponse>()
+                .responseBody.toMono().block()!!.id
+        }
+        // ULID는 사전순으로 시간 순서 유지
+        ids.zipWithNext().all { (a, b) -> a <= b }.shouldBeTrue()
+    }
+
+    @Test
+    fun `ulid batch 생성`() {
+        val count = 15
+        val result = client.get().uri("/ids/ulid/batch?count=$count")
+            .exchange()
+            .expectStatus().isOk
+            .returnResult<BatchIdResponse>()
+            .responseBody.toMono().block()!!
+
+        result.type shouldBeEqualTo "ulid"
+        result.count shouldBeEqualTo count
+        result.ids shouldHaveSize count
+    }
+
+    // ── KSUID ──────────────────────────────────────────────────────────────
+
+    @Test
+    fun `ksuid 생성`() {
+        val result = client.get().uri("/ids/ksuid")
+            .exchange()
+            .expectStatus().isOk
+            .returnResult<StringIdResponse>()
+            .responseBody.toMono().block()!!
+
+        result.type shouldBeEqualTo "ksuid"
+        result.id.length shouldBeEqualTo 27  // KSUID는 항상 27자
+        result.id.shouldNotBeEmpty()
+    }
+
+    @Test
+    fun `ksuid batch 생성`() {
+        val count = 10
+        val result = client.get().uri("/ids/ksuid/batch?count=$count")
+            .exchange()
+            .expectStatus().isOk
+            .returnResult<BatchIdResponse>()
+            .responseBody.toMono().block()!!
+
+        result.type shouldBeEqualTo "ksuid"
+        result.count shouldBeEqualTo count
+        result.ids shouldHaveSize count
+    }
+
+    // ── Hashids ────────────────────────────────────────────────────────────
+
+    @Test
+    fun `hashids 인코딩 및 디코딩`() {
+        val numbers = listOf(1L, 2L, 3L)
+        val encoded = client.get().uri("/ids/hashids/encode?numbers=1,2,3")
+            .exchange()
+            .expectStatus().isOk
+            .returnResult<HashidsResponse>()
+            .responseBody.toMono().block()!!
+
+        encoded.numbers shouldBeEqualTo numbers
+        encoded.encoded.shouldNotBeEmpty()
+        encoded.decoded shouldBeEqualTo numbers
+
+        // 디코딩 검증
+        val decoded = client.get().uri("/ids/hashids/decode/${encoded.encoded}")
+            .exchange()
+            .expectStatus().isOk
+            .returnResult<HashidsResponse>()
+            .responseBody.toMono().block()!!
+
+        decoded.decoded shouldBeEqualTo numbers
+    }
+
+    @Test
+    fun `단일 숫자 hashids 인코딩`() {
+        val result = client.get().uri("/ids/hashids/encode?numbers=42")
+            .exchange()
+            .expectStatus().isOk
+            .returnResult<HashidsResponse>()
+            .responseBody.toMono().block()!!
+
+        result.numbers shouldBeEqualTo listOf(42L)
+        result.encoded.length shouldBeGreaterThan 0
+        result.decoded shouldBeEqualTo listOf(42L)
+    }
+}

--- a/spring-boot/idgenerator/src/test/resources/application.yml
+++ b/spring-boot/idgenerator/src/test/resources/application.yml
@@ -1,0 +1,6 @@
+spring:
+  application:
+    name: idgenerator-test
+
+server:
+  port: 0  # random port for tests

--- a/spring-boot/idgenerator/src/test/resources/junit-platform.properties
+++ b/spring-boot/idgenerator/src/test/resources/junit-platform.properties
@@ -1,0 +1,3 @@
+junit.jupiter.execution.parallel.enabled=false
+junit.jupiter.execution.parallel.mode.default=same_thread
+junit.jupiter.testinstance.lifecycle.default=per_class

--- a/spring-boot/idgenerator/src/test/resources/logback-test.xml
+++ b/spring-boot/idgenerator/src/test/resources/logback-test.xml
@@ -1,0 +1,12 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %highlight(%-5level) %magenta(%5.-5thread) --- %cyan(%-40.40logger{39}) : %msg%n</pattern>
+        </encoder>
+    </appender>
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+    <logger name="io.bluetape4k" level="DEBUG"/>
+    <logger name="io.bluetape4k.workshop.idgenerator" level="DEBUG"/>
+</configuration>


### PR DESCRIPTION
## Summary

Resolves #62 — idgenerator integration/production-style workshop example.

## New Module: `spring-boot/idgenerator`

Spring Boot WebFlux REST API demonstrating all 4 bluetape4k-idgenerators algorithms:

| Algorithm | Type | Sortable | Key Feature |
|---|---|---|---|
| **Snowflake** | `Long` | Time-ordered | Machine-ID based, reverse-parseable |
| **ULID** | `String` 26-char | Lexicographic = time order | Millisecond precision, UUID-compatible |
| **KSUID** | `String` 27-char | Lexicographic = time order | Seconds precision, 128-bit random payload |
| **Hashids** | `String` variable | ❌ | Number obfuscation with salt |

## REST API Endpoints

```
GET /ids/snowflake              - generate + parse components (timestamp/machineId/sequence)
GET /ids/snowflake/parse/{id}   - reverse-parse existing Snowflake Long
GET /ids/snowflake/batch?count=N
GET /ids/ulid, /ids/ulid/batch
GET /ids/ksuid, /ids/ksuid/batch
GET /ids/hashids/encode?numbers=1,2,3
GET /ids/hashids/decode/{hash}
```

## Used bluetape4k Features

- `Snowflakers.Default` — singleton, auto machine-ID from NIC
- `Snowflake.parse(id)` — reverse-parse Long → SnowflakeId
- `Snowflake.nextIds(size)` — Sequence-based bulk generation
- `UlidGenerator` — StatefulMonotonic, same-millisecond monotonic guarantee
- `KsuidGenerator` — seconds-based time-sortable IDs
- `Hashids` — configurable salt + minHashLength

## Test Results

```
:spring-boot-idgenerator:test  BUILD SUCCESSFUL
10 tests passing
```

## README Highlights

- Algorithm comparison table (type, sortability, use cases)
- Before/after code snippets (BT vs raw approach)
- Operational warnings: machine-ID collision, clock rollback, Hashids security caveat
- Future work roadmap: Redis worker-ID allocation, Kafka event IDs, Exposed E2E

## Checklist

- [x] New module builds and all 10 tests pass
- [x] README with BT feature table + before/after + operational warnings
- [x] Lessons committed: `docs/lessons/2026-05-24-idgenerator-workshop.md`
- [x] No external infrastructure required (no Testcontainers)