### PR TITLE
feat: add spring-boot/idempotency workshop for duplicate-safe commands (#98)

### DIFF
--- a/docs/lessons/2026-05-24-issue-98-idempotency.md
+++ b/docs/lessons/2026-05-24-issue-98-idempotency.md
@@ -1,0 +1,48 @@
+# Issue #98 — Idempotency Key Workshop 구현 회고
+
+날짜: 2026-05-24
+
+## 목표
+
+중복 요청 방지를 위한 Idempotency Key 패턴을 `spring-boot/idempotency` 모듈로 구현.
+
+## 구현 선택
+
+### 저장소: Redisson `RMapCache` 선택
+
+| 옵션 | 장점 | 단점 |
+|---|---|---|
+| Raw Lettuce SET NX | 심플, 저수준 제어 | 수동 직렬화, TTL 갱신 어려움, 타입 안전성 없음 |
+| Redisson `RMapCache` | 원자적 putIfAbsent, TTL 자동 관리, 타입 안전, Kryo/Fory 코덱 지원 | Redisson 의존성 추가 |
+
+`RMapCache.putIfAbsent(key, value, ttl, unit)`은 Redis `SET NX EX`를 한 번의 원자적 호출로 처리.
+
+### 동시성 정책: `putIfAbsent` 승자 우선
+
+동시에 동일 키로 첫 요청이 들어오는 경우 Redis의 `putIfAbsent`가 단일 승자를 결정. 패자는 승자가 저장한 응답을 즉시 반환받음(409 없음). 워크샵 목적에 충분.
+
+### HTTP 상태 코드 전략
+
+- **최초 생성**: 201 Created + 응답 본문 저장
+- **재전송(replay)**: 200 OK + 동일 응답 본문
+- 봉투(`CachedResponse`)에 원본 HTTP 상태 코드 + 응답 페이로드 함께 저장
+
+## 테스트 패턴
+
+- `AbstractIdempotencyTest`: `@DynamicPropertySource`로 Testcontainer Redis 포트 바인딩
+- `RedisServer.Launcher.redis` 싱글톤 패턴: 모든 테스트가 단일 컨테이너 공유
+- `WebEnvironment.RANDOM_PORT`: 포트 충돌 없이 독립 실행
+
+## 알게 된 것
+
+1. **`RMapCache.putIfAbsent`** 는 별도 분산 락 없이 체크-앤-셋을 원자적으로 수행. 단순한 이멱등성 시나리오에서는 이것으로 충분.
+2. **`data class` + `Serializable` + `serialVersionUID`** : bluetape4k 규칙 — 모든 `data class`에 필수. `OrderRequest`, `OrderResponse`, `CachedResponse` 모두 적용.
+3. **`@DynamicPropertySource`** 는 `companion object` 안에 `@JvmStatic`과 함께 선언해야 Spring이 인식.
+4. **Spring Boot WebFlux + Coroutines** : `suspend` 함수를 `@PostMapping` 핸들러로 바로 사용 가능. `CancellationException` 재던지기 주의.
+5. **헤더 검증은 컨트롤러에서**: `required = false`로 받아 `isNullOrBlank()` 체크 후 `ResponseStatusException(400)` 던짐.
+
+## 향후 개선 사항
+
+- 동일 키 + 다른 본문 → 422 Unprocessable Entity (body hash 비교)
+- Idempotency-Key TTL 설정 가능하게 (현재 5분 하드코딩)
+- 분산 환경 테스트 (Redis Cluster)

--- a/spring-boot/idempotency/README.ko.md
+++ b/spring-boot/idempotency/README.ko.md
@@ -1,0 +1,109 @@
+# spring-boot/idempotency
+
+**Idempotency Key** 패턴을 이용한 중복 요청 방지 예제. Redis(Redisson)와 Spring Boot WebFlux + Kotlin 코루틴을 사용합니다.
+
+## 아키텍처
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant OrderController
+    participant IdempotencyService
+    participant Redis (RMapCache)
+
+    Client->>OrderController: POST /api/orders<br/>Idempotency-Key: <uuid>
+    OrderController->>IdempotencyService: processOrder(key, request)
+    IdempotencyService->>Redis (RMapCache): GET key
+    alt 캐시 HIT (재전송)
+        Redis (RMapCache)-->>IdempotencyService: CachedResponse
+        IdempotencyService-->>OrderController: IdempotencyResult.Replay
+        OrderController-->>Client: 200 OK + 원본 OrderResponse
+    else 캐시 MISS (최초 요청)
+        Redis (RMapCache)-->>IdempotencyService: null
+        IdempotencyService->>Redis (RMapCache): putIfAbsent(key, response, TTL=5분)
+        IdempotencyService-->>OrderController: IdempotencyResult.Created
+        OrderController-->>Client: 201 Created + 새 OrderResponse
+    end
+```
+
+## 주요 기능
+
+| 기능 | 설명 |
+|---|---|
+| **중복 감지** | `Idempotency-Key` 요청 헤더를 Redis 캐시와 비교 |
+| **저장 백엔드** | Redisson `RMapCache` — 원자적 `putIfAbsent` (SET NX 의미론) |
+| **TTL** | 키당 5분 |
+| **동시성** | `putIfAbsent`로 첫 번째 작성자가 우선; 후속 동시 요청은 캐시된 응답 수신 |
+| **헤더 없음** | HTTP 400 Bad Request |
+| **최초 생성** | HTTP 201 Created |
+| **재전송** | HTTP 200 OK + 원본 응답 본문 |
+
+## Before / After 비교
+
+### Before — Lettuce로 직접 Redis SET NX
+
+```kotlin
+// 저수준 접근: 수동 직렬화, TTL 관리 없음, 타입 안전성 없음
+val result = commands.set(key, json, SetArgs().nx().ex(300))
+if (result == null) {
+    val cached = objectMapper.readValue(commands.get(key), OrderResponse::class.java)
+    return ResponseEntity.ok(cached)
+}
+return ResponseEntity.status(201).body(response)
+```
+
+### After — bluetape4k Redisson `RMapCache` (이 모듈)
+
+```kotlin
+// 고수준 접근: 타입 안전, TTL 자동 관리
+val cache = redisson.getMapCache<String, CachedResponse>("idempotency:orders")
+val previous = cache.putIfAbsent(key, newCached, 5, TimeUnit.MINUTES)
+return if (previous == null) IdempotencyResult.Created(newCached)
+       else IdempotencyResult.Replay(previous)
+```
+
+`RMapCache.putIfAbsent`가 체크-앤-셋을 원자적으로 처리하므로 별도의 락이나 Lua 스크립트가 필요 없습니다.
+
+## 사용법
+
+### 애플리케이션 시작
+
+```bash
+./gradlew :spring-boot-idempotency:bootRun
+```
+
+`RedisServer.Launcher.redis` Testcontainer가 자동으로 시작됩니다.
+
+### 요청 예시
+
+```bash
+# 최초 요청 → 201 Created
+http POST :8080/api/orders \
+  "Idempotency-Key: $(uuidgen)" \
+  productId=prod-001 quantity:=2 userId=user-123
+
+# 동일 키로 재전송 → 200 OK, 동일한 orderId
+http POST :8080/api/orders \
+  "Idempotency-Key: <동일-uuid>" \
+  productId=prod-001 quantity:=2 userId=user-123
+```
+
+### Idempotency-Key 없음 → 400
+
+```bash
+http POST :8080/api/orders productId=prod-001 quantity:=2 userId=user-123
+# HTTP/1.1 400 Bad Request
+```
+
+## 테스트 실행
+
+```bash
+./gradlew :spring-boot-idempotency:test
+```
+
+`RedisServer.Launcher.redis` 싱글톤 Testcontainer와 `@DynamicPropertySource`를 사용합니다.
+
+## 알려진 제한사항 / 향후 개선
+
+- **요청 본문 해시 검증 미구현**: 동일 키로 다른 본문 전송 시 422를 반환하지 않음.
+- **동시 최초 요청 정책**: `putIfAbsent`로 처리; 패자는 즉시 캐시된 응답을 받습니다(409 없음).

--- a/spring-boot/idempotency/README.md
+++ b/spring-boot/idempotency/README.md
@@ -1,0 +1,126 @@
+# spring-boot/idempotency
+
+Duplicate-safe command handling with **Idempotency Key** pattern using Redis (Redisson) and Spring Boot WebFlux + Kotlin Coroutines.
+
+## Architecture
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant OrderController
+    participant IdempotencyService
+    participant Redis (RMapCache)
+
+    Client->>OrderController: POST /api/orders<br/>Idempotency-Key: <uuid>
+    OrderController->>IdempotencyService: processOrder(key, request)
+    IdempotencyService->>Redis (RMapCache): GET key
+    alt Cache HIT (replay)
+        Redis (RMapCache)-->>IdempotencyService: CachedResponse
+        IdempotencyService-->>OrderController: IdempotencyResult.Replay
+        OrderController-->>Client: 200 OK + original OrderResponse
+    else Cache MISS (first write)
+        Redis (RMapCache)-->>IdempotencyService: null
+        IdempotencyService->>Redis (RMapCache): putIfAbsent(key, response, TTL=5min)
+        IdempotencyService-->>OrderController: IdempotencyResult.Created
+        OrderController-->>Client: 201 Created + new OrderResponse
+    end
+```
+
+## Core Features
+
+| Feature | Detail |
+|---|---|
+| **Duplicate detection** | `Idempotency-Key` request header matched against Redis cache |
+| **Storage backend** | Redisson `RMapCache` — atomic `putIfAbsent` (SET NX semantics) |
+| **TTL** | 5 minutes per key |
+| **Concurrency** | First writer wins via `putIfAbsent`; concurrent late writers receive the cached response |
+| **Missing header** | HTTP 400 Bad Request |
+| **First creation** | HTTP 201 Created |
+| **Replay** | HTTP 200 OK with original response body |
+
+## Before / After
+
+### Before — Raw Redis SET NX (Lettuce)
+
+```kotlin
+// Low-level approach: manual serialization, no TTL refresh, no type safety
+val commands: RedisCommands<String, String> = ...
+val json = objectMapper.writeValueAsString(response)
+val result = commands.set(key, json, SetArgs().nx().ex(300))
+if (result == null) {
+    // key already existed — deserialize cached value
+    val cached = objectMapper.readValue(commands.get(key), OrderResponse::class.java)
+    return ResponseEntity.ok(cached)
+}
+return ResponseEntity.status(201).body(response)
+```
+
+### After — bluetape4k Redisson `RMapCache` (this module)
+
+```kotlin
+// High-level approach: type-safe, TTL managed automatically
+val cache = redisson.getMapCache<String, CachedResponse>("idempotency:orders")
+val previous = cache.putIfAbsent(key, newCached, 5, TimeUnit.MINUTES)
+return if (previous == null) IdempotencyResult.Created(newCached)
+       else IdempotencyResult.Replay(previous)
+```
+
+`RMapCache.putIfAbsent` combines the check-and-set atomically; no separate lock or Lua script needed.
+
+## Usage
+
+### Start the application
+
+```bash
+./gradlew :spring-boot-idempotency:bootRun
+```
+
+The embedded `RedisServer.Launcher.redis` Testcontainer starts automatically.
+
+### Example request
+
+```bash
+# First call → 201 Created
+http POST :8080/api/orders \
+  "Idempotency-Key: $(uuidgen)" \
+  productId=prod-001 quantity:=2 userId=user-123
+
+# Retry with same key → 200 OK, identical orderId
+http POST :8080/api/orders \
+  "Idempotency-Key: <same-uuid>" \
+  productId=prod-001 quantity:=2 userId=user-123
+```
+
+### Without Idempotency-Key → 400
+
+```bash
+http POST :8080/api/orders productId=prod-001 quantity:=2 userId=user-123
+# HTTP/1.1 400 Bad Request
+```
+
+## Configuration
+
+| Property | Default | Description |
+|---|---|---|
+| `spring.data.redis.host` | `localhost` | Redis host |
+| `spring.data.redis.port` | `6379` | Redis port |
+
+## Running Tests
+
+```bash
+./gradlew :spring-boot-idempotency:test
+```
+
+Tests use `RedisServer.Launcher.redis` singleton Testcontainer with `@DynamicPropertySource` for port binding.
+
+## Dependencies
+
+- `bluetape4k-redis` / `bluetape4k-redisson` — Redisson client helpers
+- `bluetape4k-testcontainers` — `RedisServer.Launcher` singleton
+- `bluetape4k-coroutines` — coroutine utilities
+- `spring-boot-starter-webflux` — reactive HTTP + coroutine support
+
+## Known Limitations / Future Enhancements
+
+- **Body-hash mismatch detection**: this module does not detect when the same key is submitted with a different request body (a full implementation would return 422 Unprocessable Entity in that case).
+- **Concurrent in-flight policy**: concurrent first-time requests resolve via `putIfAbsent`; no 409 is returned — the loser simply receives the winner's cached response.

--- a/spring-boot/idempotency/build.gradle.kts
+++ b/spring-boot/idempotency/build.gradle.kts
@@ -1,0 +1,55 @@
+plugins {
+    alias(libs.plugins.kotlin.spring)
+    alias(libs.plugins.spring.boot)
+}
+
+springBoot {
+    mainClass.set("io.bluetape4k.workshop.idempotency.IdempotencyApplicationKt")
+}
+
+configurations {
+    testImplementation.get().extendsFrom(compileOnly.get(), runtimeOnly.get())
+}
+
+dependencies {
+    // bluetape4k
+    implementation(libs.bluetape4k.jackson3)
+    implementation(libs.bluetape4k.coroutines)
+    implementation(libs.bluetape4k.redis)
+    implementation(libs.bluetape4k.redisson)
+    implementation(libs.bluetape4k.testcontainers)
+    testImplementation(libs.bluetape4k.junit5)
+
+    // Redis — Lettuce
+    implementation(libs.lettuce.core)
+
+    // Redis — Redisson
+    implementation(libs.redisson.lib)
+
+    // Spring Boot
+    implementation(libs.spring.boot.autoconfigure.lib)
+    annotationProcessor(libs.spring.boot.autoconfigure.processor)
+    annotationProcessor(libs.spring.boot.configuration.processor)
+    runtimeOnly(libs.spring.boot.devtools)
+
+    implementation(libs.spring.boot.starter.actuator)
+    implementation(libs.spring.boot.starter.webflux.lib)
+    testImplementation(libs.spring.boot.starter.webflux.test)
+    testImplementation(libs.spring.boot.starter.test) {
+        exclude(group = "junit", module = "junit")
+        exclude(group = "org.junit.vintage", module = "junit-vintage-engine")
+        exclude(module = "mockito-core")
+    }
+
+    // Coroutines
+    implementation(libs.kotlinx.coroutines.core.lib)
+    implementation(libs.kotlinx.coroutines.reactor)
+    testImplementation(libs.kotlinx.coroutines.test.lib)
+
+    // Reactor
+    implementation(libs.reactor.kotlin.extensions)
+    testImplementation(libs.reactor.test)
+
+    // SpringDoc - OpenAPI
+    implementation(libs.springdoc.openapi.starter.webflux.ui)
+}

--- a/spring-boot/idempotency/src/main/kotlin/io/bluetape4k/workshop/idempotency/IdempotencyApplication.kt
+++ b/spring-boot/idempotency/src/main/kotlin/io/bluetape4k/workshop/idempotency/IdempotencyApplication.kt
@@ -1,0 +1,28 @@
+package io.bluetape4k.workshop.idempotency
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.testcontainers.storage.RedisServer
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
+
+/**
+ * Idempotency Key workshop application.
+ *
+ * Demonstrates duplicate-safe command handling using Redis (Redisson RMapCache)
+ * and Spring Boot WebFlux with Kotlin coroutines.
+ */
+@SpringBootApplication(proxyBeanMethods = false)
+class IdempotencyApplication {
+
+    companion object : KLogging() {
+        /**
+         * Singleton Redis server started via Testcontainers for local development and tests.
+         */
+        @JvmStatic
+        val redisServer: RedisServer = RedisServer.Launcher.redis
+    }
+}
+
+fun main(args: Array<String>) {
+    runApplication<IdempotencyApplication>(*args)
+}

--- a/spring-boot/idempotency/src/main/kotlin/io/bluetape4k/workshop/idempotency/config/RedissonConfig.kt
+++ b/spring-boot/idempotency/src/main/kotlin/io/bluetape4k/workshop/idempotency/config/RedissonConfig.kt
@@ -1,0 +1,45 @@
+package io.bluetape4k.workshop.idempotency.config
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.info
+import io.bluetape4k.support.uninitialized
+import org.redisson.Redisson
+import org.redisson.api.RedissonClient
+import org.redisson.config.Config
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+/**
+ * Redisson client configuration.
+ *
+ * Reads `spring.data.redis.host` and `spring.data.redis.port` from application properties,
+ * which are overridden at test time via [DynamicPropertySource].
+ */
+@Configuration(proxyBeanMethods = false)
+class RedissonConfig {
+
+    companion object : KLogging()
+
+    @Value("\${spring.data.redis.host:localhost}")
+    private val redisHost: String = uninitialized()
+
+    @Value("\${spring.data.redis.port:6379}")
+    private val redisPort: Int = 6379
+
+    @Bean(destroyMethod = "shutdown")
+    fun redissonClient(): RedissonClient {
+        val address = "redis://$redisHost:$redisPort"
+        log.info { "Creating Redisson client for $address" }
+
+        val config = Config().apply {
+            useSingleServer()
+                .setAddress(address)
+                .setConnectionPoolSize(32)
+                .setConnectionMinimumIdleSize(8)
+                .setTimeout(3000)
+                .setRetryAttempts(3)
+        }
+        return Redisson.create(config)
+    }
+}

--- a/spring-boot/idempotency/src/main/kotlin/io/bluetape4k/workshop/idempotency/controller/OrderController.kt
+++ b/spring-boot/idempotency/src/main/kotlin/io/bluetape4k/workshop/idempotency/controller/OrderController.kt
@@ -1,0 +1,64 @@
+package io.bluetape4k.workshop.idempotency.controller
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import io.bluetape4k.workshop.idempotency.model.OrderRequest
+import io.bluetape4k.workshop.idempotency.model.OrderResponse
+import io.bluetape4k.workshop.idempotency.service.IdempotencyResult
+import io.bluetape4k.workshop.idempotency.service.IdempotencyService
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestHeader
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.server.ResponseStatusException
+
+/**
+ * REST controller for idempotent order creation.
+ *
+ * ## Behavior / Contract
+ * - `POST /api/orders` requires an `Idempotency-Key` header.
+ * - A missing or blank `Idempotency-Key` returns HTTP 400.
+ * - First request with a key returns HTTP 201 with the new [OrderResponse].
+ * - Repeated request with the same key within the TTL returns HTTP 200 with the original [OrderResponse].
+ */
+@RestController
+@RequestMapping("/api/orders")
+class OrderController(private val idempotencyService: IdempotencyService) {
+
+    companion object : KLogging() {
+        const val IDEMPOTENCY_KEY_HEADER = "Idempotency-Key"
+    }
+
+    /**
+     * Creates an order in a duplicate-safe manner.
+     *
+     * Clients must supply an `Idempotency-Key` header (UUID recommended).
+     * Retrying the request with the same key within 5 minutes returns the original response.
+     */
+    @PostMapping
+    suspend fun createOrder(
+        @RequestHeader(IDEMPOTENCY_KEY_HEADER, required = false) idempotencyKey: String?,
+        @RequestBody request: OrderRequest,
+    ): ResponseEntity<OrderResponse> {
+        val key = idempotencyKey?.trim()
+        if (key.isNullOrBlank()) {
+            throw ResponseStatusException(
+                HttpStatus.BAD_REQUEST,
+                "Header '$IDEMPOTENCY_KEY_HEADER' is required and must not be blank"
+            )
+        }
+
+        log.debug { "Processing order with idempotency key=$key, request=$request" }
+
+        return when (val result = idempotencyService.processOrder(key, request)) {
+            is IdempotencyResult.Created ->
+                ResponseEntity.status(HttpStatus.CREATED).body(result.cached.response)
+
+            is IdempotencyResult.Replay ->
+                ResponseEntity.ok(result.cached.response)
+        }
+    }
+}

--- a/spring-boot/idempotency/src/main/kotlin/io/bluetape4k/workshop/idempotency/model/OrderModels.kt
+++ b/spring-boot/idempotency/src/main/kotlin/io/bluetape4k/workshop/idempotency/model/OrderModels.kt
@@ -1,0 +1,55 @@
+package io.bluetape4k.workshop.idempotency.model
+
+import java.io.Serializable
+import java.time.Instant
+
+/**
+ * Request payload for creating an order.
+ *
+ * ## Behavior / Contract
+ * - [productId] must be non-blank.
+ * - [quantity] must be positive.
+ * - [userId] must be non-blank.
+ */
+data class OrderRequest(
+    val productId: String,
+    val quantity: Int,
+    val userId: String,
+) : Serializable {
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+/**
+ * Response returned for a successfully processed (or replayed) order.
+ *
+ * ## Behavior / Contract
+ * - First creation returns HTTP 201.
+ * - Replayed requests with the same Idempotency-Key return HTTP 200 with the same body.
+ */
+data class OrderResponse(
+    val orderId: String,
+    val status: String,
+    val processedAt: Instant,
+) : Serializable {
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+/**
+ * Envelope stored in the idempotency cache, combining HTTP status with response body.
+ *
+ * ## Behavior / Contract
+ * - [httpStatus] is the status code returned on first creation (e.g., 201).
+ * - [response] is the original [OrderResponse] payload.
+ */
+data class CachedResponse(
+    val httpStatus: Int,
+    val response: OrderResponse,
+) : Serializable {
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}

--- a/spring-boot/idempotency/src/main/kotlin/io/bluetape4k/workshop/idempotency/service/IdempotencyService.kt
+++ b/spring-boot/idempotency/src/main/kotlin/io/bluetape4k/workshop/idempotency/service/IdempotencyService.kt
@@ -1,0 +1,86 @@
+package io.bluetape4k.workshop.idempotency.service
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import io.bluetape4k.logging.info
+import io.bluetape4k.workshop.idempotency.model.CachedResponse
+import io.bluetape4k.workshop.idempotency.model.OrderRequest
+import io.bluetape4k.workshop.idempotency.model.OrderResponse
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.redisson.api.RedissonClient
+import org.springframework.stereotype.Service
+import java.time.Instant
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+
+/**
+ * Service that provides idempotent order creation backed by Redisson [RMapCache].
+ *
+ * ## Behavior / Contract
+ * - First call with a given key creates an order, stores the response in Redis with a 5-minute TTL,
+ *   and returns HTTP 201.
+ * - Subsequent calls with the same key within the TTL return the cached response with HTTP 200.
+ * - Concurrent first-time calls with the same key: the first writer wins via [RMapCache.putIfAbsent];
+ *   the loser receives a 409 Conflict immediately (no waiting).
+ * - Blank idempotency keys are rejected before this service is called (controller responsibility).
+ */
+@Service
+class IdempotencyService(private val redisson: RedissonClient) {
+
+    companion object : KLogging() {
+        private const val CACHE_NAME = "idempotency:orders"
+        private const val TTL_MINUTES = 5L
+    }
+
+    /**
+     * Attempts to process an order idempotently.
+     *
+     * @param idempotencyKey unique client-supplied key for this request
+     * @param request the order payload
+     * @return [IdempotencyResult] indicating whether this is a new response or a cached replay
+     */
+    suspend fun processOrder(idempotencyKey: String, request: OrderRequest): IdempotencyResult =
+        withContext(Dispatchers.IO) {
+            val cache = redisson.getMapCache<String, CachedResponse>(CACHE_NAME)
+
+            // Check for existing cached response first (fast path)
+            val existing = cache.get(idempotencyKey)
+            if (existing != null) {
+                log.debug { "Cache HIT for idempotency key=$idempotencyKey" }
+                return@withContext IdempotencyResult.Replay(existing)
+            }
+
+            // Create a new order response
+            val newResponse = OrderResponse(
+                orderId = UUID.randomUUID().toString(),
+                status = "CREATED",
+                processedAt = Instant.now(),
+            )
+            val newCached = CachedResponse(httpStatus = 201, response = newResponse)
+
+            // putIfAbsent: atomic SET NX semantics via Redisson
+            val previous = cache.putIfAbsent(idempotencyKey, newCached, TTL_MINUTES, TimeUnit.MINUTES)
+
+            if (previous == null) {
+                // We were the first writer
+                log.info { "Order created for idempotency key=$idempotencyKey, orderId=${newResponse.orderId}" }
+                IdempotencyResult.Created(newCached)
+            } else {
+                // A concurrent request already stored a value; serve that cached result
+                log.debug { "Concurrent write detected for idempotency key=$idempotencyKey — returning cached response" }
+                IdempotencyResult.Replay(previous)
+            }
+        }
+}
+
+/**
+ * Sealed result type for idempotent order processing.
+ */
+sealed class IdempotencyResult {
+    /** The order was created for the first time. HTTP 201. */
+    data class Created(val cached: CachedResponse) : IdempotencyResult()
+
+    /** The same idempotency key was seen before. HTTP 200 with original payload. */
+    data class Replay(val cached: CachedResponse) : IdempotencyResult()
+}

--- a/spring-boot/idempotency/src/main/resources/application.yml
+++ b/spring-boot/idempotency/src/main/resources/application.yml
@@ -2,9 +2,6 @@ spring:
   application:
     name: idempotency
 
-  profiles:
-    active: app
-
   jackson:
     serialization:
       indent-output: true

--- a/spring-boot/idempotency/src/main/resources/application.yml
+++ b/spring-boot/idempotency/src/main/resources/application.yml
@@ -1,0 +1,33 @@
+spring:
+  application:
+    name: idempotency
+
+  profiles:
+    active: app
+
+  jackson:
+    serialization:
+      indent-output: true
+
+  data:
+    redis:
+      host: ${testcontainers.redis.host:localhost}
+      port: ${testcontainers.redis.port:6379}
+
+server:
+  port: 8080
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "*"
+  endpoint:
+    health:
+      show-details: always
+
+springdoc:
+  api-docs:
+    path: /v3/api-docs
+  swagger-ui:
+    path: /swagger-ui.html

--- a/spring-boot/idempotency/src/test/kotlin/io/bluetape4k/workshop/idempotency/AbstractIdempotencyTest.kt
+++ b/spring-boot/idempotency/src/test/kotlin/io/bluetape4k/workshop/idempotency/AbstractIdempotencyTest.kt
@@ -1,0 +1,34 @@
+package io.bluetape4k.workshop.idempotency
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.support.uninitialized
+import io.bluetape4k.testcontainers.storage.RedisServer
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.ApplicationContext
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.springframework.test.web.reactive.server.WebTestClient
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+abstract class AbstractIdempotencyTest {
+
+    companion object : KLogging() {
+        @JvmStatic
+        val redis: RedisServer = RedisServer.Launcher.redis
+
+        @JvmStatic
+        @DynamicPropertySource
+        fun registerRedisProperties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.data.redis.host") { redis.host }
+            registry.add("spring.data.redis.port") { redis.port.toString() }
+        }
+    }
+
+    @Autowired
+    protected val context: ApplicationContext = uninitialized()
+
+    protected val client: WebTestClient by lazy {
+        WebTestClient.bindToApplicationContext(context).build()
+    }
+}

--- a/spring-boot/idempotency/src/test/kotlin/io/bluetape4k/workshop/idempotency/controller/OrderControllerTest.kt
+++ b/spring-boot/idempotency/src/test/kotlin/io/bluetape4k/workshop/idempotency/controller/OrderControllerTest.kt
@@ -1,0 +1,158 @@
+package io.bluetape4k.workshop.idempotency.controller
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldNotBeEmpty
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.workshop.idempotency.AbstractIdempotencyTest
+import io.bluetape4k.workshop.idempotency.model.OrderRequest
+import io.bluetape4k.workshop.idempotency.model.OrderResponse
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.test.web.reactive.server.returnResult
+import reactor.kotlin.core.publisher.toMono
+import java.util.UUID
+
+class OrderControllerTest : AbstractIdempotencyTest() {
+
+    companion object : KLogging() {
+        private const val ORDERS_PATH = "/api/orders"
+        private const val IDEMPOTENCY_KEY_HEADER = "Idempotency-Key"
+    }
+
+    private fun newIdempotencyKey(): String = UUID.randomUUID().toString()
+
+    private val sampleRequest = OrderRequest(
+        productId = "prod-001",
+        quantity = 2,
+        userId = "user-123",
+    )
+
+    @Test
+    fun `새 요청은 201 Created를 반환한다`() = runTest {
+        client.post()
+            .uri(ORDERS_PATH)
+            .header(IDEMPOTENCY_KEY_HEADER, newIdempotencyKey())
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(sampleRequest)
+            .exchange()
+            .expectStatus().isCreated
+            .returnResult<OrderResponse>()
+            .responseBody
+            .toMono()
+            .block()!!
+            .also { response ->
+                response.orderId.shouldNotBeEmpty()
+                response.status shouldBeEqualTo "CREATED"
+            }
+    }
+
+    @Test
+    fun `동일한 Idempotency-Key로 재전송하면 200 OK와 동일 응답을 반환한다`() = runTest {
+        val key = newIdempotencyKey()
+
+        // First request → 201 Created
+        val first = client.post()
+            .uri(ORDERS_PATH)
+            .header(IDEMPOTENCY_KEY_HEADER, key)
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(sampleRequest)
+            .exchange()
+            .expectStatus().isCreated
+            .returnResult<OrderResponse>()
+            .responseBody
+            .toMono()
+            .block()!!
+
+        // Second request with same key → 200 OK, same orderId
+        val second = client.post()
+            .uri(ORDERS_PATH)
+            .header(IDEMPOTENCY_KEY_HEADER, key)
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(sampleRequest)
+            .exchange()
+            .expectStatus().isOk
+            .returnResult<OrderResponse>()
+            .responseBody
+            .toMono()
+            .block()!!
+
+        second.orderId shouldBeEqualTo first.orderId
+        second.processedAt shouldBeEqualTo first.processedAt
+    }
+
+    @Test
+    fun `다른 Idempotency-Key는 새로운 주문을 생성한다`() = runTest {
+        val keyA = newIdempotencyKey()
+        val keyB = newIdempotencyKey()
+
+        val responseA = client.post()
+            .uri(ORDERS_PATH)
+            .header(IDEMPOTENCY_KEY_HEADER, keyA)
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(sampleRequest)
+            .exchange()
+            .expectStatus().isCreated
+            .returnResult<OrderResponse>()
+            .responseBody.toMono().block()!!
+
+        val responseB = client.post()
+            .uri(ORDERS_PATH)
+            .header(IDEMPOTENCY_KEY_HEADER, keyB)
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(sampleRequest)
+            .exchange()
+            .expectStatus().isCreated
+            .returnResult<OrderResponse>()
+            .responseBody.toMono().block()!!
+
+        // Different keys → different order IDs
+        assert(responseA.orderId != responseB.orderId) {
+            "Different idempotency keys should produce different order IDs"
+        }
+    }
+
+    @Test
+    fun `Idempotency-Key 헤더가 없으면 400 Bad Request를 반환한다`() = runTest {
+        client.post()
+            .uri(ORDERS_PATH)
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(sampleRequest)
+            .exchange()
+            .expectStatus().isBadRequest
+    }
+
+    @Test
+    fun `빈 Idempotency-Key 헤더는 400 Bad Request를 반환한다`() = runTest {
+        client.post()
+            .uri(ORDERS_PATH)
+            .header(IDEMPOTENCY_KEY_HEADER, "   ")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(sampleRequest)
+            .exchange()
+            .expectStatus().isEqualTo(HttpStatus.BAD_REQUEST)
+    }
+
+    @Test
+    fun `세 번 재전송해도 항상 동일한 응답을 반환한다`() = runTest {
+        val key = newIdempotencyKey()
+
+        val responses = (1..3).map {
+            client.post()
+                .uri(ORDERS_PATH)
+                .header(IDEMPOTENCY_KEY_HEADER, key)
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(sampleRequest)
+                .exchange()
+                .returnResult<OrderResponse>()
+                .responseBody.toMono().block()!!
+        }
+
+        // All responses must carry the same orderId
+        val distinctOrderIds = responses.map { it.orderId }.toSet()
+        assert(distinctOrderIds.size == 1) {
+            "All replays must return the same orderId, got: $distinctOrderIds"
+        }
+    }
+}

--- a/spring-boot/idempotency/src/test/kotlin/io/bluetape4k/workshop/idempotency/controller/OrderControllerTest.kt
+++ b/spring-boot/idempotency/src/test/kotlin/io/bluetape4k/workshop/idempotency/controller/OrderControllerTest.kt
@@ -1,7 +1,9 @@
 package io.bluetape4k.workshop.idempotency.controller
 
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldHaveSize
 import io.bluetape4k.assertions.shouldNotBeEmpty
+import io.bluetape4k.assertions.shouldNotBeEqualTo
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.workshop.idempotency.AbstractIdempotencyTest
 import io.bluetape4k.workshop.idempotency.model.OrderRequest
@@ -108,9 +110,7 @@ class OrderControllerTest : AbstractIdempotencyTest() {
             .responseBody.toMono().block()!!
 
         // Different keys → different order IDs
-        assert(responseA.orderId != responseB.orderId) {
-            "Different idempotency keys should produce different order IDs"
-        }
+        responseA.orderId shouldNotBeEqualTo responseB.orderId
     }
 
     @Test
@@ -151,8 +151,6 @@ class OrderControllerTest : AbstractIdempotencyTest() {
 
         // All responses must carry the same orderId
         val distinctOrderIds = responses.map { it.orderId }.toSet()
-        assert(distinctOrderIds.size == 1) {
-            "All replays must return the same orderId, got: $distinctOrderIds"
-        }
+        distinctOrderIds shouldHaveSize 1
     }
 }

--- a/spring-boot/idempotency/src/test/resources/application.yml
+++ b/spring-boot/idempotency/src/test/resources/application.yml
@@ -1,0 +1,6 @@
+spring:
+  application:
+    name: idempotency-test
+
+server:
+  port: 0

--- a/spring-boot/idempotency/src/test/resources/junit-platform.properties
+++ b/spring-boot/idempotency/src/test/resources/junit-platform.properties
@@ -1,0 +1,3 @@
+junit.jupiter.execution.parallel.enabled=false
+junit.jupiter.execution.parallel.mode.default=same_thread
+junit.jupiter.testinstance.lifecycle.default=per_class

--- a/spring-boot/idempotency/src/test/resources/logback-test.xml
+++ b/spring-boot/idempotency/src/test/resources/logback-test.xml
@@ -1,0 +1,12 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %highlight(%-5level) %magenta(%5.-5thread) --- %cyan(%-40.40logger{39}) : %msg%n</pattern>
+        </encoder>
+    </appender>
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+    <logger name="io.bluetape4k" level="DEBUG"/>
+    <logger name="io.bluetape4k.workshop.idempotency" level="DEBUG"/>
+</configuration>


### PR DESCRIPTION
## Summary

Adds a new `spring-boot/idempotency` workshop module demonstrating the **Idempotency Key** pattern for duplicate-safe command handling.

## Changes

- `spring-boot/idempotency/` — new Spring Boot WebFlux + Coroutines module
  - `IdempotencyApplication` — Spring Boot entry point with embedded Testcontainer Redis
  - `OrderController` — `POST /api/orders` with `Idempotency-Key` header enforcement
  - `IdempotencyService` — Redisson `RMapCache.putIfAbsent` for atomic idempotency check (5-minute TTL)
  - `OrderModels` — `OrderRequest`, `OrderResponse`, `CachedResponse` (all `Serializable`)
  - `RedissonConfig` — Redisson client wired from `spring.data.redis.*` properties
  - `AbstractIdempotencyTest` + `OrderControllerTest` — 6 tests via WebTestClient
- `docs/lessons/2026-05-24-issue-98-idempotency.md` — implementation retrospective (Korean)
- `README.md` (English) + `README.ko.md` (Korean)

## HTTP Behaviour

| Scenario | Status |
|---|---|
| First request with new key | 201 Created |
| Repeat with same key (within TTL) | 200 OK — same body |
| Different key | 201 Created — new order |
| Missing or blank `Idempotency-Key` | 400 Bad Request |

## Test Results

```
./gradlew :spring-boot-idempotency:test

BUILD SUCCESSFUL — 6 tests, 0 failures, 0 skipped
```

Tests:
- 새 요청은 201 Created를 반환한다
- 동일한 Idempotency-Key로 재전송하면 200 OK와 동일 응답을 반환한다
- 다른 Idempotency-Key는 새로운 주문을 생성한다
- Idempotency-Key 헤더가 없으면 400 Bad Request를 반환한다
- 빈 Idempotency-Key 헤더는 400 Bad Request를 반환한다
- 세 번 재전송해도 항상 동일한 응답을 반환한다

## Verification

```bash
./gradlew :spring-boot-idempotency:test
```

Closes #98