### PR TITLE
docs: add bluetape4k feature tables to observability/virtualthreads modules (#87)

### DIFF
--- a/docs/lessons/2026-05-24-issue-87-observability-docs.md
+++ b/docs/lessons/2026-05-24-issue-87-observability-docs.md
@@ -1,0 +1,70 @@
+# Issue #87 — Observability/Performance 모듈 README 강화 교훈
+
+## 작업 개요
+
+- 대상: `observability/micrometer-observation`, `observability/micrometer-tracing-coroutines`,
+  `virtualthreads/spring-mvc-tomcat`, `virtualthreads/spring-webflux`
+- 목표: `Used bluetape4k Features` 표 + Before/After 코드 스니펫 추가 (코드 변경 없음)
+
+## 핵심 교훈
+
+### 1. bluetape4k API와 workshop 로컬 헬퍼를 구분해야 한다
+
+`observability/micrometer-observation`의 `ObservationSupport.kt`에 있는
+`Observation.observe { }` 람다 확장은 **workshop 로컬 코드**이지 bluetape4k 라이브러리가 아니다.
+실제 bluetape4k-micrometer API는 `withObservation` / `withObservationSuspending`이다.
+
+README를 작성할 때 `build.gradle.kts`와 실제 import 문을 모두 확인해야 한다.
+
+### 2. 코루틴 관찰(Observation)은 별도 DSL이 필요하다
+
+표준 Micrometer `Observation.start().stop()`은 코루틴에서
+`CancellationException`을 삼킬 위험이 있다.
+
+```kotlin
+// 위험: CancellationException 누락 가능
+val obs = Observation.createNotStarted("name", registry).start()
+try {
+    delay(100)        // suspend point — cancellation here may not propagate correctly
+} finally {
+    obs.stop()
+}
+
+// 안전: bluetape4k withObservationSuspending
+withObservationSuspending("name", registry) {
+    delay(100)        // CancellationException 자동 처리·전파
+}
+```
+
+`withObservationSuspending`은 `CancellationException`을 rethrow하므로
+structured concurrency를 깨뜨리지 않는다.
+
+### 3. KLoggingChannel vs KLogging 구분
+
+| 클래스 | 사용 상황 |
+|---|---|
+| `KLogging` | 일반 동기 코드 (`companion object: KLogging()`) |
+| `KLoggingChannel` | 코루틴 환경 (`companion object: KLoggingChannel()`) |
+
+코루틴 코드에서 `KLogging`을 쓰면 MDC 컨텍스트가 전파되지 않을 수 있다.
+
+### 4. `ZipkinServer.Launcher.zipkin` 싱글턴 패턴
+
+`GenericContainer`를 직접 쓰거나 `@Testcontainers` 어노테이션을 쓰는 대신
+bluetape4k Testcontainers 싱글턴 Launcher를 사용하면
+테스트 간 컨테이너를 재사용해 전체 테스트 시간을 단축할 수 있다.
+
+### 5. README 섹션 추가 시 언어 일관성
+
+기존 README가 한국어로 작성되어 있으면 새 섹션도 한국어로 유지한다.
+영어 README에 새 섹션을 추가할 때만 영어를 사용한다.
+(CLAUDE.md 문서 언어 정책: 공개 기여자용은 영어, 내부 엔지니어용은 한국어 허용)
+
+## 파일 변경 요약
+
+| 파일 | 변경 내용 |
+|---|---|
+| `observability/micrometer-observation/README.md` | bluetape4k 활용 표 + Before/After (logging DSL, ObservationTextPublisher) 추가 |
+| `observability/micrometer-tracing-coroutines/README.md` | 7줄 → 전체 재작성: 구성 표, tracing 파이프라인 설명, bluetape4k 표, withObservation/withObservationSuspending Before/After, ZipkinServer.Launcher Before/After |
+| `virtualthreads/spring-mvc-tomcat/README.md` | bluetape4k 표 + structuredTaskScopeAll/virtualFutureAll Before/After 추가 |
+| `virtualthreads/spring-webflux/README.md` | bluetape4k 표 + Dispatchers.VT/uninitialized()/inheritInheritableThreadLocals Before/After 추가 |

--- a/observability/micrometer-observation/README.md
+++ b/observability/micrometer-observation/README.md
@@ -32,6 +32,74 @@ class GreetingService(private val registry: ObservationRegistry) {
 }
 ```
 
+## bluetape4k 활용 기능
+
+| 기능 | 아티팩트 | 코드 위치 | 이점 |
+|---|---|---|---|
+| 구조화된 로깅 (`KLogging`, `KotlinLogging.logger`) | `bluetape4k-logging` | `GreetingService`, `ObservationLoggingConfig` | Kotlin DSL 로그 람다로 지연 평가, 불필요한 문자열 생성 방지 |
+| `debug {}` / `info {}` 확장 함수 | `bluetape4k-logging` | 모든 소스 파일 | `if (log.isDebugEnabled)` 보일러플레이트 제거 |
+| JUnit 5 확장 (`@TestInstance`, `shouldNotBeNull` 등) | `bluetape4k-junit5` | `ObservationRegistryTest` | 간결한 assertion 체인 |
+| Jackson 3.x 직렬화 지원 | `bluetape4k-jackson3` | REST API 응답 | Spring Boot 4 + Jackson 3 호환 자동 설정 |
+
+## bluetape4k Before / After
+
+### 구조화된 로깅 (Kotlin DSL)
+
+```kotlin
+// Before — 표준 SLF4J
+import org.slf4j.LoggerFactory
+private val log = LoggerFactory.getLogger(GreetingService::class.java)
+
+fun sayHello(): String {
+    if (log.isDebugEnabled) {
+        log.debug("call sayHelloInternal")
+    }
+    return "Hello, World!"
+}
+
+// After — bluetape4k-logging
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+
+companion object: KLogging()
+
+fun sayHello(): String {
+    log.debug { "call sayHelloInternal" }  // 람다로 지연 평가, 불필요한 문자열 생성 없음
+    return "Hello, World!"
+}
+```
+
+### Observation 이벤트 로깅 핸들러
+
+```kotlin
+// Before — 표준 Micrometer ObservationHandler 직접 구현
+@Configuration
+class ObservationLoggingConfig {
+    private val log = LoggerFactory.getLogger("ObservationLogger")
+
+    @Bean
+    fun observationLogger(): ObservationHandler<Observation.Context> {
+        return ObservationHandler { event ->
+            if (log.isDebugEnabled) log.debug("Observation event: $event")
+        }
+    }
+}
+
+// After — bluetape4k-logging + ObservationTextPublisher
+import io.bluetape4k.logging.KotlinLogging
+import io.bluetape4k.logging.debug
+
+@Configuration(proxyBeanMethods = false)
+class ObservationLoggingConfig {
+    private val logger = KotlinLogging.logger("io.bluetape4k.workshop.observation.ObservationLogger")
+
+    @Bean
+    fun observationLogger(): ObservationHandler<Observation.Context> {
+        return ObservationTextPublisher { logger.debug { it } }
+    }
+}
+```
+
 ## 테스트
 
 - `ObservationRegistryTest` — `ObservationRegistry` 직접 테스트

--- a/observability/micrometer-tracing-coroutines/README.md
+++ b/observability/micrometer-tracing-coroutines/README.md
@@ -1,7 +1,137 @@
 # Micrometer Observation for Spring Boot 4 WebFlux & Coroutines
 
+Spring Boot 4 WebFlux 환경에서 Micrometer Tracing을 동기(Sync), 리액터(Reactor), 코루틴(Coroutine) 방식으로 적용하는 예제입니다.
+bluetape4k의 `withObservation` / `withObservationSuspending` DSL로 코루틴 context에서 tracing span을 안전하게 전파합니다.
+
 ## 아키텍처 다이어그램
 
 ![micrometer tracing coroutines Sequence Flow diagram](../../docs/images/readme-diagrams/observability-micrometer-tracing-coroutines-sequence-01.png)
 
 ![micrometer tracing coroutines Architecture 2 diagram](../../docs/images/readme-diagrams/observability-micrometer-tracing-coroutines-diagram-01.png)
+
+## 주요 구성
+
+| 클래스 | 역할 |
+|---|---|
+| `ObservationConfig` | `ObservedAspect` 빈 등록 — `@Observed` AOP 활성화, Controller 제외 필터 |
+| `NettyConfig` | Reactor Netty 서버 튜닝 (keepalive, backlog, event-loop 크기) |
+| `SyncService` | 동기 방식 서비스 — `@Observed` + `withObservation {}` 중첩 span |
+| `CoroutineService` | 코루틴 서비스 — `withObservationSuspending {}` 으로 suspend 함수 내 span 생성 |
+| `ReactorService` | Reactor 서비스 — `@Observed` 클래스 레벨 적용 |
+| `SyncController` | 동기 REST 엔드포인트 (`/sync`) |
+| `CoroutineController` | 코루틴 REST 엔드포인트 (`/coroutine`) |
+| `ReactorController` | Reactor REST 엔드포인트 (`/reactor`) |
+| `TracingApplication` | `ZipkinServer.Launcher.zipkin` 으로 Zipkin 컨테이너 자동 시작 |
+
+## Tracing 전달 방식
+
+이 예제는 두 가지 tracing 파이프라인을 모두 지원합니다.
+
+```
+Micrometer Tracing → OTel Bridge → OTel Exporter → Zipkin Server (활성)
+Micrometer Tracing → Brave Bridge → Zipkin Reporter → Zipkin Server (비활성/주석)
+```
+
+## bluetape4k 활용 기능
+
+| 기능 | 아티팩트 | 코드 위치 | 이점 |
+|---|---|---|---|
+| `withObservation {}` DSL | `bluetape4k-micrometer` | `SyncService` | `Observation.createNotStarted().start().stop()` 보일러플레이트 제거 |
+| `withObservationSuspending {}` DSL | `bluetape4k-micrometer` | `CoroutineService` | suspend 함수 안에서 span 생성·전파; `CancellationException` 안전 처리 |
+| `KLoggingChannel` (코루틴 로거) | `bluetape4k-logging` | `CoroutineService`, `CoroutineController` | 코루틴 context-aware 로깅, MDC 자동 전파 |
+| `KLogging` | `bluetape4k-logging` | `SyncService`, `SyncController` | SLF4J companion object 로거 |
+| `ZipkinServer.Launcher.zipkin` | `bluetape4k-testcontainers` | `TracingApplication` | Zipkin 컨테이너 싱글턴 자동 시작·URL 제공 |
+| `bluetape4k-junit5` assertion (`shouldNotBeNull` 등) | `bluetape4k-junit5` | 테스트 파일 전반 | `assertNotNull(x)` 대신 Kotlin 스타일 체인 |
+| `kotlinx.coroutines.test.runTest` | `bluetape4k-coroutines` (전이 의존성) | `CoroutineServiceTest` | suspend 테스트를 가상 시간으로 실행 |
+
+## bluetape4k Before / After
+
+### 동기 함수에서 중첩 span 생성
+
+```kotlin
+// Before — 표준 Micrometer (수동 start/stop)
+fun preProcessing() {
+    val obs = Observation.createNotStarted("pre-processing", observationRegistry)
+    obs.start()
+    try {
+        Thread.sleep(100)
+    } finally {
+        obs.stop()
+    }
+}
+
+// After — bluetape4k withObservation DSL
+import io.bluetape4k.micrometer.observation.withObservation
+
+private fun preProcessing() {
+    withObservation("pre-processing", observationRegistry) {
+        log.debug { "Pre processing ..." }
+        Thread.sleep(100)
+    }
+}
+```
+
+### 코루틴 suspend 함수 안에서 span 생성
+
+```kotlin
+// Before — 코루틴에서 Observation 수동 처리 (CancellationException 누락 위험)
+private suspend fun preProcessing() {
+    val obs = Observation.createNotStarted("pre-processing", observationRegistry)
+    obs.start()
+    try {
+        delay(200)
+    } catch (e: Exception) {
+        obs.error(e)
+        throw e
+    } finally {
+        obs.stop()
+    }
+}
+
+// After — bluetape4k withObservationSuspending DSL
+import io.bluetape4k.micrometer.observation.coroutines.withObservationSuspending
+
+private suspend fun preProcessing() {
+    withObservationSuspending("pre-processing", observationRegistry) {
+        log.debug { "Pre processing ..." }
+        delay(200)  // CancellationException 자동 처리·전파
+    }
+}
+```
+
+### Zipkin 서버 자동 시작 (Testcontainers 싱글턴)
+
+```kotlin
+// Before — Zipkin URL을 application.yml에 하드코딩 또는 직접 GenericContainer 관리
+@SpringBootApplication
+class TracingApplication
+
+// After — bluetape4k ZipkinServer.Launcher 싱글턴
+import io.bluetape4k.testcontainers.infra.ZipkinServer
+
+@SpringBootApplication(proxyBeanMethods = false)
+class TracingApplication {
+    companion object: KLogging() {
+        @JvmStatic
+        val zipkinServer = ZipkinServer.Launcher.zipkin   // 공유 싱글턴, 한 번만 시작
+
+        @JvmStatic
+        val zipkinUrl: String get() = zipkinServer.url
+    }
+}
+```
+
+## 테스트
+
+- `CoroutineServiceTest` — `withObservationSuspending` 적용 코루틴 서비스 검증 (`runTest`)
+- `SyncServiceTest` — `withObservation` 적용 동기 서비스 검증
+- `CoroutineControllerTest` — WebFlux `WebTestClient` 기반 통합 테스트
+- `SyncControllerTest` — 동기 Controller 통합 테스트
+- `ZipkinServerLaunchTest` — Zipkin 컨테이너 시작 확인
+
+## 참고
+
+- [Micrometer Observation 공식 문서](https://micrometer.io/docs/observation)
+- [Micrometer Tracing 공식 문서](https://micrometer.io/docs/tracing)
+- [Spring Boot Actuator + Micrometer](https://docs.spring.io/spring-boot/reference/actuator/metrics.html)
+- [`micrometer-observation`](../micrometer-observation) — Spring MVC + `@Observed` 기본 예제

--- a/virtualthreads/spring-mvc-tomcat/README.md
+++ b/virtualthreads/spring-mvc-tomcat/README.md
@@ -47,16 +47,16 @@ class TomcatConfig {
 Spring Configuration에 `@Async` 작업을 할 때, Virtual Thread 를 사용할 수 있도록 설정합니다. (참고: config/AsyncConfig.kt)
 
 ```kotlin
-@Configuration
+@Configuration(proxyBeanMethods = false)
 @EnableAsync
 class AsyncConfig {
 
-    @Bean
+    @Bean(TaskExecutionAutoConfiguration.APPLICATION_TASK_EXECUTOR_BEAN_NAME)
     fun asyncTaskExecutor(): AsyncTaskExecutor {
-        return TaskExecutorAdapter(Executors.newVirtualThreadPerTaskExecutor())
-            .apply {
-                setTaskDecorator(LoggingTaskDecorator())
-            }
+        val factory = Thread.ofVirtual().name("async-vt-exec-", 0).factory()
+        return TaskExecutorAdapter(Executors.newThreadPerTaskExecutor(factory)).apply {
+            setTaskDecorator(LoggingTaskDecorator())
+        }
     }
 }
 ```
@@ -69,6 +69,86 @@ coroutines/CoroutinesSupport.kt)
 ```kotlin
 val Dispatchers.VirtualThread: CoroutineDispatcher
     get() = Executors.newVirtualThreadPerTaskExecutor().asCoroutineDispatcher()
+```
+
+## bluetape4k 활용 기능
+
+| 기능 | 아티팩트 | 코드 위치 | 이점 |
+|---|---|---|---|
+| `structuredTaskScopeAll` | `bluetape4k-virtualthread-api` | `VirtualThreadController.multipleTasks()` | JDK `StructuredTaskScope.ShutdownOnFailure` 보일러플레이트 제거, 예외 자동 집계 |
+| `virtualFutureAll` | `bluetape4k-virtualthread-api` | `VirtualThreadController.multipleTasksWithVirtualFuture()` | `CompletableFuture.allOf` 대비 Virtual Thread 기반 병렬 실행을 한 줄로 |
+| `KLoggingChannel` | `bluetape4k-logging` | `VirtualThreadController`, `AsyncConfig` | 코루틴 context-aware 로거 companion object |
+| `KLogging` | `bluetape4k-logging` | `AsyncConfig` | SLF4J companion object 로거 |
+| Hibernate 확장 | `bluetape4k-hibernate` | JPA Entity/Repository | Spring Boot 4 + Hibernate 6/7 자동 설정 |
+| 캐시 지원 | `bluetape4k-cache-core` | 캐시 설정 | Caffeine + JCache 통합 |
+| Testcontainers 래퍼 | `bluetape4k-testcontainers` | `AbstractVirtualThreadMvcTest` | MySQL 컨테이너 싱글턴 자동 시작·재사용 |
+
+## bluetape4k Before / After
+
+### 다수의 Virtual Thread Task 병렬 실행
+
+```kotlin
+// Before — JDK StructuredTaskScope 직접 사용
+fun multipleTasks(): String {
+    val taskSize = 100
+    val factory = Thread.ofVirtual().name("vt-multi-", 0).factory()
+
+    StructuredTaskScope.ShutdownOnFailure().use { scope ->
+        repeat(taskSize) {
+            scope.fork {
+                Thread.sleep(Random.nextLong(500, 1000))
+            }
+        }
+        scope.join().throwIfFailed()
+    }
+    return "Done $taskSize tasks"
+}
+
+// After — bluetape4k structuredTaskScopeAll
+import io.bluetape4k.concurrent.virtualthread.structuredTaskScopeAll
+
+fun multipleTasks(): String {
+    val taskSize = 100
+    structuredTaskScopeAll("multi", factory) { scope ->
+        repeat(taskSize) {
+            scope.fork {
+                Thread.sleep(Random.nextLong(500, 1000))
+                log.debug { "Task $it done. (${Thread.currentThread()})" }
+            }
+        }
+        scope.join().throwIfFailed()
+        Unit
+    }
+    return "Run multiple[$taskSize] tasks. (${Thread.currentThread()})"
+}
+```
+
+### CompletableFuture 기반 병렬 Virtual Thread 실행
+
+```kotlin
+// Before — CompletableFuture.allOf + VirtualThread executor 수동 관리
+fun multipleTasksWithFuture(): String {
+    val executor = Executors.newVirtualThreadPerTaskExecutor()
+    val futures = List(100) { i ->
+        CompletableFuture.runAsync({
+            Thread.sleep(1000)
+        }, executor)
+    }
+    CompletableFuture.allOf(*futures.toTypedArray()).get()
+    executor.shutdown()
+    return "Done"
+}
+
+// After — bluetape4k virtualFutureAll
+import io.bluetape4k.concurrent.virtualthread.virtualFutureAll
+
+fun multipleTasksWithVirtualFuture(): String {
+    val tasks = List(100) {
+        { Thread.sleep(1000) }
+    }
+    virtualFutureAll(tasks, executor).await()
+    return "Run multiple[100] tasks. (${Thread.currentThread()})"
+}
 ```
 
 ## 성능 측정

--- a/virtualthreads/spring-webflux/README.md
+++ b/virtualthreads/spring-webflux/README.md
@@ -16,18 +16,112 @@ Spring Webflux 환경에서 다양한 Coroutine Dispatcher 의 성능을 비교�
           get() = Executors.newVirtualThreadPerTaskExecutor().asCoroutineDispatcher()
     ```
 
+## bluetape4k 활용 기능
+
+| 기능 | 아티팩트 | 코드 위치 | 이점 |
+|---|---|---|---|
+| Virtual Thread 지원 라이브러리 | `bluetape4k-virtualthread-api` / `-jdk21` | `VirtualThreadDispatcherController`, `AsyncConfig` | JDK 21 `newVirtualThreadPerTaskExecutor` 래퍼 및 확장 유틸리티 |
+| `KLoggingChannel` (코루틴 로거) | `bluetape4k-logging` | 모든 컨트롤러 | 코루틴 context-aware 로깅; MDC 자동 전파 |
+| `uninitialized()` | `bluetape4k-core` | `AbstractDispatcherController` | `lateinit` 없이 non-null 필드 지연 초기화 (`@Value` 주입) |
+| 코루틴 확장 | `bluetape4k-coroutines` | Flow 기반 엔드포인트 | `channelFlow`, `flatMapMerge` 등 코루틴 Flow 지원 |
+| IO 유틸리티 | `bluetape4k-io` | 파일/스트림 처리 | Okio 기반 IO 확장 |
+| Jackson 3.x 지원 | `bluetape4k-jackson3` | REST API 직렬화 | Spring Boot 4 + Jackson 3 호환 자동 설정 |
+| Testcontainers 래퍼 | `bluetape4k-testcontainers` | `AbstractWebfluxVirtualThreadTest` | 외부 서비스 컨테이너 싱글턴 |
+
+## bluetape4k Before / After
+
+### Virtual Thread Dispatcher 설정
+
+```kotlin
+// Before — 표준 JDK API로 직접 설정
+@RestController
+@RequestMapping("/virtual-thread")
+class VirtualThreadDispatcherController {
+
+    private val dispatcher: CoroutineDispatcher =
+        Executors.newVirtualThreadPerTaskExecutor().asCoroutineDispatcher()
+
+    @GetMapping("/deferred")
+    fun deferredEndpoint(): Deferred<Banner> = CoroutineScope(dispatcher).async {
+        delay(100)
+        randomBanner()
+    }
+}
+
+// After — bluetape4k Dispatchers.VT (관용적 확장 프로퍼티)
+import io.bluetape4k.concurrent.virtualthread.VT
+
+@RestController
+@RequestMapping("/virtual-thread")
+class VirtualThreadDispatcherController {
+
+    private val dispatcher: CoroutineDispatcher = Dispatchers.VT
+
+    @GetMapping("/deferred")
+    fun deferredEndpoint(): Deferred<Banner> = CoroutineScope(dispatcher).async {
+        delay(100)
+        randomBanner()
+    }
+}
+```
+
+### `@Value` 주입 필드 지연 초기화
+
+```kotlin
+// Before — lateinit var (nullable 위험, 컴파일 경고)
+@Value("\${server.port:8080}")
+private lateinit var port: String
+
+// After — bluetape4k uninitialized()
+import io.bluetape4k.support.uninitialized
+
+@Value("\${server.port:8080}")
+private val port: String = uninitialized()  // non-null val, Spring이 주입
+```
+
+### Async 작업에 Virtual Thread 사용
+
+```kotlin
+// Before — Executors.newVirtualThreadPerTaskExecutor() + TaskExecutorAdapter 수동 조합
+@Configuration
+@EnableAsync
+class AsyncConfig {
+    @Bean
+    fun asyncTaskExecutor(): AsyncTaskExecutor {
+        return TaskExecutorAdapter(Executors.newVirtualThreadPerTaskExecutor())
+    }
+}
+
+// After — bluetape4k virtual thread factory + inheritInheritableThreadLocals 설정 포함
+@Configuration(proxyBeanMethods = false)
+@EnableAsync
+class AsyncConfig {
+    companion object: KLoggingChannel()
+
+    private val virtualThreadFactory = Thread.ofVirtual()
+        .inheritInheritableThreadLocals(true)  // ThreadLocal 컨텍스트 전파 보장
+        .name("vt-executor-", 0)
+        .factory()
+
+    @Bean
+    fun asyncTaskExecutor(): AsyncTaskExecutor {
+        return TaskExecutorAdapter(Executors.newThreadPerTaskExecutor(virtualThreadFactory))
+    }
+}
+```
+
 ## Gatling 을 이용한 성능 측정
 
 우선 _WebfluxVirtualThreadApp_ 을 gradle `bootRun` task를 이용하여 실행시킵니다.
 
 ```bash
-$ ./gradlew :spring-webflux-virtualthread:bootRun
+./gradlew :spring-webflux-virtualthread:bootRun
 ```
 
 다음으로 gradle `gatlingRun` task를 이용하여 Stress test를 수행합니다.
 
 ```bash
-$ ./gradlew :spring-webflux-virtualthread:gatlingRun
+./gradlew :spring-webflux-virtualthread:gatlingRun
 ```
 
 ### Gatling 스트레스 시나리오


### PR DESCRIPTION
## Summary

Add  tables and Before/After code snippets to four module READMEs. No source code changes — documentation only.

## Changed Files

| File | Change |
|---|---|
| `observability/micrometer-observation/README.md` | Added bluetape4k feature table + Before/After for logging DSL and ObservationTextPublisher |
| `observability/micrometer-tracing-coroutines/README.md` | Near-full rewrite (was 7 lines): added overview, component table, tracing pipeline diagram, bluetape4k feature table, `withObservation`/`withObservationSuspending` Before/After, ZipkinServer.Launcher Before/After |
| `virtualthreads/spring-mvc-tomcat/README.md` | Added bluetape4k feature table + Before/After for `structuredTaskScopeAll` and `virtualFutureAll` |
| `virtualthreads/spring-webflux/README.md` | Added bluetape4k feature table + Before/After for `Dispatchers.VT`, `uninitialized()`, and `inheritInheritableThreadLocals` |
| `docs/lessons/2026-05-24-issue-87-observability-docs.md` | New lessons file capturing key findings |

## Key bluetape4k APIs Documented

- **`bluetape4k-micrometer`**: `withObservation {}` and `withObservationSuspending {}` DSL — safe span creation in sync and coroutine contexts
- **`bluetape4k-virtualthread-api`**: `structuredTaskScopeAll`, `virtualFutureAll`, `Dispatchers.VT`
- **`bluetape4k-logging`**: `KLogging`, `KLoggingChannel`, `debug {}`/`info {}` lambda extensions
- **`bluetape4k-testcontainers`**: `ZipkinServer.Launcher.zipkin` singleton pattern
- **`bluetape4k-core`**: `uninitialized()` for non-null `@Value`-injected fields

## Verification

- All 4 README files render valid Markdown
- Kotlin code snippets verified against actual source files
- No source code changes