### PR TITLE
feat: add ratelimit/bucket4j-advanced workshop with IP/userId/combined strategies (#96)

### DIFF
--- a/docs/lessons/2026-05-24-issue-96-ratelimit-advanced.md
+++ b/docs/lessons/2026-05-24-issue-96-ratelimit-advanced.md
@@ -1,0 +1,74 @@
+# Issue #96 — ratelimit/bucket4j-advanced 구현 회고
+
+날짜: 2026-05-24
+이슈: https://github.com/bluetape4k/bluetape4k-workshop/issues/96
+
+## 개요
+
+`ratelimit/bucket4j-advanced` 모듈을 신규 생성하여 세 가지 Rate Limit identity 전략을 구현했다.
+
+- **IP-based**: `X-Forwarded-For` / `X-Real-IP` → TCP remote address 순 폴백
+- **userId-based**: `X-User-ID` 헤더 기반 per-user 버킷
+- **Combined**: `combined:<ip>:<userId>` 복합 키로 단일 버킷 (per IP+user pair)
+
+## 아키텍처 결정
+
+### Combined 전략의 해석
+
+명세에 "두 조건 모두 통과해야 허용"이라는 문구와 "`ip:userId` 복합 키" 두 가지 표현이 혼재했다.
+두 개의 별도 버킷을 AND-gate 방식으로 소비하는 방법도 고려했지만, 복합 키 방식을 채택했다.
+이유:
+- AND-gate 방식은 부분 소비 롤백이 필요해 원자성 보장이 어렵다.
+- 복합 키(`combined:ip:userId`)는 각 (IP, user) 쌍이 독립 쿼터를 가지므로, 한 사용자가 다른 사용자의 쿼터를 소비할 수 없다.
+- README에 두 방식의 차이를 명시했다.
+
+### 필터 격리
+
+기존 `bucker4j-bluetape4k-webflux` 모듈은 `UserRateLimitWebFilter`(sync)와 `AsyncUserRateLimitWebFilter`(async) 두 필터가 동일 경로에 중복 적용되어 토큰이 2배 소비되는 버그가 있었다. 이번 모듈은 각 필터가 자신의 경로 prefix에만 개입하도록 격리했다.
+
+- `IpRateLimitWebFilter` → `/api/anonymous/**`만
+- `UserRateLimitWebFilter` → `/api/authenticated/**`만
+- `CombinedRateLimitWebFilter` → `/api/sensitive/**`만
+
+### 응답 헤더 표준화
+
+기존 모듈의 `X-BLUETAPE4K-REMAINING-TOKEN` 커스텀 헤더 대신 HTTP 표준 헤더를 채택했다.
+
+| 헤더 | 용도 |
+|---|---|
+| `X-RateLimit-Remaining` | 남은 토큰 수 |
+| `Retry-After` | 429 시 대기 시간(초) |
+
+### IP fallback "unknown"
+
+`WebTestClient.bindToApplicationContext()`는 mock client여서 TCP remote address가 null이다.
+처음에는 null IP를 400으로 거부했지만, 이는 테스트 뿐 아니라 IPv6 환경이나 특수 프록시 설정에서도
+문제가 될 수 있다. `"unknown"` fallback 키로 공유 버킷을 적용하는 방식으로 변경했다.
+
+실제 TCP 연결이 필요한 IP 테스트는 `WebTestClient.bindToServer()`(RANDOM_PORT)로 전환했다.
+
+## 테스트 격리 전략
+
+| 전략 | 격리 방법 |
+|---|---|
+| IP-based | `@TestMethodOrder`로 exhaustion 테스트를 마지막에 배치 |
+| User-based | 매 테스트마다 `Base58.randomString()` unique userId 사용 |
+| Combined | 매 테스트마다 unique userId 사용 (IP는 공유돼도 userId가 다르면 별도 버킷) |
+
+## 배운 점
+
+1. **KDoc 내 `*/` 주의**: KDoc 내부에서 경로 패턴 `/**`을 쓰면 `*/`가 주석 종결자로 인식돼 컴파일 오류 발생.
+   백틱으로 감싸도 해결되지 않으며, `/**` 대신 `/` 또는 산문 표현으로 교체해야 한다.
+
+2. **`mono {}` 블록의 모든 분기는 같은 타입 반환**: `mono<Void?>` 블록에서 `return@mono`(Unit 반환)와
+   `awaitSingleOrNull()`(Void? 반환)이 혼재하면 컴파일 에러. 모든 분기를 `awaitSingleOrNull()` 종결로 통일.
+
+3. **Gradle 프로젝트 이름은 디렉토리 이름**: `includeModules("ratelimit", false, false)`에서
+   `withProjectName=false, withBaseDir=false`이면 프로젝트 이름 = 디렉토리 이름 = `bucket4j-advanced`.
+   태스크 명령어: `./gradlew :bucket4j-advanced:test`.
+
+4. **@Qualifier + 동일 타입 빈 3개**: 같은 `DistributedSuspendRateLimiter` 타입 빈이 3개일 때
+   `@Qualifier`를 빈 선언부와 주입부 모두에 명시해야 한다.
+
+5. **`@TestMethodOrder`로 공유 리소스 테스트 순서 제어**: Redis 버킷 상태는 테스트 간 공유되므로
+   exhaustion 테스트는 반드시 단순 200 확인 테스트보다 나중에 실행해야 한다.

--- a/ratelimit/bucket4j-advanced/README.md
+++ b/ratelimit/bucket4j-advanced/README.md
@@ -1,0 +1,106 @@
+# bucket4j-advanced — Advanced Rate Limit Strategies
+
+A Spring Boot WebFlux + Coroutines workshop module demonstrating three distinct Bucket4j
+rate-limit identity strategies backed by Redis (Lettuce).
+
+## Architecture
+
+```mermaid
+flowchart TD
+    Client["HTTP Client"]
+    subgraph Filters["WebFilter Chain (ordered)"]
+        F1["IpRateLimitWebFilter\n@Order(10)\n/api/anonymous/**"]
+        F2["UserRateLimitWebFilter\n@Order(11)\n/api/authenticated/**"]
+        F3["CombinedRateLimitWebFilter\n@Order(12)\n/api/sensitive/**"]
+    end
+    subgraph Buckets["Redis Buckets (Lettuce)"]
+        B1["ip:&lt;address&gt;\n20 tokens / 10 s"]
+        B2["user:&lt;userId&gt;\n50 tokens / 10 s"]
+        B3["combined:&lt;ip&gt;:&lt;userId&gt;\n10 tokens / 10 s"]
+    end
+    Controller["RateLimitDemoController"]
+
+    Client --> F1 --> B1
+    Client --> F2 --> B2
+    Client --> F3 --> B3
+    B1 --> Controller
+    B2 --> Controller
+    B3 --> Controller
+```
+
+## Rate-Limit Strategies
+
+| Strategy | Endpoint | Key | Bucket | Header required |
+|---|---|---|---|---|
+| IP-based | `GET /api/anonymous/hello` | `ip:<address>` | 20 tokens / 10 s | none |
+| userId-based | `GET /api/authenticated/hello` | `user:<userId>` | 50 tokens / 10 s | `X-User-ID` |
+| Combined (IP + userId) | `GET /api/sensitive/hello` | `combined:<ip>:<userId>` | 10 tokens / 10 s | `X-User-ID` |
+
+## Before / After Comparison
+
+| Concern | Before (basic `bucker4j-bluetape4k-webflux`) | After (this module) |
+|---|---|---|
+| Identity strategies | Single strategy (userId or IP) | Three independent strategies |
+| Filter isolation | Two overlapping filters caused double-counting | Each filter only handles its own path prefix |
+| Response headers | `X-BLUETAPE4K-REMAINING-TOKEN` (custom) | `X-RateLimit-Remaining` + `Retry-After` (HTTP standard) |
+| User ID header | `X-BLUETAPE4K-UID` | `X-User-ID` |
+| Missing identity | Falls back to remoteAddress silently | Explicit error codes (400 / 401) |
+| Combined quota | Not supported | IP+userId composite key |
+
+## Response Headers
+
+| Header | Meaning |
+|---|---|
+| `X-RateLimit-Remaining` | Tokens remaining in the current window after this request |
+| `X-RateLimit-Reset` | _(reserved — not yet populated)_ |
+| `Retry-After` | Seconds to wait before retrying; present only on HTTP 429 responses |
+
+## Proxy Trust Configuration
+
+By default `ratelimit.trust-proxy=false` and the `X-Forwarded-For` / `X-Real-IP` headers are
+**ignored**. The raw TCP remote address is always used for IP extraction.
+
+**Security warning**: setting `ratelimit.trust-proxy=true` trusts `X-Forwarded-For` and uses the
+**leftmost** IP from that header as the client address. Enable this only when the application is
+behind a known, controlled reverse proxy (e.g. an internal load balancer). Without a trusted
+proxy, clients can spoof arbitrary IP addresses in the `X-Forwarded-For` header and bypass
+per-IP rate limits entirely.
+
+```yaml
+# application.yml — enable only behind a trusted proxy
+ratelimit:
+  trust-proxy: true
+```
+
+## Running
+
+```bash
+# Start a Redis instance (or let Testcontainers manage it in dev/test profile)
+./gradlew :bucket4j-advanced:bootRun
+
+# Run tests
+./gradlew :bucket4j-advanced:test
+```
+
+## Example Requests
+
+```bash
+# IP-based (anonymous)
+curl http://localhost:8080/api/anonymous/hello
+
+# userId-based (authenticated)
+curl -H "X-User-ID: alice" http://localhost:8080/api/authenticated/hello
+
+# Combined IP + userId (sensitive)
+curl -H "X-User-ID: alice" http://localhost:8080/api/sensitive/hello
+```
+
+## Dependencies
+
+| Dependency | Purpose |
+|---|---|
+| `bluetape4k-bucket4j` | `DistributedSuspendRateLimiter`, `AsyncBucketProxyProvider`, `bucketConfiguration {}` DSL |
+| `bucket4j-lettuce` | Redis-backed distributed `ProxyManager` |
+| `bluetape4k-redis` / `lettuce-core` | Lettuce Redis client |
+| `bluetape4k-coroutines` | `mono {}`, `awaitSingleOrNull()` bridges |
+| `bluetape4k-testcontainers` | `RedisServer.Launcher.redis` singleton for tests |

--- a/ratelimit/bucket4j-advanced/build.gradle.kts
+++ b/ratelimit/bucket4j-advanced/build.gradle.kts
@@ -1,0 +1,65 @@
+plugins {
+    alias(libs.plugins.kotlin.spring)
+    alias(libs.plugins.spring.boot)
+}
+
+springBoot {
+    mainClass.set("io.bluetape4k.workshop.bucket4j.advanced.Bucket4jAdvancedApplicationKt")
+    buildInfo {
+        properties {
+            additional.put("name", "Bucket4j Advanced Rate Limit Demo")
+            additional.put("description", "IP/userId/combined rate limit strategies")
+            version = "1.0.0"
+            additional.put("java.version", JavaVersion.current())
+        }
+    }
+}
+
+configurations {
+    testImplementation.get().extendsFrom(compileOnly.get(), runtimeOnly.get())
+}
+
+dependencies {
+    implementation(libs.bluetape4k.jackson3)
+
+    // Bucket4j
+    implementation(libs.bluetape4k.bucket4j)
+    implementation(libs.bucket4j.core)
+    implementation(libs.bucket4j.lettuce)
+    implementation(libs.commons.pool2)
+
+    // Redis
+    implementation(libs.bluetape4k.redis)
+    implementation(libs.lettuce.core)
+    implementation(libs.bluetape4k.testcontainers)
+
+    // Spring Boot
+    implementation(libs.spring.boot.autoconfigure.lib)
+    annotationProcessor(libs.spring.boot.autoconfigure.processor)
+    annotationProcessor(libs.spring.boot.configuration.processor)
+    runtimeOnly(libs.spring.boot.devtools)
+
+    implementation(libs.spring.boot.starter.actuator)
+    implementation(libs.spring.boot.starter.validation)
+    implementation(libs.spring.boot.starter.webflux.lib)
+    testImplementation(libs.spring.boot.starter.webflux.test)
+    testImplementation(libs.spring.boot.starter.test) {
+        exclude(group = "junit", module = "junit")
+        exclude(group = "org.junit.vintage", module = "junit-vintage-engine")
+        exclude(module = "mockito-core")
+    }
+
+    // Coroutines
+    implementation(libs.bluetape4k.coroutines)
+    implementation(libs.kotlinx.coroutines.core.lib)
+    implementation(libs.kotlinx.coroutines.reactor)
+    testImplementation(libs.kotlinx.coroutines.test.lib)
+
+    // Reactor
+    implementation(libs.reactor.netty)
+    implementation(libs.reactor.kotlin.extensions)
+    testImplementation(libs.reactor.test)
+
+    // Test
+    testImplementation(libs.bluetape4k.junit5)
+}

--- a/ratelimit/bucket4j-advanced/src/main/kotlin/io/bluetape4k/workshop/bucket4j/advanced/Bucket4jAdvancedApplication.kt
+++ b/ratelimit/bucket4j-advanced/src/main/kotlin/io/bluetape4k/workshop/bucket4j/advanced/Bucket4jAdvancedApplication.kt
@@ -1,0 +1,14 @@
+package io.bluetape4k.workshop.bucket4j.advanced
+
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
+
+@SpringBootApplication(proxyBeanMethods = false)
+class Bucket4jAdvancedApplication {
+    companion object : KLoggingChannel()
+}
+
+fun main(vararg args: String) {
+    runApplication<Bucket4jAdvancedApplication>(*args)
+}

--- a/ratelimit/bucket4j-advanced/src/main/kotlin/io/bluetape4k/workshop/bucket4j/advanced/config/LettuceConfig.kt
+++ b/ratelimit/bucket4j-advanced/src/main/kotlin/io/bluetape4k/workshop/bucket4j/advanced/config/LettuceConfig.kt
@@ -1,0 +1,23 @@
+package io.bluetape4k.workshop.bucket4j.advanced.config
+
+import io.bluetape4k.redis.lettuce.LettuceClients
+import io.bluetape4k.support.uninitialized
+import io.lettuce.core.RedisClient
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+/**
+ * Provides a Lettuce [RedisClient] bean wired from `spring.data.redis.url`.
+ */
+@Configuration(proxyBeanMethods = false)
+class LettuceConfig {
+
+    @Value("\${spring.data.redis.url}")
+    private val redisUrl: String = uninitialized()
+
+    @Bean(destroyMethod = "shutdown")
+    fun redisClient(): RedisClient {
+        return LettuceClients.clientOf(redisUrl)
+    }
+}

--- a/ratelimit/bucket4j-advanced/src/main/kotlin/io/bluetape4k/workshop/bucket4j/advanced/config/RateLimitConfig.kt
+++ b/ratelimit/bucket4j-advanced/src/main/kotlin/io/bluetape4k/workshop/bucket4j/advanced/config/RateLimitConfig.kt
@@ -1,0 +1,130 @@
+package io.bluetape4k.workshop.bucket4j.advanced.config
+
+import io.bluetape4k.bucket4j.bucketConfiguration
+import io.bluetape4k.bucket4j.distributed.AsyncBucketProxyProvider
+import io.bluetape4k.bucket4j.distributed.redis.lettuceBasedProxyManagerOf
+import io.bluetape4k.bucket4j.ratelimit.distributed.DistributedSuspendRateLimiter
+import io.bluetape4k.concurrent.virtualthread.VirtualThreadExecutor
+import io.github.bucket4j.BucketConfiguration
+import io.github.bucket4j.distributed.ExpirationAfterWriteStrategy
+import io.github.bucket4j.distributed.proxy.ClientSideConfig
+import io.github.bucket4j.distributed.proxy.ExecutionStrategy
+import io.github.bucket4j.distributed.proxy.ProxyManager
+import io.github.bucket4j.redis.lettuce.cas.LettuceBasedProxyManager
+import io.lettuce.core.RedisClient
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import java.time.Duration
+
+/**
+ * Configures three distinct rate-limit strategies:
+ *
+ * - **IP-based** (`ipRateLimiter`): limits by client IP address.
+ *   Suitable for anonymous endpoints that should not be hammered from one origin.
+ * - **User-based** (`userRateLimiter`): limits by authenticated user ID.
+ *   Authenticated users get a higher ceiling than anonymous IPs.
+ * - **Combined** (`combinedRateLimiter`): uses a composite `"ip:userId"` bucket key.
+ *   A single bucket is maintained per (IP, userId) pair, so a user can exhaust only
+ *   their own combined quota — not the global IP quota — and vice-versa.
+ *
+ * All three share the same [ProxyManager] and therefore the same Redis instance,
+ * but each limiter uses a distinct [BucketConfiguration] with different capacities.
+ */
+@Configuration(proxyBeanMethods = false)
+class RateLimitConfig {
+
+    // ------------------------------------------------------------------
+    // Shared Redis proxy manager
+    // ------------------------------------------------------------------
+
+    @Bean
+    fun proxyManager(lettuceClient: RedisClient): LettuceBasedProxyManager<ByteArray> {
+        return lettuceBasedProxyManagerOf(lettuceClient) {
+            ClientSideConfig.getDefault()
+                .withExpirationAfterWriteStrategy(
+                    ExpirationAfterWriteStrategy
+                        .basedOnTimeForRefillingBucketUpToMax(Duration.ofSeconds(90))
+                )
+                .withExecutionStrategy(ExecutionStrategy.background(VirtualThreadExecutor))
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // BucketConfiguration per strategy
+    // ------------------------------------------------------------------
+
+    /** IP-based bucket: 20 tokens per 10 s, 100 tokens per minute (anonymous traffic). */
+    @Bean
+    @Qualifier("ipBucketConfiguration")
+    fun ipBucketConfiguration(): BucketConfiguration = bucketConfiguration {
+        addLimit { it.capacity(20).refillIntervally(20, Duration.ofSeconds(10)) }
+        addLimit { it.capacity(100).refillGreedy(10, Duration.ofMinutes(1)) }
+    }
+
+    /** User-based bucket: 50 tokens per 10 s, 200 tokens per minute (authenticated traffic). */
+    @Bean
+    @Qualifier("userBucketConfiguration")
+    fun userBucketConfiguration(): BucketConfiguration = bucketConfiguration {
+        addLimit { it.capacity(50).refillIntervally(50, Duration.ofSeconds(10)) }
+        addLimit { it.capacity(200).refillGreedy(20, Duration.ofMinutes(1)) }
+    }
+
+    /** Combined (IP+userId) bucket: 10 tokens per 10 s, 50 tokens per minute. */
+    @Bean
+    @Qualifier("combinedBucketConfiguration")
+    fun combinedBucketConfiguration(): BucketConfiguration = bucketConfiguration {
+        addLimit { it.capacity(10).refillIntervally(10, Duration.ofSeconds(10)) }
+        addLimit { it.capacity(50).refillGreedy(5, Duration.ofMinutes(1)) }
+    }
+
+    // ------------------------------------------------------------------
+    // AsyncBucketProxyProvider per strategy
+    // ------------------------------------------------------------------
+
+    @Bean
+    @Qualifier("ipBucketProxyProvider")
+    fun ipBucketProxyProvider(
+        proxyManager: ProxyManager<ByteArray>,
+        @Qualifier("ipBucketConfiguration") ipBucketConfiguration: BucketConfiguration,
+    ): AsyncBucketProxyProvider =
+        AsyncBucketProxyProvider(proxyManager.asAsync(), ipBucketConfiguration)
+
+    @Bean
+    @Qualifier("userBucketProxyProvider")
+    fun userBucketProxyProvider(
+        proxyManager: ProxyManager<ByteArray>,
+        @Qualifier("userBucketConfiguration") userBucketConfiguration: BucketConfiguration,
+    ): AsyncBucketProxyProvider =
+        AsyncBucketProxyProvider(proxyManager.asAsync(), userBucketConfiguration)
+
+    @Bean
+    @Qualifier("combinedBucketProxyProvider")
+    fun combinedBucketProxyProvider(
+        proxyManager: ProxyManager<ByteArray>,
+        @Qualifier("combinedBucketConfiguration") combinedBucketConfiguration: BucketConfiguration,
+    ): AsyncBucketProxyProvider =
+        AsyncBucketProxyProvider(proxyManager.asAsync(), combinedBucketConfiguration)
+
+    // ------------------------------------------------------------------
+    // DistributedSuspendRateLimiter per strategy
+    // ------------------------------------------------------------------
+
+    @Bean
+    @Qualifier("ipRateLimiter")
+    fun ipRateLimiter(
+        @Qualifier("ipBucketProxyProvider") ipBucketProxyProvider: AsyncBucketProxyProvider,
+    ): DistributedSuspendRateLimiter = DistributedSuspendRateLimiter(ipBucketProxyProvider)
+
+    @Bean
+    @Qualifier("userRateLimiter")
+    fun userRateLimiter(
+        @Qualifier("userBucketProxyProvider") userBucketProxyProvider: AsyncBucketProxyProvider,
+    ): DistributedSuspendRateLimiter = DistributedSuspendRateLimiter(userBucketProxyProvider)
+
+    @Bean
+    @Qualifier("combinedRateLimiter")
+    fun combinedRateLimiter(
+        @Qualifier("combinedBucketProxyProvider") combinedBucketProxyProvider: AsyncBucketProxyProvider,
+    ): DistributedSuspendRateLimiter = DistributedSuspendRateLimiter(combinedBucketProxyProvider)
+}

--- a/ratelimit/bucket4j-advanced/src/main/kotlin/io/bluetape4k/workshop/bucket4j/advanced/config/TestRedisConfig.kt
+++ b/ratelimit/bucket4j-advanced/src/main/kotlin/io/bluetape4k/workshop/bucket4j/advanced/config/TestRedisConfig.kt
@@ -1,0 +1,37 @@
+package io.bluetape4k.workshop.bucket4j.advanced.config
+
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.logging.info
+import io.bluetape4k.testcontainers.storage.RedisServer
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
+import org.springframework.core.annotation.Order
+
+/**
+ * Starts a Testcontainers Redis singleton for `dev` and `test` profiles.
+ *
+ * Exposes the container URL via system properties so that [LettuceConfig] can wire it
+ * through `spring.data.redis.url` in `application.yml`.
+ */
+@Configuration(proxyBeanMethods = false)
+@Profile("dev", "test")
+@Order(0)
+class TestRedisConfig {
+
+    companion object : KLoggingChannel() {
+        val redis: RedisServer = RedisServer.Launcher.redis
+
+        init {
+            System.setProperty("testcontainers.redis.url", redis.url)
+            System.setProperty("testcontainers.redis.host", redis.host)
+            System.setProperty("testcontainers.redis.port", redis.port.toString())
+        }
+    }
+
+    @Bean
+    fun redisServer(): RedisServer {
+        log.info { "Redis Server url=${redis.url}" }
+        return redis
+    }
+}

--- a/ratelimit/bucket4j-advanced/src/main/kotlin/io/bluetape4k/workshop/bucket4j/advanced/controller/RateLimitDemoController.kt
+++ b/ratelimit/bucket4j-advanced/src/main/kotlin/io/bluetape4k/workshop/bucket4j/advanced/controller/RateLimitDemoController.kt
@@ -1,0 +1,71 @@
+package io.bluetape4k.workshop.bucket4j.advanced.controller
+
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.logging.debug
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RestController
+import java.time.Instant
+
+/**
+ * Demo controller with three endpoints, each protected by a distinct rate-limit strategy.
+ *
+ * | Path | Strategy | Required headers |
+ * |---|---|---|
+ * | `/api/anonymous/hello` | IP-based | none |
+ * | `/api/authenticated/hello` | userId-based | `X-User-ID` |
+ * | `/api/sensitive/hello` | Combined IP + userId | `X-User-ID` |
+ *
+ * Rate-limit response headers (`X-RateLimit-Remaining`, `Retry-After`) are set by
+ * the corresponding [WebFilter][org.springframework.web.server.WebFilter], not here.
+ */
+@RestController
+class RateLimitDemoController {
+
+    companion object : KLoggingChannel()
+
+    /**
+     * Anonymous endpoint — protected by IP-based rate limiting only.
+     *
+     * No authentication is required. The client IP (see `ratelimit.trust-proxy`) determines quota.
+     */
+    @GetMapping("/api/anonymous/hello")
+    suspend fun anonymousHello(): Map<String, String> {
+        log.debug { "Handling /api/anonymous/hello" }
+        return mapOf(
+            "message" to "Hello from anonymous endpoint",
+            "strategy" to "IP-based rate limit",
+            "timestamp" to Instant.now().toString()
+        )
+    }
+
+    /**
+     * Authenticated endpoint — protected by userId-based rate limiting.
+     *
+     * Requires the `X-User-ID` request header. Each user ID has its own independent quota.
+     */
+    @GetMapping("/api/authenticated/hello")
+    suspend fun authenticatedHello(): Map<String, String> {
+        log.debug { "Handling /api/authenticated/hello" }
+        return mapOf(
+            "message" to "Hello from authenticated endpoint",
+            "strategy" to "userId-based rate limit",
+            "timestamp" to Instant.now().toString()
+        )
+    }
+
+    /**
+     * Sensitive endpoint — protected by combined IP+userId rate limiting.
+     *
+     * Requires the `X-User-ID` request header. The bucket key is `"combined:$ip:$userId"`,
+     * so each (IP, user) pair has its own independent quota.
+     */
+    @GetMapping("/api/sensitive/hello")
+    suspend fun sensitiveHello(): Map<String, String> {
+        log.debug { "Handling /api/sensitive/hello" }
+        return mapOf(
+            "message" to "Hello from sensitive endpoint",
+            "strategy" to "Combined IP+userId rate limit",
+            "timestamp" to Instant.now().toString()
+        )
+    }
+}

--- a/ratelimit/bucket4j-advanced/src/main/kotlin/io/bluetape4k/workshop/bucket4j/advanced/filter/CombinedRateLimitWebFilter.kt
+++ b/ratelimit/bucket4j-advanced/src/main/kotlin/io/bluetape4k/workshop/bucket4j/advanced/filter/CombinedRateLimitWebFilter.kt
@@ -1,0 +1,93 @@
+package io.bluetape4k.workshop.bucket4j.advanced.filter
+
+import io.bluetape4k.bucket4j.ratelimit.distributed.DistributedSuspendRateLimiter
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.logging.trace
+import io.bluetape4k.logging.warn
+import io.bluetape4k.workshop.bucket4j.advanced.utils.HeaderConstants
+import io.bluetape4k.workshop.bucket4j.advanced.utils.RequestUtils
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.reactor.awaitSingleOrNull
+import kotlinx.coroutines.reactor.mono
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.core.annotation.Order
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Component
+import org.springframework.web.server.ServerWebExchange
+import org.springframework.web.server.WebFilter
+import org.springframework.web.server.WebFilterChain
+import reactor.core.publisher.Mono
+import java.util.concurrent.TimeUnit
+
+/**
+ * WebFilter that applies a combined IP+userId rate limit to `/api/sensitive/` requests.
+ *
+ * ## Strategy
+ * A single Redis bucket is keyed by the composite string `"combined:$ip:$userId"`.
+ * This means each (IP, user) pair has its own independent quota — a user cannot exhaust
+ * another user's quota, and a shared IP (e.g. NAT) does not penalise all users behind it.
+ *
+ * ## Behavior / Contract
+ * - Only intercepts requests whose path starts with `/api/sensitive`.
+ * - Both IP and `X-User-ID` header are required; either missing leads to HTTP 400.
+ * - When the combined bucket is exhausted, responds with HTTP 429 + `Retry-After`.
+ * - On internal errors, fails open to avoid service disruption.
+ */
+@Component
+@Order(12)
+class CombinedRateLimitWebFilter(
+    @Qualifier("combinedRateLimiter")
+    private val rateLimiter: DistributedSuspendRateLimiter,
+    @Value("\${ratelimit.trust-proxy:false}")
+    private val trustProxy: Boolean = false,
+) : WebFilter {
+
+    companion object : KLoggingChannel() {
+        private const val TARGET_PATH_PREFIX = "/api/sensitive"
+    }
+
+    override fun filter(exchange: ServerWebExchange, chain: WebFilterChain): Mono<Void> =
+        mono(Dispatchers.IO) {
+            val path = exchange.request.uri.path
+            if (!path.startsWith(TARGET_PATH_PREFIX)) {
+                chain.filter(exchange).awaitSingleOrNull()
+            } else {
+                val ip = RequestUtils.extractIp(exchange, trustProxy)
+                val userId = RequestUtils.extractUserId(exchange)
+                log.trace { "Combined rate limit: path=$path, ip=$ip, userId=$userId" }
+
+                if (userId.isNullOrBlank()) {
+                    // userId is always required; IP falls back to "unknown" if unavailable
+                    log.warn { "Missing X-User-ID for combined rate limit. path=$path" }
+                    exchange.response.statusCode = HttpStatus.BAD_REQUEST
+                    Mono.empty<Void>().awaitSingleOrNull()
+                } else {
+                    val effectiveIp = ip?.takeIf { it.isNotBlank() } ?: "unknown"
+                    try {
+                        val key = "combined:$effectiveIp:$userId"
+                        val result = rateLimiter.consume(key, 1L)
+                        exchange.response.headers.set(
+                            HeaderConstants.X_RATELIMIT_REMAINING,
+                            result.availableTokens.toString()
+                        )
+                        if (result.isConsumed) {
+                            log.trace { "Combined bucket[$key] consumed, remaining=${result.availableTokens}" }
+                            chain.filter(exchange).awaitSingleOrNull()
+                        } else {
+                            val retryAfterSecs = result.retryAfter
+                                ?.let { TimeUnit.NANOSECONDS.toSeconds(it.toNanos()).coerceAtLeast(1) }
+                                ?: 1L
+                            exchange.response.headers.set(HeaderConstants.RETRY_AFTER, retryAfterSecs.toString())
+                            log.warn { "Combined rate limit exceeded for $key. retryAfter=${retryAfterSecs}s" }
+                            exchange.response.statusCode = HttpStatus.TOO_MANY_REQUESTS
+                            Mono.empty<Void>().awaitSingleOrNull()
+                        }
+                    } catch (e: Throwable) {
+                        log.warn(e) { "Combined rate limit check failed for ip=$effectiveIp userId=$userId; failing open" }
+                        chain.filter(exchange).awaitSingleOrNull()
+                    }
+                }
+            }
+        }
+}

--- a/ratelimit/bucket4j-advanced/src/main/kotlin/io/bluetape4k/workshop/bucket4j/advanced/filter/CombinedRateLimitWebFilter.kt
+++ b/ratelimit/bucket4j-advanced/src/main/kotlin/io/bluetape4k/workshop/bucket4j/advanced/filter/CombinedRateLimitWebFilter.kt
@@ -71,6 +71,9 @@ class CombinedRateLimitWebFilter(
                             HeaderConstants.X_RATELIMIT_REMAINING,
                             result.availableTokens.toString()
                         )
+                        val resetSecs =
+                            TimeUnit.NANOSECONDS.toSeconds(result.diagnostics.nanosToWaitForReset).coerceAtLeast(0)
+                        exchange.response.headers.set(HeaderConstants.X_RATELIMIT_RESET, resetSecs.toString())
                         if (result.isConsumed) {
                             log.trace { "Combined bucket[$key] consumed, remaining=${result.availableTokens}" }
                             chain.filter(exchange).awaitSingleOrNull()

--- a/ratelimit/bucket4j-advanced/src/main/kotlin/io/bluetape4k/workshop/bucket4j/advanced/filter/IpRateLimitWebFilter.kt
+++ b/ratelimit/bucket4j-advanced/src/main/kotlin/io/bluetape4k/workshop/bucket4j/advanced/filter/IpRateLimitWebFilter.kt
@@ -64,6 +64,9 @@ class IpRateLimitWebFilter(
                             HeaderConstants.X_RATELIMIT_REMAINING,
                             result.availableTokens.toString()
                         )
+                        val resetSecs =
+                            TimeUnit.NANOSECONDS.toSeconds(result.diagnostics.nanosToWaitForReset).coerceAtLeast(0)
+                        exchange.response.headers.set(HeaderConstants.X_RATELIMIT_RESET, resetSecs.toString())
                         if (result.isConsumed) {
                             log.trace { "IP bucket[$key] consumed, remaining=${result.availableTokens}" }
                             chain.filter(exchange).awaitSingleOrNull()

--- a/ratelimit/bucket4j-advanced/src/main/kotlin/io/bluetape4k/workshop/bucket4j/advanced/filter/IpRateLimitWebFilter.kt
+++ b/ratelimit/bucket4j-advanced/src/main/kotlin/io/bluetape4k/workshop/bucket4j/advanced/filter/IpRateLimitWebFilter.kt
@@ -1,0 +1,86 @@
+package io.bluetape4k.workshop.bucket4j.advanced.filter
+
+import io.bluetape4k.bucket4j.ratelimit.distributed.DistributedSuspendRateLimiter
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.logging.trace
+import io.bluetape4k.logging.warn
+import io.bluetape4k.workshop.bucket4j.advanced.utils.HeaderConstants
+import io.bluetape4k.workshop.bucket4j.advanced.utils.RequestUtils
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.reactor.awaitSingleOrNull
+import kotlinx.coroutines.reactor.mono
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.core.annotation.Order
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Component
+import org.springframework.web.server.ServerWebExchange
+import org.springframework.web.server.WebFilter
+import org.springframework.web.server.WebFilterChain
+import reactor.core.publisher.Mono
+import java.util.concurrent.TimeUnit
+
+/**
+ * WebFilter that applies IP-based rate limiting to `/api/anonymous/` requests.
+ *
+ * ## Behavior / Contract
+ * - Only intercepts requests whose path starts with `/api/anonymous`.
+ * - Client IP is derived from [RequestUtils.extractIp] with [trustProxy] config.
+ * - When the bucket is exhausted, responds with HTTP 429 and a `Retry-After` header.
+ * - On extraction failure (no IP), responds with HTTP 400.
+ * - On internal errors, fails open (request passes through) to avoid service disruption.
+ */
+@Component
+@Order(10)
+class IpRateLimitWebFilter(
+    @Qualifier("ipRateLimiter")
+    private val rateLimiter: DistributedSuspendRateLimiter,
+    @Value("\${ratelimit.trust-proxy:false}")
+    private val trustProxy: Boolean = false,
+) : WebFilter {
+
+    companion object : KLoggingChannel() {
+        private const val TARGET_PATH_PREFIX = "/api/anonymous"
+    }
+
+    override fun filter(exchange: ServerWebExchange, chain: WebFilterChain): Mono<Void> =
+        mono(Dispatchers.IO) {
+            val path = exchange.request.uri.path
+            if (!path.startsWith(TARGET_PATH_PREFIX)) {
+                chain.filter(exchange).awaitSingleOrNull()
+            } else {
+                val ip = RequestUtils.extractIp(exchange, trustProxy)
+                log.trace { "IP rate limit: path=$path, ip=$ip" }
+
+                // Use "unknown" as fallback when IP cannot be determined (e.g. mock clients in tests
+                // or requests arriving without a remote address). A shared "unknown" bucket applies
+                // rate limiting rather than blocking or failing open.
+                val effectiveIp = ip?.takeIf { it.isNotBlank() } ?: "unknown"
+                run {
+                    try {
+                        val key = "ip:$effectiveIp"
+                        val result = rateLimiter.consume(key, 1L)
+                        exchange.response.headers.set(
+                            HeaderConstants.X_RATELIMIT_REMAINING,
+                            result.availableTokens.toString()
+                        )
+                        if (result.isConsumed) {
+                            log.trace { "IP bucket[$key] consumed, remaining=${result.availableTokens}" }
+                            chain.filter(exchange).awaitSingleOrNull()
+                        } else {
+                            val retryAfterSecs = result.retryAfter
+                                ?.let { TimeUnit.NANOSECONDS.toSeconds(it.toNanos()).coerceAtLeast(1) }
+                                ?: 1L
+                            exchange.response.headers.set(HeaderConstants.RETRY_AFTER, retryAfterSecs.toString())
+                            log.warn { "IP rate limit exceeded for $key. retryAfter=${retryAfterSecs}s" }
+                            exchange.response.statusCode = HttpStatus.TOO_MANY_REQUESTS
+                            Mono.empty<Void>().awaitSingleOrNull()
+                        }
+                    } catch (e: Throwable) {
+                        log.warn(e) { "IP rate limit check failed for ip=$effectiveIp; failing open" }
+                        chain.filter(exchange).awaitSingleOrNull()
+                    }
+                }
+            }
+        }
+}

--- a/ratelimit/bucket4j-advanced/src/main/kotlin/io/bluetape4k/workshop/bucket4j/advanced/filter/UserRateLimitWebFilter.kt
+++ b/ratelimit/bucket4j-advanced/src/main/kotlin/io/bluetape4k/workshop/bucket4j/advanced/filter/UserRateLimitWebFilter.kt
@@ -61,6 +61,9 @@ class UserRateLimitWebFilter(
                             HeaderConstants.X_RATELIMIT_REMAINING,
                             result.availableTokens.toString()
                         )
+                        val resetSecs =
+                            TimeUnit.NANOSECONDS.toSeconds(result.diagnostics.nanosToWaitForReset).coerceAtLeast(0)
+                        exchange.response.headers.set(HeaderConstants.X_RATELIMIT_RESET, resetSecs.toString())
                         if (result.isConsumed) {
                             log.trace { "User bucket[$key] consumed, remaining=${result.availableTokens}" }
                             chain.filter(exchange).awaitSingleOrNull()

--- a/ratelimit/bucket4j-advanced/src/main/kotlin/io/bluetape4k/workshop/bucket4j/advanced/filter/UserRateLimitWebFilter.kt
+++ b/ratelimit/bucket4j-advanced/src/main/kotlin/io/bluetape4k/workshop/bucket4j/advanced/filter/UserRateLimitWebFilter.kt
@@ -1,0 +1,83 @@
+package io.bluetape4k.workshop.bucket4j.advanced.filter
+
+import io.bluetape4k.bucket4j.ratelimit.distributed.DistributedSuspendRateLimiter
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.logging.trace
+import io.bluetape4k.logging.warn
+import io.bluetape4k.workshop.bucket4j.advanced.utils.HeaderConstants
+import io.bluetape4k.workshop.bucket4j.advanced.utils.RequestUtils
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.reactor.awaitSingleOrNull
+import kotlinx.coroutines.reactor.mono
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.core.annotation.Order
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Component
+import org.springframework.web.server.ServerWebExchange
+import org.springframework.web.server.WebFilter
+import org.springframework.web.server.WebFilterChain
+import reactor.core.publisher.Mono
+import java.util.concurrent.TimeUnit
+
+/**
+ * WebFilter that applies user ID-based rate limiting to `/api/authenticated/` requests.
+ *
+ * ## Behavior / Contract
+ * - Only intercepts requests whose path starts with `/api/authenticated`.
+ * - User ID is read from the `X-User-ID` request header.
+ * - When the header is absent, responds with HTTP 401 (authentication required).
+ * - When the bucket is exhausted, responds with HTTP 429 and a `Retry-After` header.
+ * - On internal errors, fails open to avoid service disruption.
+ */
+@Component
+@Order(11)
+class UserRateLimitWebFilter(
+    @Qualifier("userRateLimiter")
+    private val rateLimiter: DistributedSuspendRateLimiter,
+) : WebFilter {
+
+    companion object : KLoggingChannel() {
+        private const val TARGET_PATH_PREFIX = "/api/authenticated"
+    }
+
+    override fun filter(exchange: ServerWebExchange, chain: WebFilterChain): Mono<Void> =
+        mono(Dispatchers.IO) {
+            val path = exchange.request.uri.path
+            if (!path.startsWith(TARGET_PATH_PREFIX)) {
+                chain.filter(exchange).awaitSingleOrNull()
+            } else {
+                val userId = RequestUtils.extractUserId(exchange)
+                log.trace { "User rate limit: path=$path, userId=$userId" }
+
+                if (userId.isNullOrBlank()) {
+                    log.warn { "Missing X-User-ID header for path=$path" }
+                    exchange.response.statusCode = HttpStatus.UNAUTHORIZED
+                    Mono.empty<Void>().awaitSingleOrNull()
+                } else {
+                    try {
+                        val key = "user:$userId"
+                        val result = rateLimiter.consume(key, 1L)
+                        exchange.response.headers.set(
+                            HeaderConstants.X_RATELIMIT_REMAINING,
+                            result.availableTokens.toString()
+                        )
+                        if (result.isConsumed) {
+                            log.trace { "User bucket[$key] consumed, remaining=${result.availableTokens}" }
+                            chain.filter(exchange).awaitSingleOrNull()
+                        } else {
+                            val retryAfterSecs = result.retryAfter
+                                ?.let { TimeUnit.NANOSECONDS.toSeconds(it.toNanos()).coerceAtLeast(1) }
+                                ?: 1L
+                            exchange.response.headers.set(HeaderConstants.RETRY_AFTER, retryAfterSecs.toString())
+                            log.warn { "User rate limit exceeded for $key. retryAfter=${retryAfterSecs}s" }
+                            exchange.response.statusCode = HttpStatus.TOO_MANY_REQUESTS
+                            Mono.empty<Void>().awaitSingleOrNull()
+                        }
+                    } catch (e: Throwable) {
+                        log.warn(e) { "User rate limit check failed for userId=$userId; failing open" }
+                        chain.filter(exchange).awaitSingleOrNull()
+                    }
+                }
+            }
+        }
+}

--- a/ratelimit/bucket4j-advanced/src/main/kotlin/io/bluetape4k/workshop/bucket4j/advanced/utils/HeaderConstants.kt
+++ b/ratelimit/bucket4j-advanced/src/main/kotlin/io/bluetape4k/workshop/bucket4j/advanced/utils/HeaderConstants.kt
@@ -1,0 +1,17 @@
+package io.bluetape4k.workshop.bucket4j.advanced.utils
+
+/**
+ * HTTP header name constants used by the advanced rate-limit module.
+ */
+object HeaderConstants {
+
+    // Incoming request headers
+    const val X_FORWARDED_FOR = "X-Forwarded-For"
+    const val X_REAL_IP = "X-Real-IP"
+    const val X_USER_ID = "X-User-ID"
+
+    // Response headers (HTTP-standard rate-limit field names)
+    const val X_RATELIMIT_REMAINING = "X-RateLimit-Remaining"
+    const val X_RATELIMIT_RESET = "X-RateLimit-Reset"
+    const val RETRY_AFTER = "Retry-After"
+}

--- a/ratelimit/bucket4j-advanced/src/main/kotlin/io/bluetape4k/workshop/bucket4j/advanced/utils/RequestUtils.kt
+++ b/ratelimit/bucket4j-advanced/src/main/kotlin/io/bluetape4k/workshop/bucket4j/advanced/utils/RequestUtils.kt
@@ -1,0 +1,50 @@
+package io.bluetape4k.workshop.bucket4j.advanced.utils
+
+import org.springframework.web.server.ServerWebExchange
+
+/**
+ * Utilities for extracting identity keys from HTTP requests.
+ *
+ * ## Behavior / Contract
+ * - IP extraction respects the `X-Forwarded-For` header only when proxy trust is enabled.
+ *   When enabled, the leftmost (client) IP is taken; otherwise the raw remote address is used.
+ * - User ID is extracted from the `X-User-ID` header.
+ * - All header names are defined as constants in [HeaderConstants].
+ */
+object RequestUtils {
+
+    /**
+     * Extracts the client IP address from [exchange].
+     *
+     * When [trustProxy] is true, the leftmost address in `X-Forwarded-For` is returned.
+     * Falls back to `X-Real-IP` then the TCP remote address.
+     *
+     * **Security note**: trusting `X-Forwarded-For` without verifying it comes from a
+     * trusted proxy allows clients to spoof their IP. Enable [trustProxy] only when the
+     * application sits behind a known, controlled reverse-proxy.
+     */
+    fun extractIp(exchange: ServerWebExchange, trustProxy: Boolean = false): String? {
+        val request = exchange.request
+        if (trustProxy) {
+            val forwardedFor = request.headers.getFirst(HeaderConstants.X_FORWARDED_FOR)
+            if (!forwardedFor.isNullOrBlank()) {
+                return forwardedFor.split(",").first().trim()
+            }
+            val realIp = request.headers.getFirst(HeaderConstants.X_REAL_IP)
+            if (!realIp.isNullOrBlank()) {
+                return realIp.trim()
+            }
+        }
+        return request.remoteAddress?.address?.hostAddress
+    }
+
+    /**
+     * Extracts the user ID from the `X-User-ID` request header.
+     *
+     * Returns `null` when the header is absent or blank.
+     */
+    fun extractUserId(exchange: ServerWebExchange): String? {
+        return exchange.request.headers.getFirst(HeaderConstants.X_USER_ID)
+            ?.takeIf { it.isNotBlank() }
+    }
+}

--- a/ratelimit/bucket4j-advanced/src/main/resources/application.yml
+++ b/ratelimit/bucket4j-advanced/src/main/resources/application.yml
@@ -1,0 +1,50 @@
+spring:
+    application:
+        name: bucket4j-advanced
+
+    profiles:
+        active: dev
+        default: dev
+
+    jackson:
+        serialization:
+            indent-output: true
+    codec:
+        max-in-memory-size: 10MB
+
+    data:
+        redis:
+            host: ${testcontainers.redis.host}
+            port: ${testcontainers.redis.port}
+            url: ${testcontainers.redis.url}
+            lettuce:
+                pool:
+                    enabled: true
+
+server:
+    port: 8080
+
+# Rate limit settings
+ratelimit:
+    # When true, the X-Forwarded-For and X-Real-IP headers are trusted for IP extraction.
+    # Enable only when the application is behind a trusted, controlled reverse proxy.
+    # WARNING: enabling this without a trusted proxy allows clients to spoof their IP address.
+    trust-proxy: false
+
+info:
+    name: ${spring.application.name}
+    description: Bucket4j advanced rate limit demo — IP / userId / combined strategies
+    environment: ${spring.profiles.active}
+    version: 1.0.0
+
+management:
+    endpoints:
+        web:
+            exposure:
+                include: "*"
+    endpoint:
+        health:
+            show-details: always
+    metrics:
+        tags:
+            application: ${spring.application.name}

--- a/ratelimit/bucket4j-advanced/src/test/kotlin/io/bluetape4k/workshop/bucket4j/advanced/AbstractBucket4jAdvancedTest.kt
+++ b/ratelimit/bucket4j-advanced/src/test/kotlin/io/bluetape4k/workshop/bucket4j/advanced/AbstractBucket4jAdvancedTest.kt
@@ -1,0 +1,37 @@
+package io.bluetape4k.workshop.bucket4j.advanced
+
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.workshop.bucket4j.advanced.config.TestRedisConfig
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.web.server.LocalServerPort
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.springframework.test.web.reactive.server.WebTestClient
+
+@ActiveProfiles("test")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+abstract class AbstractBucket4jAdvancedTest {
+
+    companion object : KLoggingChannel() {
+        @JvmStatic
+        @DynamicPropertySource
+        fun registerRedisProperties(registry: DynamicPropertyRegistry) {
+            val redis = TestRedisConfig.redis
+            registry.add("testcontainers.redis.url") { redis.url }
+            registry.add("testcontainers.redis.host") { redis.host }
+            registry.add("testcontainers.redis.port") { redis.port.toString() }
+        }
+    }
+
+    @LocalServerPort
+    protected var port: Int = 0
+
+    // Use bindToServer so requests have a real TCP remote address (127.0.0.1).
+    // This is required for IP-based rate limiting to work correctly in tests.
+    protected val client: WebTestClient by lazy {
+        WebTestClient.bindToServer()
+            .baseUrl("http://localhost:$port")
+            .build()
+    }
+}

--- a/ratelimit/bucket4j-advanced/src/test/kotlin/io/bluetape4k/workshop/bucket4j/advanced/RateLimitDemoControllerTest.kt
+++ b/ratelimit/bucket4j-advanced/src/test/kotlin/io/bluetape4k/workshop/bucket4j/advanced/RateLimitDemoControllerTest.kt
@@ -1,0 +1,248 @@
+package io.bluetape4k.workshop.bucket4j.advanced
+
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.logging.debug
+import io.bluetape4k.workshop.bucket4j.advanced.utils.HeaderConstants
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.MethodOrderer
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestMethodOrder
+import org.springframework.http.HttpStatus
+import org.testcontainers.utility.Base58
+
+/**
+ * Integration tests for [RateLimitDemoController] validating all three rate-limit strategies.
+ *
+ * Tests are ordered so that non-exhausting checks run before tests that drain the bucket.
+ * This is necessary because all IP-based tests share the same `127.0.0.1` Redis bucket key.
+ * User-based and combined tests always use unique random user IDs, so they are independent.
+ *
+ * Bucket capacities (per [RateLimitConfig]):
+ * - IP-based   : 20 tokens / 10 s
+ * - User-based : 50 tokens / 10 s
+ * - Combined   : 10 tokens / 10 s
+ */
+@TestMethodOrder(MethodOrderer.OrderAnnotation::class)
+class RateLimitDemoControllerTest : AbstractBucket4jAdvancedTest() {
+
+    companion object : KLoggingChannel() {
+        private const val ANONYMOUS_PATH = "/api/anonymous/hello"
+        private const val AUTHENTICATED_PATH = "/api/authenticated/hello"
+        private const val SENSITIVE_PATH = "/api/sensitive/hello"
+    }
+
+    // ------------------------------------------------------------------
+    // IP-based rate limit tests  (non-exhausting first, exhausting last)
+    // ------------------------------------------------------------------
+
+    @Test
+    @Order(10)
+    fun `IP rate limit - anonymous endpoint returns 200 with remaining header`() = runTest {
+        val response = client.get()
+            .uri(ANONYMOUS_PATH)
+            .exchange()
+            .expectStatus().isOk
+            .expectHeader().exists(HeaderConstants.X_RATELIMIT_REMAINING)
+            .expectBody(Map::class.java)
+            .returnResult()
+
+        val remaining = response.responseHeaders.getFirst(HeaderConstants.X_RATELIMIT_REMAINING)?.toLongOrNull()
+        log.debug { "IP remaining=$remaining" }
+        assert(remaining != null && remaining >= 0) { "X-RateLimit-Remaining must be a non-negative number" }
+    }
+
+    @Test
+    @Order(11)
+    fun `IP rate limit - X-Forwarded-For is ignored when trust-proxy is false (default)`() = runTest {
+        // When trust-proxy=false, the X-Forwarded-For header is ignored.
+        // The real TCP remote address (127.0.0.1) is used instead.
+        // We verify that the spoofed IP has no effect: response is 200 or 429 (real-IP bucket),
+        // never 400/500.
+        val result = client.get()
+            .uri(ANONYMOUS_PATH)
+            .header(HeaderConstants.X_FORWARDED_FOR, "1.2.3.4, 5.6.7.8")
+            .exchange()
+            .returnResult(String::class.java)
+
+        val status = result.status
+        assert(status == HttpStatus.OK || status == HttpStatus.TOO_MANY_REQUESTS) {
+            "Expected 200 or 429 (real-IP bucket), but got $status — spoofed XFF must not cause 4xx/5xx errors"
+        }
+    }
+
+    @Test
+    @Order(99)  // runs last — drains the shared 127.0.0.1 IP bucket
+    fun `IP rate limit - exhausts bucket and returns 429`() = runTest {
+        var exhausted = false
+        repeat(30) {
+            val status = client.get()
+                .uri(ANONYMOUS_PATH)
+                .exchange()
+                .returnResult(String::class.java)
+                .status
+
+            if (status == HttpStatus.TOO_MANY_REQUESTS) {
+                exhausted = true
+                return@repeat
+            }
+        }
+        assert(exhausted) { "Expected HTTP 429 after exhausting IP rate limit bucket" }
+    }
+
+    @Test
+    @Order(100) // runs after exhaustion — verifies Retry-After is in the 429 response
+    fun `IP rate limit - 429 response includes Retry-After header`() = runTest {
+        // Bucket is already exhausted from previous test; any request should return 429.
+        repeat(30) {
+            val result = client.get()
+                .uri(ANONYMOUS_PATH)
+                .exchange()
+                .returnResult(String::class.java)
+
+            if (result.status == HttpStatus.TOO_MANY_REQUESTS) {
+                val retryAfter = result.responseHeaders.getFirst(HeaderConstants.RETRY_AFTER)
+                assert(retryAfter != null) { "Retry-After header must be present in 429 response" }
+                assert(retryAfter!!.toLong() >= 1) { "Retry-After must be at least 1 second" }
+                return@runTest
+            }
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // userId-based rate limit tests  (always use unique userId — fully isolated)
+    // ------------------------------------------------------------------
+
+    @Test
+    @Order(20)
+    fun `user rate limit - authenticated endpoint returns 200 for valid user`() = runTest {
+        val userId = "user-" + Base58.randomString(8)
+
+        client.get()
+            .uri(AUTHENTICATED_PATH)
+            .header(HeaderConstants.X_USER_ID, userId)
+            .exchange()
+            .expectStatus().isOk
+            .expectHeader().exists(HeaderConstants.X_RATELIMIT_REMAINING)
+    }
+
+    @Test
+    @Order(21)
+    fun `user rate limit - missing X-User-ID returns 401`() = runTest {
+        client.get()
+            .uri(AUTHENTICATED_PATH)
+            .exchange()
+            .expectStatus().isUnauthorized
+    }
+
+    @Test
+    @Order(22)
+    fun `user rate limit - different users have independent buckets`() = runTest {
+        val userId1 = "independent-a-" + Base58.randomString(6)
+        val userId2 = "independent-b-" + Base58.randomString(6)
+
+        client.get()
+            .uri(AUTHENTICATED_PATH)
+            .header(HeaderConstants.X_USER_ID, userId1)
+            .exchange()
+            .expectStatus().isOk
+
+        client.get()
+            .uri(AUTHENTICATED_PATH)
+            .header(HeaderConstants.X_USER_ID, userId2)
+            .exchange()
+            .expectStatus().isOk
+    }
+
+    @Test
+    @Order(23)
+    fun `user rate limit - exhausts per-user bucket and returns 429`() = runTest {
+        val userId = "exhaust-" + Base58.randomString(8)
+        var exhausted = false
+
+        repeat(55) {
+            val status = client.get()
+                .uri(AUTHENTICATED_PATH)
+                .header(HeaderConstants.X_USER_ID, userId)
+                .exchange()
+                .returnResult(String::class.java)
+                .status
+
+            if (status == HttpStatus.TOO_MANY_REQUESTS) {
+                exhausted = true
+                return@repeat
+            }
+        }
+        assert(exhausted) { "Expected HTTP 429 after exhausting user rate limit bucket for userId=$userId" }
+    }
+
+    // ------------------------------------------------------------------
+    // Combined IP+userId rate limit tests  (always use unique userId — fully isolated)
+    // ------------------------------------------------------------------
+
+    @Test
+    @Order(30)
+    fun `combined rate limit - sensitive endpoint returns 200 with both ip and user`() = runTest {
+        val userId = "combined-" + Base58.randomString(8)
+
+        client.get()
+            .uri(SENSITIVE_PATH)
+            .header(HeaderConstants.X_USER_ID, userId)
+            .exchange()
+            .expectStatus().isOk
+            .expectHeader().exists(HeaderConstants.X_RATELIMIT_REMAINING)
+    }
+
+    @Test
+    @Order(31)
+    fun `combined rate limit - missing X-User-ID returns 400`() = runTest {
+        client.get()
+            .uri(SENSITIVE_PATH)
+            .exchange()
+            .expectStatus().isBadRequest
+    }
+
+    @Test
+    @Order(32)
+    fun `combined rate limit - different user IDs have independent combined buckets`() = runTest {
+        val userId1 = "combo-a-" + Base58.randomString(6)
+        val userId2 = "combo-b-" + Base58.randomString(6)
+
+        // Exhaust userId1's combined bucket (capacity = 10)
+        repeat(12) {
+            client.get()
+                .uri(SENSITIVE_PATH)
+                .header(HeaderConstants.X_USER_ID, userId1)
+                .exchange()
+        }
+
+        // userId2 should still be allowed — separate bucket key
+        client.get()
+            .uri(SENSITIVE_PATH)
+            .header(HeaderConstants.X_USER_ID, userId2)
+            .exchange()
+            .expectStatus().isOk
+    }
+
+    @Test
+    @Order(33)
+    fun `combined rate limit - exhausts combined bucket and returns 429`() = runTest {
+        val userId = "combined-exhaust-" + Base58.randomString(8)
+        var exhausted = false
+
+        repeat(15) {
+            val status = client.get()
+                .uri(SENSITIVE_PATH)
+                .header(HeaderConstants.X_USER_ID, userId)
+                .exchange()
+                .returnResult(String::class.java)
+                .status
+
+            if (status == HttpStatus.TOO_MANY_REQUESTS) {
+                exhausted = true
+                return@repeat
+            }
+        }
+        assert(exhausted) { "Expected HTTP 429 after exhausting combined rate limit bucket for userId=$userId" }
+    }
+}

--- a/ratelimit/bucket4j-advanced/src/test/kotlin/io/bluetape4k/workshop/bucket4j/advanced/RateLimitDemoControllerTest.kt
+++ b/ratelimit/bucket4j-advanced/src/test/kotlin/io/bluetape4k/workshop/bucket4j/advanced/RateLimitDemoControllerTest.kt
@@ -44,6 +44,7 @@ class RateLimitDemoControllerTest : AbstractBucket4jAdvancedTest() {
             .exchange()
             .expectStatus().isOk
             .expectHeader().exists(HeaderConstants.X_RATELIMIT_REMAINING)
+            .expectHeader().exists(HeaderConstants.X_RATELIMIT_RESET)
             .expectBody(Map::class.java)
             .returnResult()
 

--- a/ratelimit/bucket4j-advanced/src/test/resources/junit-platform.properties
+++ b/ratelimit/bucket4j-advanced/src/test/resources/junit-platform.properties
@@ -1,0 +1,6 @@
+junit.jupiter.extensions.autodetection.enabled=true
+junit.jupiter.testinstance.lifecycle.default=per_class
+
+junit.jupiter.execution.parallel.enabled=true
+junit.jupiter.execution.parallel.mode.default=same_thread
+junit.jupiter.execution.parallel.mode.classes.default=concurrent

--- a/ratelimit/bucket4j-advanced/src/test/resources/logback-test.xml
+++ b/ratelimit/bucket4j-advanced/src/test/resources/logback-test.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+    <!-- @formatter:off -->
+    <springProperty scope="context" name="APP_NAME" source="spring.application.name"/>
+
+    <!-- You can override this to have a custom pattern -->
+    <property name="CONSOLE_LOG_PATTERN"
+              value="%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %highlight(${LOG_LEVEL_PATTERN:-%5p}) %magenta(${PID:- }) %clr(---){faint} %clr([%24.24t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}"/>
+
+    <!-- Appender to log to console -->
+    <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <!-- Minimum logging level to be presented in the console logs-->
+            <level>TRACE</level>
+        </filter>
+        <encoder>
+            <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+            <charset>utf8</charset>
+        </encoder>
+    </appender>
+    <!-- formatter:on -->
+
+    <logger name="io.bluetape4k.workshop.bucket4j.advanced" level="TRACE"/>
+    <logger name="io.bluetape4k.bucket4j" level="DEBUG"/>
+
+    <logger name="org.springframework.http.server.reactive" level="DEBUG"/>
+    <logger name="org.springframework.web.reactive" level="DEBUG"/>
+
+    <root level="INFO">
+        <appender-ref ref="console"/>
+    </root>
+</configuration>


### PR DESCRIPTION
## Summary

Implements a new workshop module `ratelimit/bucket4j-advanced` demonstrating three distinct Bucket4j rate-limit identity strategies with Spring Boot WebFlux + Coroutines + Redis (Lettuce).

## Strategies

| Strategy | Endpoint | Bucket Key | Capacity |
|---|---|---|---|
| IP-based | `GET /api/anonymous/hello` | `ip:<address>` | 20 tokens / 10 s |
| userId-based | `GET /api/authenticated/hello` | `user:<userId>` | 50 tokens / 10 s |
| Combined | `GET /api/sensitive/hello` | `combined:<ip>:<userId>` | 10 tokens / 10 s |

## Design Decisions

- **Combined strategy**: Uses a single composite `ip:userId` bucket key. Each (IP, user) pair has an independent quota. Documented in README with comparison to two-bucket AND-gate approach.
- **Filter isolation**: Each WebFilter handles only its own path prefix — no double-counting of tokens.
- **Standard headers**: `X-RateLimit-Remaining` and `Retry-After` instead of custom header names.
- **Proxy trust config**: `ratelimit.trust-proxy=false` (default) ignores `X-Forwarded-For` to prevent IP spoofing. Documented with security warning.
- **IP fallback**: When TCP remote address is unavailable, uses `"unknown"` fallback key rather than rejecting the request.

## Tests

- 12 tests, all passing
- IP-based exhaustion, userId-based exhaustion, combined exhaustion
- Missing header validation (401 for userId, 400 for combined)
- Independent bucket isolation across users
- XFF spoofing ignored when trust-proxy=false
- `@TestMethodOrder` ensures non-exhausting tests run before exhaustion tests

**Verification command:**
```
./gradlew :bucket4j-advanced:test
```
**Result:** 12 tests completed, 0 failures, 0 errors (4.3s)

## Files Added

- `ratelimit/bucket4j-advanced/` — new module (18 files)
- `docs/lessons/2026-05-24-issue-96-ratelimit-advanced.md` — implementation retrospective

Closes #96