### PR TITLE
docs: add bluetape4k feature tables to async/reactive modules (#86)

### DIFF
--- a/docs/lessons/2026-05-24-issue-86-async-reactive-docs.md
+++ b/docs/lessons/2026-05-24-issue-86-async-reactive-docs.md
@@ -1,0 +1,54 @@
+# Issue #86: Async/Reactive Module README Enhancement
+
+## 개요
+
+bluetape4k-workshop의 async/reactive 관련 6개 모듈 README에 `사용된 bluetape4k 기능` 표와
+`bluetape4k Before / After` 코드 스니펫을 추가했습니다.
+
+## 업데이트된 모듈
+
+| 모듈 | 추가 섹션 | 핵심 bluetape4k API |
+|---|---|---|
+| `kotlin/coroutines` | 기능 표 + Before/After 4개 | `KLoggingChannel`, `suspendLogging`, `Flow.log()`, `assertResult` |
+| `spring-boot/webflux-coroutines` | 이미 완성됨 — 변경 없음 | `Dispatchers.VT`, `Flow.async`, `Runtimex`, `KLoggingChannel` |
+| `spring-data/r2dbc-coroutines` | 기능 표 + Before/After 2개 | `*Suspending` 확장 함수군, `runSuspendIO` |
+| `vertx/coroutines` | 기능 표 + Before/After 2개 | `suspendHandler`, `withSuspendTestContext` |
+| `vertx/vertx-sqlclient` | 기능 표 + Before/After 3개 | `withSuspendTransaction`, `testWithSuspendTransaction`, `MySQL8Server.Launcher` |
+| `vertx/vertx-webclient` | 기능 표 + Before/After 2개 | `suspendHandler`, `Jackson`, `withSuspendTestContext` |
+
+## 방법론: 실제 코드 기반 문서화
+
+기능 표와 Before/After 스니펫은 각 모듈의 실제 import 구문을 분석하여 작성했습니다.
+태스크 명세에서 제안된 API 목록(`Dispatchers.VT`, `SuspendedJobTester` 등)은 실제
+`kotlin/coroutines` 모듈에 사용되지 않으므로 명세 목록이 아닌 실제 사용 API를 기재했습니다.
+
+## 주요 발견
+
+### `spring-data/r2dbc-coroutines`의 `*Suspending` 확장 함수군
+
+`bluetape4k-spring-boot4-r2dbc` 아티팩트가 `R2dbcEntityOperations`에 대한
+suspend 래퍼를 제공합니다. `countAllSuspending`, `selectAllSuspending`,
+`findOneByIdSuspending`, `findOneByIdOrNullSuspending`, `findFirstByIdSuspending`,
+`insertSuspending`, `deleteAllSuspending` 등 모든 CRUD 연산이 suspend 함수로 제공되어
+Mono/Flux 변환 보일러플레이트가 완전히 제거됩니다.
+
+### `vertx/vertx-sqlclient`의 트랜잭션 패턴
+
+`withSuspendTransaction { conn -> }`: 트랜잭션을 열고 suspend 블록 실행 후 예외 시 자동 롤백.
+
+`testWithSuspendTransaction(testContext, pool) { }`: 테스트용 확장으로
+`VertxTestContext` 완료 처리와 트랜잭션 롤백을 결합하여 테스트 격리를 자동으로 보장합니다.
+
+### `kotlin/coroutines`의 실제 bluetape4k 의존성
+
+이 모듈은 `Dispatchers.VT`나 `SuspendedJobTester`를 사용하지 않습니다.
+실제 사용 API: `KLoggingChannel`, `suspendLogging`, `coroutines.support.log`,
+`Flow.log()`, `coroutines.tests.assertResult`, `PropertyCoroutineContext`,
+`runSuspendTest`, `Fakers`, `OutputCapture`, `withLoggingContext`.
+
+## 적용한 문서화 원칙
+
+1. **실제 코드 기반**: import 분석으로 실제 사용 API만 기재
+2. **Before/After 정직성**: Before는 표준 라이브러리 방식, After는 bluetape4k 방식으로만 비교
+3. **한국어 유지**: 기존 README의 한국어 스타일 유지 (workspace CLAUDE.md 정책)
+4. **중복 없음**: 이미 완성된 webflux-coroutines README는 수정하지 않음

--- a/kotlin/coroutines/README.md
+++ b/kotlin/coroutines/README.md
@@ -8,8 +8,6 @@ Kotlin Coroutines의 핵심 개념을 학습하는 예제 모음입니다.
 
 ## 예제 범주
 
-## 예제 범주
-
 ### 기초 (`guide/`)
 | 파일 | 내용 |
 |---|---|
@@ -39,6 +37,85 @@ Kotlin Coroutines의 핵심 개념을 학습하는 예제 모음입니다.
 
 ### Flow 테스트 (`tests/`)
 - `TurbineExamples` — [Turbine](https://github.com/cashapp/turbine) 라이브러리를 사용한 Flow 테스트
+
+## 사용된 bluetape4k 기능
+
+| 기능 | 아티팩트 | 코드 위치 | 이점 |
+|---|---|---|---|
+| `KLoggingChannel` | `bluetape4k-logging` | 모든 companion object | 코루틴 컨텍스트를 포함한 구조적 로깅; SLF4J MDC와 연동 |
+| `suspendLogging { }` | `bluetape4k-logging` | `DispatcherExamples` | suspend 컨텍스트에서 안전하게 로그 메시지 빌드 |
+| `coroutines.support.log` | `bluetape4k-coroutines` | `DispatcherExamples` | Job에 이름 태그 달아 완료 로그 자동 출력 |
+| `Flow<T>.log()` | `bluetape4k-coroutines` | `FlowBuilderExamples`, `FlowLifecycleExamples` | Flow 파이프라인 중간에 emit 값 로깅 |
+| `coroutines.tests.assertResult` | `bluetape4k-coroutines` | `FlowBuilderExamples`, `CallbackFlowExamples` | Flow 결과를 Turbine 없이 검증하는 테스트 유틸 |
+| `PropertyCoroutineContext` | `bluetape4k-coroutines` | `context/` 패키지 | 타입 안전 키-값 저장소를 가진 커스텀 CoroutineContext 구현 |
+| `runSuspendTest { }` | `bluetape4k-junit5` | 테스트 전체 | JUnit 5에서 suspend 테스트를 실행하는 확장 함수 |
+| `Fakers` | `bluetape4k-junit5` | 테스트 픽스처 | JavaFaker 기반 테스트 데이터 생성 유틸리티 |
+| `OutputCapture` / `OutputCapturer` | `bluetape4k-junit5` | 출력 검증 테스트 | stdout/stderr 캡처 JUnit 5 확장 |
+| `bluetape4k-assertions` | `bluetape4k-core` | 테스트 전체 | Kluent 스타일의 가독성 높은 단언문 (`shouldBeEqualTo`, `shouldNotBeNull` 등) |
+| `Uuid` (idgenerators) | `bluetape4k-idgenerators` | `UuidProviderCoroutineContext` | UUID v7 등 다양한 ID 생성 전략 |
+| `withLoggingContext { }` | `bluetape4k-logging` | MDC 연동 예제 | Kotlin DSL 방식의 MDC context 설정 |
+
+## bluetape4k Before / After
+
+### `KLoggingChannel` vs 표준 Logger
+
+```kotlin
+// Before — SLF4J LoggerFactory 직접 사용
+class MyClass {
+    companion object {
+        private val log = LoggerFactory.getLogger(MyClass::class.java)
+    }
+}
+
+// After — bluetape4k KLoggingChannel (코루틴 컨텍스트 포함)
+class MyClass {
+    companion object: KLoggingChannel()
+    // log 프로퍼티 자동 생성 + 코루틴 컨텍스트 정보 로그에 포함
+}
+```
+
+### `suspendLogging { }` vs 일반 로그 호출
+
+```kotlin
+// Before — 코루틴 내 일반 로그 (스레드 정보만 포함)
+launch(Dispatchers.IO) {
+    log.debug("Running on thread ${Thread.currentThread().name}")
+}
+
+// After — bluetape4k suspendLogging (코루틴 이름 + 스레드 정보 포함)
+launch(Dispatchers.IO) {
+    suspendLogging { "Running on thread ${Thread.currentThread().name}" }
+    // 출력 예: [DefaultDispatcher-worker-1 @coroutine#3] Running on thread ...
+}
+```
+
+### `Flow<T>.log()` 디버깅 연산자
+
+```kotlin
+// Before — 중간 값 확인을 위한 onEach + println
+flow { emit(1); emit(2) }
+    .onEach { println("value: $it") }
+    .collect()
+
+// After — bluetape4k .log() 확장 함수
+flow { emit(1); emit(2) }
+    .log("my-flow")   // 자동으로 emit/complete/error 이벤트 로깅
+    .collect()
+```
+
+### `coroutines.tests.assertResult` vs Turbine
+
+```kotlin
+// Before — Turbine 라이브러리 의존 필요
+someFlow.test {
+    awaitItem() shouldBeEqualTo 1
+    awaitItem() shouldBeEqualTo 2
+    awaitComplete()
+}
+
+// After — bluetape4k assertResult (추가 의존성 없음)
+someFlow.assertResult(1, 2)
+```
 
 ## 참고
 

--- a/spring-data/r2dbc-coroutines/README.md
+++ b/spring-data/r2dbc-coroutines/README.md
@@ -6,6 +6,73 @@
 
 ![r2dbc coroutines Sequence Flow 2 diagram](../../docs/images/readme-diagrams/spring-data-r2dbc-coroutines-sequence-01.png)
 
+## 사용된 bluetape4k 기능
+
+| 기능 | 아티팩트 | 코드 위치 | 이점 |
+|---|---|---|---|
+| `*Suspending` 확장 함수군 | `bluetape4k-spring-boot4-r2dbc` | `PostRepository.kt` | `R2dbcEntityOperations`에 suspend 래퍼 추가 — Flow/Mono 변환 없이 바로 suspend 함수 호출 |
+| `countAllSuspending<T>()` | `bluetape4k-spring-boot4-r2dbc` | `PostRepository.count()` | `operations.count(...)` + `.awaitSingle()` 패턴을 한 줄로 대체 |
+| `selectAllSuspending<T>()` | `bluetape4k-spring-boot4-r2dbc` | `PostRepository.findAll()` | `Flux` → `Flow` 변환을 내부에서 처리 |
+| `findOneByIdSuspending(id)` / `findOneByIdOrNullSuspending(id)` | `bluetape4k-spring-boot4-r2dbc` | `PostRepository.findOneById()` | ID로 단건 조회 — null 여부를 반환 타입으로 표현 |
+| `findFirstByIdSuspending(id)` / `findFirstByIdOrNullSuspending(id)` | `bluetape4k-spring-boot4-r2dbc` | `PostRepository.findFirstById()` | 첫 번째 매칭 엔티티 조회 |
+| `insertSuspending(entity)` | `bluetape4k-spring-boot4-r2dbc` | `PostRepository.save()` | insert 후 생성된 엔티티 반환 — Mono 체이닝 없이 suspend |
+| `deleteAllSuspending<T>()` | `bluetape4k-spring-boot4-r2dbc` | `PostRepository.deleteAll()` | 타입 파라미터로 대상 엔티티 지정, 삭제된 행 수 반환 |
+| `runSuspendIO { }` | `bluetape4k-junit5` | 테스트 전체 | `runBlocking(Dispatchers.IO)` 패턴을 JUnit 5 확장으로 제공 |
+| `KLoggingChannel` | `bluetape4k-logging` | 모든 companion object | 코루틴 컨텍스트 포함 구조적 로깅 |
+| `bluetape4k-assertions` | `bluetape4k-core` | 테스트 전체 | 가독성 높은 단언문 (`shouldBeEqualTo`, `shouldNotBeNull` 등) |
+
+## bluetape4k Before / After
+
+### `R2dbcEntityOperations` suspend 확장 함수
+
+```kotlin
+// Before — Reactor API + awaitXxx() 수동 변환
+@Repository
+class PostRepository(private val operations: R2dbcEntityOperations) {
+    suspend fun count(): Long =
+        operations.count(Query.empty(), Post::class.java).awaitSingle()
+
+    fun findAll(): Flow<Post> =
+        operations.select(Post::class.java).all().asFlow()
+
+    suspend fun findOneById(id: Long): Post =
+        operations.selectOne(Query.query(Criteria.where("id").`is`(id)), Post::class.java)
+            .awaitSingleOrNull() ?: throw NoSuchElementException("Post not found: $id")
+
+    suspend fun save(post: Post): Post =
+        operations.insert(post).awaitSingle()
+}
+
+// After — bluetape4k *Suspending 확장 함수 (보일러플레이트 제거)
+@Repository
+class PostRepository(private val operations: R2dbcEntityOperations) {
+    suspend fun count(): Long = operations.countAllSuspending<Post>()
+    fun findAll(): Flow<Post> = operations.selectAllSuspending<Post>()
+    suspend fun findOneById(id: Long): Post = operations.findOneByIdSuspending(id)
+    suspend fun findOneByIdOrNull(id: Long): Post? = operations.findOneByIdOrNullSuspending(id)
+    suspend fun save(post: Post): Post = operations.insertSuspending(post)
+    suspend fun deleteAll(): Long = operations.deleteAllSuspending<Post>()
+}
+```
+
+### `runSuspendIO { }` 테스트 패턴
+
+```kotlin
+// Before — runBlocking + Dispatchers.IO 명시
+@Test
+fun `find all posts`() = runBlocking(Dispatchers.IO) {
+    val posts = postRepository.findAll().toList()
+    posts.shouldNotBeEmpty()
+}
+
+// After — bluetape4k runSuspendIO (더 명확한 의도 표현)
+@Test
+fun `find all posts`() = runSuspendIO {
+    val posts = postRepository.findAll().toList()
+    posts.shouldNotBeEmpty()
+}
+```
+
 ## 참고
 
 * [Spring Data Examples - r2dbc/example](https://github.com/spring-projects/spring-data-examples/tree/main/r2dbc/example)

--- a/vertx/coroutines/README.md
+++ b/vertx/coroutines/README.md
@@ -44,6 +44,70 @@ router.get("/movie/:id").suspendHandler { ctx ->
 | `POST` | `/rateMovie/:id?getRating=N` | 영화 평점 등록 |
 | `GET` | `/getRating/:id` | 영화 평균 평점 조회 |
 
+## 사용된 bluetape4k 기능
+
+| 기능 | 아티팩트 | 코드 위치 | 이점 |
+|---|---|---|---|
+| `suspendHandler { }` | `bluetape4k-vertx` | `MainVerticle.kt` | Vert.x `Handler<RoutingContext>`를 suspend 람다로 래핑 — 콜백 중첩 없이 순차 코드 작성 |
+| `withSuspendTestContext` | `bluetape4k-vertx` | 테스트 전체 | Vert.x `VertxTestContext`를 코루틴 블록에서 안전하게 사용하는 테스트 헬퍼 |
+| `runSuspendTest { }` | `bluetape4k-junit5` | 테스트 전체 | JUnit 5에서 suspend 테스트를 실행하는 확장 함수 |
+| `KLoggingChannel` | `bluetape4k-logging` | 모든 companion object | 코루틴 컨텍스트 포함 구조적 로깅 |
+| `bluetape4k-assertions` | `bluetape4k-core` | 테스트 전체 | 가독성 높은 단언문 (`shouldBeEqualTo`, `shouldNotBeEmpty` 등) |
+
+## bluetape4k Before / After
+
+### `suspendHandler { }` vs 콜백 기반 라우팅
+
+```kotlin
+// Before — 전통 Vert.x 콜백 방식
+router.get("/movie/:id").handler { ctx ->
+    pool.preparedQuery("SELECT TITLE FROM MOVIE WHERE ID=?")
+        .execute(Tuple.of(ctx.pathParam("id"))) { ar ->
+            if (ar.succeeded()) {
+                val rows = ar.result()
+                ctx.response().end(/* 결과 직렬화 */)
+            } else {
+                ctx.fail(ar.cause())
+            }
+        }
+}
+
+// After — bluetape4k suspendHandler (suspend 함수로 순차 처리)
+router.get("/movie/:id").suspendHandler { ctx ->
+    val rows = pool
+        .preparedQuery("SELECT TITLE FROM MOVIE WHERE ID=?")
+        .execute(Tuple.of(ctx.pathParam("id")))
+        .coAwait()          // Future → suspend
+    ctx.response().end(Json.obj { ... }.encode())
+}
+```
+
+### `withSuspendTestContext` vs VertxTestContext 수동 처리
+
+```kotlin
+// Before — VertxTestContext 수동 완료/실패 처리
+@Test
+fun `test route`(vertx: Vertx, testContext: VertxTestContext) {
+    vertx.deployVerticle(MainVerticle()) { ar ->
+        if (ar.succeeded()) {
+            // 콜백 중첩으로 테스트 로직 작성
+            testContext.completeNow()
+        } else {
+            testContext.failNow(ar.cause())
+        }
+    }
+}
+
+// After — bluetape4k withSuspendTestContext (코루틴 블록 자동 완료)
+@Test
+fun `test route`(vertx: Vertx, testContext: VertxTestContext) = runSuspendTest {
+    vertx.withSuspendTestContext(testContext) {
+        vertx.deployVerticle(MainVerticle()).coAwait()
+        // 순차 코드로 테스트 작성 — 예외 시 testContext.failNow() 자동 호출
+    }
+}
+```
+
 ## 빌드 및 테스트
 
 ```bash

--- a/vertx/vertx-sqlclient/README.md
+++ b/vertx/vertx-sqlclient/README.md
@@ -36,3 +36,86 @@ import io.vertx.codegen.annotations.ModuleGen;
 
 참고 자료 :
 [Mapping with Vert.x data objects](https://vertx.io/docs/vertx-sql-client-templates/java/#_mapping_with_vert_x_data_objects)
+
+## 사용된 bluetape4k 기능
+
+| 기능 | 아티팩트 | 코드 위치 | 이점 |
+|---|---|---|---|
+| `withSuspendTransaction { }` | `bluetape4k-vertx` | `JDBCPoolExamples.kt`, `AbstractSqlClientTest` | `Pool`에서 트랜잭션을 열고 suspend 블록 실행 후 자동 커밋/롤백 |
+| `testWithSuspendTransaction` | `bluetape4k-vertx` | 테스트 전체 | `VertxTestContext`와 트랜잭션을 결합한 테스트 헬퍼 — 트랜잭션 자동 롤백으로 테스트 격리 |
+| `tupleMapperOfRecord` | `bluetape4k-vertx` | `SqlClientTemplateExamples.kt` | Kotlin data class / record를 Vert.x `TupleMapper`로 변환하는 유틸 |
+| `MySQL8Server.Launcher` | `bluetape4k-testcontainers` | `AbstractSqlClientTest` | Testcontainers MySQL 8 싱글톤 서버 — 모듈 내 모든 테스트가 하나의 컨테이너 재사용 |
+| `runSuspendIO { }` | `bluetape4k-junit5` | 테스트 전체 | `runBlocking(Dispatchers.IO)` 패턴을 JUnit 5 확장으로 제공 |
+| `KLoggingChannel` | `bluetape4k-logging` | 모든 companion object | 코루틴 컨텍스트 포함 구조적 로깅 |
+| `requireNotBlank` | `bluetape4k-core` | 입력 검증 | `require(value.isNotBlank())` 패턴을 확장 함수로 제공 |
+| `bluetape4k-assertions` | `bluetape4k-core` | 테스트 전체 | 가독성 높은 단언문 (`shouldBeEqualTo`, `shouldHaveSize` 등) |
+
+## bluetape4k Before / After
+
+### `withSuspendTransaction { }` vs Future 체이닝
+
+```kotlin
+// Before — Vert.x Future + 콜백 체이닝
+pool.withTransaction { conn ->
+    conn.query("SELECT * from test").execute()
+        .flatMap { rows ->
+            // 결과 처리
+            Future.succeededFuture(rows)
+        }
+}.onSuccess { result ->
+    // 성공 처리
+}.onFailure { err ->
+    // 실패 처리
+}
+
+// After — bluetape4k withSuspendTransaction (suspend 블록으로 순차 처리)
+pool.withSuspendTransaction { conn: SqlConnection ->
+    val rows = conn.query("SELECT * from test").execute().coAwait()
+    // 결과 처리 — 예외 발생 시 자동 롤백
+}
+```
+
+### `testWithSuspendTransaction` vs 수동 테스트 격리
+
+```kotlin
+// Before — 테스트 후 수동으로 데이터 정리 필요
+@Test
+fun `test insert`(vertx: Vertx, testContext: VertxTestContext) {
+    runBlocking(vertx.dispatcher()) {
+        pool.withSuspendTransaction { conn ->
+            conn.query("INSERT INTO test VALUES (3, 'Test')").execute().coAwait()
+            // 테스트 종료 후 데이터가 남아 다른 테스트에 영향
+        }
+        testContext.completeNow()
+    }
+}
+
+// After — bluetape4k testWithSuspendTransaction (자동 롤백 + testContext 처리)
+@Test
+fun `test insert`(vertx: Vertx, testContext: VertxTestContext) = runSuspendIO {
+    vertx.testWithSuspendTransaction(testContext, pool) {
+        pool.query("INSERT INTO test VALUES (3, 'Test')").execute().coAwait()
+        // 테스트 완료 후 자동 롤백 → 테스트 간 격리 보장
+    }
+}
+```
+
+### `MySQL8Server.Launcher` Testcontainers 싱글톤
+
+```kotlin
+// Before — 테스트마다 또는 클래스마다 컨테이너 생성
+class MyTest {
+    companion object {
+        @JvmField
+        @Container
+        val mysql = MySQLContainer("mysql:8.0")  // 매번 새 컨테이너 기동
+    }
+}
+
+// After — bluetape4k 싱글톤 런처 (JVM 전체에서 하나의 컨테이너 재사용)
+abstract class AbstractSqlClientTest {
+    companion object: KLoggingChannel() {
+        val mysql = MySQL8Server.Launcher.mysql  // 이미 기동된 인스턴스 반환
+    }
+}
+```

--- a/vertx/vertx-webclient/README.md
+++ b/vertx/vertx-webclient/README.md
@@ -93,3 +93,52 @@ vertx.deployVerticle(CoroutineServer()).coAwait()
 | 콜백 | `send { ar -> ... }` | 전통적 Vert.x 방식, 중첩 가능성 높음 |
 | `coAwait()` | `send().coAwait()` | Kotlin 코루틴, 동기 코드처럼 읽힘 |
 | `CoroutineVerticle` | `override suspend fun start()` | Verticle 전체를 코루틴으로 작성 |
+
+## 사용된 bluetape4k 기능
+
+| 기능 | 아티팩트 | 코드 위치 | 이점 |
+|---|---|---|---|
+| `suspendHandler { }` | `bluetape4k-vertx` | `RequestExamples.kt`, `ResponseExamples.kt` | Vert.x `Handler<RoutingContext>`를 suspend 람다로 래핑 |
+| `withSuspendTestContext` | `bluetape4k-vertx` | 테스트 전체 | Vert.x `VertxTestContext`를 코루틴 블록에서 안전하게 사용하는 테스트 헬퍼 |
+| `Jackson` (jackson3) | `bluetape4k-jackson3` | `ResponseExamples.kt` | Jackson 3.x `ObjectMapper` 싱글톤 제공 — 직렬화/역직렬화 공유 인스턴스 |
+| `runSuspendTest { }` | `bluetape4k-junit5` | 테스트 전체 | JUnit 5에서 suspend 테스트를 실행하는 확장 함수 |
+| `KLoggingChannel` | `bluetape4k-logging` | 모든 companion object | 코루틴 컨텍스트 포함 구조적 로깅 |
+| `bluetape4k-assertions` | `bluetape4k-core` | 테스트 전체 | 가독성 높은 단언문 (`shouldBeEqualTo`, `shouldNotBeNull` 등) |
+
+## bluetape4k Before / After
+
+### `suspendHandler { }` vs 콜백 라우팅
+
+```kotlin
+// Before — 전통 Vert.x 라우터 핸들러 (콜백)
+router.put("/request").handler(BodyHandler.create()).handler { ctx ->
+    val body = ctx.body().asString()
+    // 비즈니스 로직
+    ctx.response().end("OK")
+}
+
+// After — bluetape4k suspendHandler (suspend 함수로 작성)
+router.put("/request").handler(BodyHandler.create()).suspendHandler { ctx ->
+    val body = ctx.body().asString()
+    // suspend 함수 호출 가능 (예: DB 조회, 외부 API 호출)
+    ctx.response().end("OK")
+}
+```
+
+### `Jackson` 싱글톤 vs 직접 ObjectMapper 생성
+
+```kotlin
+// Before — 매번 ObjectMapper 생성 또는 companion object에 직접 선언
+companion object {
+    private val objectMapper = ObjectMapper().apply {
+        registerModule(JavaTimeModule())
+        registerModule(KotlinModule.Builder().build())
+    }
+}
+
+// After — bluetape4k Jackson 싱글톤 (미리 설정된 ObjectMapper 공유)
+import io.bluetape4k.jackson3.Jackson
+
+val json = Jackson.defaultJsonMapper.writeValueAsString(user)
+val user = Jackson.defaultJsonMapper.readValue(json, User::class.java)
+```


### PR DESCRIPTION
## Summary

Resolves #86

Adds `## 사용된 bluetape4k 기능` tables and `## bluetape4k Before / After` code snippets to README files for async/reactive modules in the workshop.

## Changed Modules

| Module | Status | Key bluetape4k APIs |
|---|---|---|
| `kotlin/coroutines` | Updated | `KLoggingChannel`, `suspendLogging`, `Flow.log()`, `assertResult`, `PropertyCoroutineContext`, `runSuspendTest` |
| `spring-data/r2dbc-coroutines` | Updated | `*Suspending` extension family on `R2dbcEntityOperations`, `runSuspendIO` |
| `vertx/coroutines` | Updated | `suspendHandler`, `withSuspendTestContext`, `runSuspendTest` |
| `vertx/vertx-sqlclient` | Updated | `withSuspendTransaction`, `testWithSuspendTransaction`, `tupleMapperOfRecord`, `MySQL8Server.Launcher` |
| `vertx/vertx-webclient` | Updated | `suspendHandler`, `Jackson.defaultJsonMapper`, `withSuspendTestContext` |
| `spring-boot/webflux-coroutines` | No change — already had complete sections | — |

## Approach

All feature tables and Before/After snippets are derived from actual import analysis of each module's source files, not from speculative API lists. This ensures every mentioned API is genuinely used in the module.

## Additional Files

- Added `docs/lessons/2026-05-24-issue-86-async-reactive-docs.md` with methodology notes and key findings.

## Verification

- All 6 target modules checked; 5 updated (webflux-coroutines was already complete per task spec "이미 있으면 보강")
- No code changes — README documentation only
- All Before/After snippets verified against actual source code