### PR TITLE
chore: add bluetape4k-javers and bluetape4k-text library aliases to version catalog

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -203,6 +203,14 @@ bluetape4k-kafka = { module = "io.github.bluetape4k:bluetape4k-kafka" }
 bluetape4k-lettuce = { module = "io.github.bluetape4k:bluetape4k-lettuce" }
 bluetape4k-leader-core = { module = "io.github.bluetape4k.leader:bluetape4k-leader-core" }
 bluetape4k-leader-redis-lettuce = { module = "io.github.bluetape4k.leader:bluetape4k-leader-redis-lettuce" }
+bluetape4k-javers-core = { module = "io.github.bluetape4k.javers:javers-core" }
+bluetape4k-javers-persistence-redis = { module = "io.github.bluetape4k.javers:javers-persistence-redis" }
+bluetape4k-javers-persistence-kafka = { module = "io.github.bluetape4k.javers:javers-persistence-kafka" }
+bluetape4k-text-core = { module = "io.github.bluetape4k.text:tokenizer-core" }
+bluetape4k-text-korean = { module = "io.github.bluetape4k.text:tokenizer-korean" }
+bluetape4k-text-japanese = { module = "io.github.bluetape4k.text:tokenizer-japanese" }
+bluetape4k-text-lingua = { module = "io.github.bluetape4k.text:lingua" }
+bluetape4k-text-search = { module = "io.github.bluetape4k.text:text-search" }
 bluetape4k-micrometer = { module = "io.github.bluetape4k:bluetape4k-micrometer" }
 bluetape4k-redis = { module = "io.github.bluetape4k:bluetape4k-redis" }
 bluetape4k-redisson = { module = "io.github.bluetape4k:bluetape4k-redisson" }


### PR DESCRIPTION
## Summary

Add library aliases for `bluetape4k-javers` and `bluetape4k-text` modules to `gradle/libs.versions.toml`.

## Changes

- **No version entries added** — `bluetape4k-dependencies` 1.1.3 BOM already manages javers/text versions
- Added javers aliases: `bluetape4k-javers-core`, `bluetape4k-javers-persistence-redis`, `bluetape4k-javers-persistence-kafka`
- Added text aliases: `bluetape4k-text-core`, `bluetape4k-text-korean`, `bluetape4k-text-japanese`, `bluetape4k-text-lingua`, `bluetape4k-text-search`

## Motivation

Required for upcoming workshop modules:
- Issue #100 (Javers Audit History)
- Issue #105 (Text Processing / Abuse Text Detection)

## Verification

Verified that `bluetape4k-dependencies-1.1.3.pom` contains both `io.github.bluetape4k.javers` and `io.github.bluetape4k.text` artifact entries.