### PR TITLE
feat: add aws/storage-abstraction workshop with local/S3/presigned profiles (#107)

### DIFF
--- a/aws/storage-abstraction/README.md
+++ b/aws/storage-abstraction/README.md
@@ -1,0 +1,120 @@
+# Storage Abstraction Workshop
+
+Demonstrates a pluggable storage strategy that switches between local filesystem,
+AWS S3, and S3 pre-signed URL backends via Spring Profile — without changing application code.
+
+## Architecture
+
+```mermaid
+graph TD
+    Client["Application Code"] --> SI["StorageService (interface)"]
+    SI -->|"@Profile('local')"| LS["LocalStorageService\n(java.nio.file.Files)"]
+    SI -->|"@Profile('s3')"| S3["S3StorageService\n(S3Client + Floci/AWS)"]
+    SI -->|"@Profile('s3-presigned')"| SP["S3PresignedStorageService\n(S3Client + S3Presigner)"]
+    S3 --> FL["FlociServer\n(Testcontainers)"]
+    SP --> FL
+```
+
+## Key Features
+
+| Feature | Description |
+|---------|-------------|
+| Storage abstraction | Single `StorageService` interface with `upload`, `download`, `getUrl`, `delete` |
+| Profile switching | `local` / `s3` / `s3-presigned` Spring profiles select the implementation |
+| Local backend | `java.nio.file.Files` — zero external dependencies, instant test startup |
+| S3 backend | AWS SDK v2 `S3Client` wrapped in `withContext(Dispatchers.IO)` |
+| Pre-signed URLs | `S3Presigner` generates time-limited GET URLs (default 15 min, 900 s) |
+| Coroutines | All `suspend` methods; blocking I/O dispatched on `Dispatchers.IO` |
+| Local AWS emulator | `FlociServer` (Testcontainers) replaces LocalStack Community edition |
+
+## Profile Switching
+
+### local (default dev/test — no Docker required)
+
+```bash
+./gradlew :aws-storage-abstraction:bootRun --args='--spring.profiles.active=local'
+```
+
+### s3 (LocalStack-compatible — requires Docker)
+
+```bash
+./gradlew :aws-storage-abstraction:bootRun --args='--spring.profiles.active=s3'
+```
+
+### s3-presigned (S3 with pre-signed GET URLs — requires Docker)
+
+```bash
+./gradlew :aws-storage-abstraction:bootRun --args='--spring.profiles.active=s3-presigned'
+```
+
+## StorageService Interface
+
+```kotlin
+interface StorageService {
+    suspend fun upload(key: String, content: ByteArray, contentType: String): String
+    suspend fun download(key: String): ByteArray
+    suspend fun getUrl(key: String): String   // public URL or pre-signed URL
+    suspend fun delete(key: String)
+}
+```
+
+## Pre-signed URL Behaviour
+
+When the `s3-presigned` profile is active, `getUrl()` generates a pre-signed
+S3 GET URL using `S3Presigner`. The URL includes an `X-Amz-Expires=900`
+query parameter (configurable via `storage.s3.presign-duration-minutes`).
+
+```kotlin
+// Example presigned URL (LocalStack / Floci):
+// http://127.0.0.1:4566/bluetape4k-workshop-bucket/test/hello.txt
+//   ?X-Amz-Algorithm=AWS4-HMAC-SHA256
+//   &X-Amz-Date=...
+//   &X-Amz-Expires=900
+//   &X-Amz-SignedHeaders=host
+//   &X-Amz-Signature=...
+```
+
+## Configuration
+
+`src/main/resources/application.yml`:
+
+```yaml
+storage:
+  local:
+    base-path: /tmp/bluetape4k-workshop-storage   # local profile root directory
+  s3:
+    bucket-name: bluetape4k-workshop-bucket        # S3 bucket name
+    presign-duration-minutes: 15                   # pre-signed URL TTL
+```
+
+## Dependencies
+
+```kotlin
+// build.gradle.kts
+implementation(libs.bluetape4k.aws)           // bluetape4k-aws-spring-boot
+implementation(libs.bluetape4k.coroutines)
+implementation(libs.aws2.s3.lib)              // AWS SDK v2 S3
+implementation(libs.bluetape4k.testcontainers)
+implementation(libs.testcontainers.localstack) // Floci uses LocalStack-compatible API
+```
+
+## Running Tests
+
+```bash
+./gradlew :aws-storage-abstraction:test
+```
+
+Tests run all three profiles in a single Gradle task:
+
+- `LocalStorageServiceTest` — 5 tests, `local` profile, no Docker
+- `S3StorageServiceTest` — 5 tests, `s3` profile, Floci container (shared JVM singleton)
+- `S3PresignedStorageServiceTest` — 7 tests, `s3-presigned` profile, Floci + presigned URL assertions
+
+## Notes
+
+- `S3AutoConfiguration` from `bluetape4k-aws-spring-boot` is excluded in `application.yml`
+  because this module manages its own S3 beans via `S3Config`.
+- `FlociServer.Launcher.floci` is a JVM-level singleton — the container starts once and is
+  shared by all S3 test classes in the same Gradle test run.
+- All blocking AWS SDK calls are wrapped in `withContext(Dispatchers.IO)` to comply with
+  coroutine structured concurrency contracts.

--- a/aws/storage-abstraction/build.gradle.kts
+++ b/aws/storage-abstraction/build.gradle.kts
@@ -1,0 +1,51 @@
+plugins {
+    alias(libs.plugins.kotlin.spring)
+    alias(libs.plugins.kotlin.noarg)
+    alias(libs.plugins.spring.boot)
+}
+
+springBoot {
+    mainClass.set("io.bluetape4k.workshop.storage.StorageApplicationKt")
+}
+
+configurations {
+    testImplementation.get().extendsFrom(compileOnly.get(), runtimeOnly.get())
+}
+
+dependencies {
+    // bluetape4k
+    implementation(libs.bluetape4k.core)
+    implementation(libs.bluetape4k.coroutines)
+    implementation(libs.bluetape4k.jackson3)
+    implementation(libs.bluetape4k.aws)
+
+    // AWS SDK v2
+    implementation(libs.aws2.s3.lib)
+
+    // Testcontainers for LocalStack (also needed at runtime for embedded test config)
+    implementation(libs.bluetape4k.testcontainers)
+    implementation(libs.testcontainers.localstack)
+
+    // Spring Boot
+    implementation(libs.spring.boot.autoconfigure.lib)
+    annotationProcessor(libs.spring.boot.autoconfigure.processor)
+    annotationProcessor(libs.spring.boot.configuration.processor)
+    runtimeOnly(libs.spring.boot.devtools)
+
+    implementation(libs.spring.boot.starter.web)
+    implementation(libs.spring.boot.starter.actuator)
+
+    testImplementation(libs.spring.boot.starter.test) {
+        exclude(group = "junit", module = "junit")
+        exclude(group = "org.junit.vintage", module = "junit-vintage-engine")
+        exclude(module = "mockito-core")
+    }
+
+    // Coroutines
+    implementation(libs.kotlinx.coroutines.core.lib)
+    testImplementation(libs.kotlinx.coroutines.test.lib)
+
+    // Jackson
+    implementation(libs.jackson3.databind)
+    implementation(libs.jackson3.module.kotlin)
+}

--- a/aws/storage-abstraction/src/main/kotlin/io/bluetape4k/workshop/storage/LocalStorageService.kt
+++ b/aws/storage-abstraction/src/main/kotlin/io/bluetape4k/workshop/storage/LocalStorageService.kt
@@ -1,0 +1,75 @@
+package io.bluetape4k.workshop.storage
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Profile
+import org.springframework.stereotype.Service
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+
+/**
+ * Local filesystem-based [StorageService] implementation.
+ *
+ * ## Behavior / Contract
+ * - All objects are stored under [basePath] on the local filesystem.
+ * - `upload` writes bytes to `{basePath}/{key}` and returns a `file://` URL.
+ * - `download` reads bytes from `{basePath}/{key}`.
+ * - `getUrl` returns the `file://` URL for the stored path.
+ * - `delete` removes the file; silently ignores missing files.
+ * - All blocking I/O is dispatched on [Dispatchers.IO].
+ * - Active when Spring profile `local` is set.
+ *
+ * ```kotlin
+ * // With profile "local":
+ * val url = storageService.upload("test.txt", "Hello".toByteArray(), "text/plain")
+ * // url = "file:///tmp/storage/test.txt"
+ * ```
+ */
+@Service
+@Profile("local")
+class LocalStorageService(
+    @Value("\${storage.local.base-path:/tmp/bluetape4k-workshop-storage}") private val basePath: String,
+) : StorageService {
+
+    companion object : KLogging()
+
+    private val root: Path get() = Paths.get(basePath)
+
+    override suspend fun upload(key: String, content: ByteArray, contentType: String): String =
+        withContext(Dispatchers.IO) {
+            val target = resolveAndCreateParents(key)
+            Files.write(target, content)
+            log.debug { "Uploaded [$key] to $target (${content.size} bytes, $contentType)" }
+            target.toUri().toString()
+        }
+
+    override suspend fun download(key: String): ByteArray =
+        withContext(Dispatchers.IO) {
+            val target = root.resolve(key)
+            log.debug { "Downloading [$key] from $target" }
+            Files.readAllBytes(target)
+        }
+
+    override suspend fun getUrl(key: String): String =
+        withContext(Dispatchers.IO) {
+            root.resolve(key).toUri().toString()
+        }
+
+    override suspend fun delete(key: String) {
+        withContext(Dispatchers.IO) {
+            val target = root.resolve(key)
+            val deleted = Files.deleteIfExists(target)
+            log.debug { "Delete [$key]: deleted=$deleted" }
+        }
+    }
+
+    private fun resolveAndCreateParents(key: String): Path {
+        val target = root.resolve(key)
+        Files.createDirectories(target.parent ?: root)
+        return target
+    }
+}

--- a/aws/storage-abstraction/src/main/kotlin/io/bluetape4k/workshop/storage/S3Config.kt
+++ b/aws/storage-abstraction/src/main/kotlin/io/bluetape4k/workshop/storage/S3Config.kt
@@ -1,0 +1,51 @@
+package io.bluetape4k.workshop.storage
+
+import io.bluetape4k.aws.auth.staticCredentialsProviderOf
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.testcontainers.aws.FlociServer
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.presigner.S3Presigner
+
+/**
+ * S3 bean configuration for profiles `s3` and `s3-presigned`.
+ *
+ * ## Behavior / Contract
+ * - Uses [FlociServer] via [FlociServer.Launcher] singleton for local/test environments.
+ *   Floci is the open-source replacement for LocalStack Community edition.
+ * - [S3Client] is synchronous; callers wrap calls in `withContext(Dispatchers.IO)`.
+ * - [S3Presigner] is provided only for the `s3-presigned` profile.
+ *
+ * ```kotlin
+ * // Beans are auto-wired into S3StorageService / S3PresignedStorageService
+ * ```
+ */
+@Configuration(proxyBeanMethods = false)
+@Profile("s3 | s3-presigned")
+class S3Config {
+
+    companion object : KLogging() {
+        /** Shared Floci AWS emulator instance across all test runs in the same JVM. */
+        val floci: FlociServer = FlociServer.Launcher.floci
+    }
+
+    @Bean
+    fun s3Client(): S3Client =
+        S3Client.builder()
+            .endpointOverride(floci.awsEndpoint)
+            .region(Region.of(floci.regionName))
+            .credentialsProvider(staticCredentialsProviderOf(floci.awsAccessKey, floci.awsSecretKey))
+            .build()
+
+    @Bean
+    @Profile("s3-presigned")
+    fun s3Presigner(): S3Presigner =
+        S3Presigner.builder()
+            .endpointOverride(floci.awsEndpoint)
+            .region(Region.of(floci.regionName))
+            .credentialsProvider(staticCredentialsProviderOf(floci.awsAccessKey, floci.awsSecretKey))
+            .build()
+}

--- a/aws/storage-abstraction/src/main/kotlin/io/bluetape4k/workshop/storage/S3PresignedStorageService.kt
+++ b/aws/storage-abstraction/src/main/kotlin/io/bluetape4k/workshop/storage/S3PresignedStorageService.kt
@@ -1,0 +1,104 @@
+package io.bluetape4k.workshop.storage
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Profile
+import org.springframework.stereotype.Service
+import software.amazon.awssdk.core.sync.RequestBody
+import software.amazon.awssdk.core.sync.ResponseTransformer
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException
+import software.amazon.awssdk.services.s3.presigner.S3Presigner
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest
+import java.time.Duration
+
+/**
+ * AWS S3-backed [StorageService] with pre-signed URL support for the `s3-presigned` Spring profile.
+ *
+ * ## Behavior / Contract
+ * - All objects are stored in [bucketName] on S3 (or LocalStack in tests).
+ * - `upload` puts bytes to S3 and returns the same public S3 URL.
+ * - `download` retrieves bytes from S3; throws [NoSuchKeyException] if the key does not exist.
+ * - `getUrl` generates a pre-signed GET URL valid for [presignDurationMinutes] minutes (default 15).
+ *   The URL contains `X-Amz-Expires` query parameter reflecting the duration in seconds.
+ * - `delete` removes the object; silently ignores missing keys.
+ * - All blocking `S3Client` / `S3Presigner` calls are wrapped in `withContext(Dispatchers.IO)`.
+ * - Active when Spring profile `s3-presigned` is set.
+ *
+ * ```kotlin
+ * // With profile "s3-presigned":
+ * val url = storageService.upload("docs/readme.txt", bytes, "text/plain")
+ * val presignedUrl = storageService.getUrl("docs/readme.txt")
+ * // presignedUrl contains "X-Amz-Expires=900"
+ * ```
+ */
+@Service
+@Profile("s3-presigned")
+class S3PresignedStorageService(
+    private val s3Client: S3Client,
+    private val s3Presigner: S3Presigner,
+    @Value("\${storage.s3.bucket-name:bluetape4k-workshop-bucket}") private val bucketName: String,
+    @Value("\${storage.s3.presign-duration-minutes:15}") private val presignDurationMinutes: Long,
+) : StorageService {
+
+    companion object : KLogging()
+
+    override suspend fun upload(key: String, content: ByteArray, contentType: String): String =
+        withContext(Dispatchers.IO) {
+            ensureBucketExists()
+            s3Client.putObject(
+                { req -> req.bucket(bucketName).key(key).contentType(contentType).contentLength(content.size.toLong()) },
+                RequestBody.fromBytes(content)
+            )
+            log.debug { "Uploaded [$key] to s3://$bucketName (presigned, $contentType, ${content.size} bytes)" }
+            "https://s3.amazonaws.com/$bucketName/$key"
+        }
+
+    override suspend fun download(key: String): ByteArray =
+        withContext(Dispatchers.IO) {
+            log.debug { "Downloading [$key] from s3://$bucketName (presigned)" }
+            s3Client.getObject(
+                { req -> req.bucket(bucketName).key(key) },
+                ResponseTransformer.toBytes()
+            ).asByteArray()
+        }
+
+    override suspend fun getUrl(key: String): String =
+        withContext(Dispatchers.IO) {
+            val presignRequest = GetObjectPresignRequest.builder()
+                .signatureDuration(Duration.ofMinutes(presignDurationMinutes))
+                .getObjectRequest { req -> req.bucket(bucketName).key(key) }
+                .build()
+
+            val presignedUrl = s3Presigner.presignGetObject(presignRequest).url().toString()
+            log.debug { "Generated presigned URL for [$key] (expires in ${presignDurationMinutes}m)" }
+            presignedUrl
+        }
+
+    override suspend fun delete(key: String) {
+        withContext(Dispatchers.IO) {
+            try {
+                s3Client.deleteObject { req -> req.bucket(bucketName).key(key) }
+                log.debug { "Deleted [$key] from s3://$bucketName (presigned)" }
+            } catch (e: NoSuchKeyException) {
+                log.debug { "Delete [$key]: key not found, ignoring" }
+            }
+        }
+    }
+
+    private fun ensureBucketExists() {
+        val exists = try {
+            s3Client.headBucket { it.bucket(bucketName) }
+            true
+        } catch (e: Exception) {
+            false
+        }
+        if (!exists) {
+            s3Client.createBucket { it.bucket(bucketName) }
+            log.debug { "Created bucket: $bucketName" }
+        }
+    }
+}

--- a/aws/storage-abstraction/src/main/kotlin/io/bluetape4k/workshop/storage/S3StorageService.kt
+++ b/aws/storage-abstraction/src/main/kotlin/io/bluetape4k/workshop/storage/S3StorageService.kt
@@ -1,0 +1,89 @@
+package io.bluetape4k.workshop.storage
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Profile
+import org.springframework.stereotype.Service
+import software.amazon.awssdk.core.sync.RequestBody
+import software.amazon.awssdk.core.sync.ResponseTransformer
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException
+
+/**
+ * AWS S3-backed [StorageService] implementation for the `s3` Spring profile.
+ *
+ * ## Behavior / Contract
+ * - All objects are stored in [bucketName] on S3 (or LocalStack in tests).
+ * - `upload` puts bytes to S3 and returns a plain `https://s3.amazonaws.com/{bucket}/{key}` URL.
+ * - `download` retrieves bytes from S3; throws [NoSuchKeyException] if the key does not exist.
+ * - `getUrl` returns the same public S3 URL as `upload`.
+ * - `delete` removes the object; silently ignores missing keys.
+ * - All blocking `S3Client` calls are wrapped in `withContext(Dispatchers.IO)`.
+ * - Active when Spring profile `s3` is set.
+ *
+ * ```kotlin
+ * // With profile "s3":
+ * val url = storageService.upload("docs/readme.txt", bytes, "text/plain")
+ * val data = storageService.download("docs/readme.txt")
+ * storageService.delete("docs/readme.txt")
+ * ```
+ */
+@Service
+@Profile("s3")
+class S3StorageService(
+    private val s3Client: S3Client,
+    @Value("\${storage.s3.bucket-name:bluetape4k-workshop-bucket}") private val bucketName: String,
+) : StorageService {
+
+    companion object : KLogging()
+
+    override suspend fun upload(key: String, content: ByteArray, contentType: String): String =
+        withContext(Dispatchers.IO) {
+            ensureBucketExists()
+            s3Client.putObject(
+                { req -> req.bucket(bucketName).key(key).contentType(contentType).contentLength(content.size.toLong()) },
+                RequestBody.fromBytes(content)
+            )
+            log.debug { "Uploaded [$key] to s3://$bucketName ($contentType, ${content.size} bytes)" }
+            "https://s3.amazonaws.com/$bucketName/$key"
+        }
+
+    override suspend fun download(key: String): ByteArray =
+        withContext(Dispatchers.IO) {
+            log.debug { "Downloading [$key] from s3://$bucketName" }
+            s3Client.getObject(
+                { req -> req.bucket(bucketName).key(key) },
+                ResponseTransformer.toBytes()
+            ).asByteArray()
+        }
+
+    override suspend fun getUrl(key: String): String =
+        "https://s3.amazonaws.com/$bucketName/$key"
+
+    override suspend fun delete(key: String) {
+        withContext(Dispatchers.IO) {
+            try {
+                s3Client.deleteObject { req -> req.bucket(bucketName).key(key) }
+                log.debug { "Deleted [$key] from s3://$bucketName" }
+            } catch (e: NoSuchKeyException) {
+                log.debug { "Delete [$key]: key not found, ignoring" }
+            }
+        }
+    }
+
+    private fun ensureBucketExists() {
+        val exists = try {
+            s3Client.headBucket { it.bucket(bucketName) }
+            true
+        } catch (e: Exception) {
+            false
+        }
+        if (!exists) {
+            s3Client.createBucket { it.bucket(bucketName) }
+            log.debug { "Created bucket: $bucketName" }
+        }
+    }
+}

--- a/aws/storage-abstraction/src/main/kotlin/io/bluetape4k/workshop/storage/StorageApplication.kt
+++ b/aws/storage-abstraction/src/main/kotlin/io/bluetape4k/workshop/storage/StorageApplication.kt
@@ -1,0 +1,14 @@
+package io.bluetape4k.workshop.storage
+
+import io.bluetape4k.logging.KLogging
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
+
+fun main(vararg args: String) {
+    runApplication<StorageApplication>(*args)
+}
+
+@SpringBootApplication(proxyBeanMethods = false)
+class StorageApplication {
+    companion object : KLogging()
+}

--- a/aws/storage-abstraction/src/main/kotlin/io/bluetape4k/workshop/storage/StorageService.kt
+++ b/aws/storage-abstraction/src/main/kotlin/io/bluetape4k/workshop/storage/StorageService.kt
@@ -1,0 +1,55 @@
+package io.bluetape4k.workshop.storage
+
+/**
+ * Storage abstraction interface that supports local filesystem and AWS S3 backends.
+ *
+ * ## Behavior / Contract
+ * - `upload` stores the content and returns a URL to access the stored object.
+ * - `download` retrieves the raw bytes stored under the given key.
+ * - `getUrl` returns a direct URL (local) or a pre-signed URL (S3 presigned) valid for the backend.
+ * - `delete` removes the object; implementations should be idempotent (no error if key is absent).
+ * - Implementations are selected via Spring Profile: `local`, `s3`, or `s3-presigned`.
+ *
+ * ```kotlin
+ * val url = storageService.upload("docs/readme.txt", content, "text/plain")
+ * val bytes = storageService.download("docs/readme.txt")
+ * val link = storageService.getUrl("docs/readme.txt")
+ * storageService.delete("docs/readme.txt")
+ * ```
+ */
+interface StorageService {
+    /**
+     * Uploads [content] under the given [key] and returns a URL to access it.
+     *
+     * @param key object key (e.g. "folder/file.txt")
+     * @param content raw bytes to store
+     * @param contentType MIME type (e.g. "text/plain", "image/png")
+     * @return URL string pointing to the stored object
+     */
+    suspend fun upload(key: String, content: ByteArray, contentType: String): String
+
+    /**
+     * Downloads the object stored under [key] and returns its raw bytes.
+     *
+     * @param key object key
+     * @return raw bytes of the stored object
+     */
+    suspend fun download(key: String): ByteArray
+
+    /**
+     * Returns a URL to access the object stored under [key].
+     * For S3 presigned profile this is a time-limited pre-signed GET URL.
+     *
+     * @param key object key
+     * @return URL string
+     */
+    suspend fun getUrl(key: String): String
+
+    /**
+     * Deletes the object stored under [key].
+     * Implementations should be idempotent.
+     *
+     * @param key object key
+     */
+    suspend fun delete(key: String)
+}

--- a/aws/storage-abstraction/src/main/resources/application.yml
+++ b/aws/storage-abstraction/src/main/resources/application.yml
@@ -1,0 +1,15 @@
+spring:
+  application:
+    name: storage-abstraction
+  # Disable bluetape4k-aws S3 auto-configuration — we manage S3 beans ourselves via S3Config
+  autoconfigure:
+    exclude:
+      - io.bluetape4k.aws.spring.s3.S3AutoConfiguration
+      - io.bluetape4k.aws.spring.s3.S3TransferAutoConfiguration
+
+storage:
+  local:
+    base-path: /tmp/bluetape4k-workshop-storage
+  s3:
+    bucket-name: bluetape4k-workshop-bucket
+    presign-duration-minutes: 15

--- a/aws/storage-abstraction/src/test/kotlin/io/bluetape4k/workshop/storage/AbstractStorageServiceTest.kt
+++ b/aws/storage-abstraction/src/test/kotlin/io/bluetape4k/workshop/storage/AbstractStorageServiceTest.kt
@@ -1,0 +1,69 @@
+package io.bluetape4k.workshop.storage
+
+import io.bluetape4k.logging.KLogging
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.MethodOrderer
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestMethodOrder
+import org.springframework.beans.factory.annotation.Autowired
+import kotlin.test.assertContentEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Base test class for all [StorageService] implementations.
+ *
+ * Subclasses activate the appropriate Spring profile via `@ActiveProfiles`.
+ */
+@TestMethodOrder(MethodOrderer.OrderAnnotation::class)
+abstract class AbstractStorageServiceTest {
+
+    companion object : KLogging() {
+        const val TEST_KEY = "test/hello.txt"
+        val TEST_CONTENT = "Hello, Storage Abstraction!".toByteArray(Charsets.UTF_8)
+        const val TEST_CONTENT_TYPE = "text/plain"
+    }
+
+    @Autowired
+    lateinit var storageService: StorageService
+
+    @Test
+    @Order(1)
+    fun `upload returns a non-blank URL`() = runTest {
+        val url = storageService.upload(TEST_KEY, TEST_CONTENT, TEST_CONTENT_TYPE)
+        assertNotNull(url)
+        assertTrue(url.isNotBlank(), "URL must not be blank, got: $url")
+    }
+
+    @Test
+    @Order(2)
+    fun `download returns the same bytes that were uploaded`() = runTest {
+        storageService.upload(TEST_KEY, TEST_CONTENT, TEST_CONTENT_TYPE)
+        val downloaded = storageService.download(TEST_KEY)
+        assertContentEquals(TEST_CONTENT, downloaded)
+    }
+
+    @Test
+    @Order(3)
+    fun `getUrl returns a non-blank URL for an existing key`() = runTest {
+        storageService.upload(TEST_KEY, TEST_CONTENT, TEST_CONTENT_TYPE)
+        val url = storageService.getUrl(TEST_KEY)
+        assertTrue(url.isNotBlank(), "URL must not be blank, got: $url")
+    }
+
+    @Test
+    @Order(4)
+    fun `delete removes the object without error`() = runTest {
+        storageService.upload(TEST_KEY, TEST_CONTENT, TEST_CONTENT_TYPE)
+        // Should not throw
+        storageService.delete(TEST_KEY)
+    }
+
+    @Test
+    @Order(5)
+    fun `delete is idempotent for missing key`() = runTest {
+        // Delete a key that was never uploaded — must not throw
+        storageService.delete("non-existent/key.txt")
+    }
+}

--- a/aws/storage-abstraction/src/test/kotlin/io/bluetape4k/workshop/storage/LocalStorageServiceTest.kt
+++ b/aws/storage-abstraction/src/test/kotlin/io/bluetape4k/workshop/storage/LocalStorageServiceTest.kt
@@ -1,0 +1,11 @@
+package io.bluetape4k.workshop.storage
+
+import io.bluetape4k.logging.KLogging
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+
+@SpringBootTest
+@ActiveProfiles("local")
+class LocalStorageServiceTest : AbstractStorageServiceTest() {
+    companion object : KLogging()
+}

--- a/aws/storage-abstraction/src/test/kotlin/io/bluetape4k/workshop/storage/S3PresignedStorageServiceTest.kt
+++ b/aws/storage-abstraction/src/test/kotlin/io/bluetape4k/workshop/storage/S3PresignedStorageServiceTest.kt
@@ -1,0 +1,35 @@
+package io.bluetape4k.workshop.storage
+
+import io.bluetape4k.logging.KLogging
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import kotlin.test.assertTrue
+
+@SpringBootTest
+@ActiveProfiles("s3-presigned")
+class S3PresignedStorageServiceTest : AbstractStorageServiceTest() {
+
+    companion object : KLogging()
+
+    @Test
+    fun `getUrl returns a presigned URL containing X-Amz-Expires`() = runTest {
+        storageService.upload(TEST_KEY, TEST_CONTENT, TEST_CONTENT_TYPE)
+        val url = storageService.getUrl(TEST_KEY)
+        assertTrue(
+            url.contains("X-Amz-Expires", ignoreCase = true),
+            "Presigned URL must contain X-Amz-Expires, got: $url"
+        )
+    }
+
+    @Test
+    fun `presigned URL reflects configured expiry of 15 minutes (900 seconds)`() = runTest {
+        storageService.upload(TEST_KEY, TEST_CONTENT, TEST_CONTENT_TYPE)
+        val url = storageService.getUrl(TEST_KEY)
+        assertTrue(
+            url.contains("X-Amz-Expires=900", ignoreCase = true),
+            "Presigned URL must contain X-Amz-Expires=900, got: $url"
+        )
+    }
+}

--- a/aws/storage-abstraction/src/test/kotlin/io/bluetape4k/workshop/storage/S3StorageServiceTest.kt
+++ b/aws/storage-abstraction/src/test/kotlin/io/bluetape4k/workshop/storage/S3StorageServiceTest.kt
@@ -1,0 +1,11 @@
+package io.bluetape4k.workshop.storage
+
+import io.bluetape4k.logging.KLogging
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+
+@SpringBootTest
+@ActiveProfiles("s3")
+class S3StorageServiceTest : AbstractStorageServiceTest() {
+    companion object : KLogging()
+}

--- a/aws/storage-abstraction/src/test/resources/junit-platform.properties
+++ b/aws/storage-abstraction/src/test/resources/junit-platform.properties
@@ -1,0 +1,6 @@
+junit.jupiter.extensions.autodetection.enabled=true
+junit.jupiter.testinstance.lifecycle.default=per_class
+
+junit.jupiter.execution.parallel.enabled=false
+junit.jupiter.execution.parallel.mode.default=same_thread
+junit.jupiter.execution.parallel.mode.classes.default=concurrent

--- a/aws/storage-abstraction/src/test/resources/logback-test.xml
+++ b/aws/storage-abstraction/src/test/resources/logback-test.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+    <!-- @formatter:off -->
+    <springProperty scope="context" name="APP_NAME" source="spring.application.name"/>
+
+    <!-- You can override this to have a custom pattern -->
+    <property name="CONSOLE_LOG_PATTERN"
+              value="%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %highlight(${LOG_LEVEL_PATTERN:-%5p}) %magenta(${PID:- }) %clr(---){faint} %clr([%25.25t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}"/>
+
+    <!-- Appender to log to console -->
+    <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <!-- Minimum logging level to be presented in the console logs-->
+            <level>DEBUG</level>
+        </filter>
+        <encoder>
+            <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+            <charset>utf8</charset>
+        </encoder>
+    </appender>
+    <!-- formatter:on -->
+
+    <logger name="io.bluetape4k.workshop" level="DEBUG"/>
+
+    <root level="INFO">
+        <appender-ref ref="console"/>
+    </root>
+</configuration>

--- a/docs/lessons/2026-05-24-issue-107-storage-abstraction.md
+++ b/docs/lessons/2026-05-24-issue-107-storage-abstraction.md
@@ -1,0 +1,94 @@
+# Issue #107 — Storage Abstraction 워크샵 모듈 구현 회고
+
+## 개요
+
+`aws/storage-abstraction` 모듈을 신규 생성했습니다.
+Spring Profile로 로컬 파일시스템 / AWS S3 / S3 Pre-signed URL 세 가지 스토리지 전략을 전환하는 예제입니다.
+
+## 핵심 결정사항
+
+### 1. LocalStackServer → FlociServer 전환
+
+`bluetape4k-testcontainers 1.9.1`에서 `LocalStackServer`가 deprecated 되었습니다.
+`FlociServer`(GraalVM Native Image 기반 경량 AWS 에뮬레이터)가 공식 대체재입니다.
+
+API 차이:
+- `LocalStackServer.endpoint` → `FlociServer.awsEndpoint`
+- `LocalStackServer.accessKey` → `FlociServer.awsAccessKey`
+- `LocalStackServer.secretKey` → `FlociServer.awsSecretKey`
+- `LocalStackServer.region` → `FlociServer.regionName`
+
+### 2. bluetape4k-aws S3AutoConfiguration 비활성화
+
+`bluetape4k-aws-spring-boot`의 `S3AutoConfiguration`은 클래스패스에 S3가 있으면
+무조건 활성화됩니다. `local` 프로파일에서는 AWS 리전 설정이 없으므로 컨텍스트 로딩에 실패합니다.
+
+해결: `application.yml`에서 `spring.autoconfigure.exclude`로 명시적으로 제외합니다.
+
+```yaml
+spring:
+  autoconfigure:
+    exclude:
+      - io.bluetape4k.aws.spring.s3.S3AutoConfiguration
+      - io.bluetape4k.aws.spring.s3.S3TransferAutoConfiguration
+```
+
+### 3. S3Presigner — bluetape4k-aws에 없음
+
+`bluetape4k-aws-java 0.2.1`에 `S3Presigner` 관련 확장 함수가 없습니다.
+AWS SDK v2의 `S3Presigner`를 직접 사용했습니다.
+
+```kotlin
+val presignRequest = GetObjectPresignRequest.builder()
+    .signatureDuration(Duration.ofMinutes(presignDurationMinutes))
+    .getObjectRequest { req -> req.bucket(bucketName).key(key) }
+    .build()
+val url = s3Presigner.presignGetObject(presignRequest).url().toString()
+```
+
+### 4. withContext(Dispatchers.IO) 필수
+
+`StorageService` 인터페이스는 `suspend` 메서드를 선언합니다.
+`S3Client`와 `Files.*`는 블로킹 API이므로 반드시 `withContext(Dispatchers.IO)`로 감싸야 합니다.
+
+### 5. FlociServer 싱글턴 공유
+
+`FlociServer.Launcher.floci`는 JVM 수준 싱글턴입니다.
+`S3StorageServiceTest`와 `S3PresignedStorageServiceTest`가 동일한 컨테이너 인스턴스를 공유합니다.
+Floci는 모든 서비스를 기본 활성화하므로 `withServices("s3")` 호출은 no-op입니다.
+
+## 테스트 결과
+
+```
+LocalStorageServiceTest:    5 tests, 0 failures (local profile)
+S3StorageServiceTest:       5 tests, 0 failures (s3 profile)
+S3PresignedStorageServiceTest: 7 tests, 0 failures (s3-presigned profile)
+합계: 17 tests, 모두 통과
+```
+
+## 파일 구조
+
+```
+aws/storage-abstraction/
+├── build.gradle.kts
+├── README.md
+└── src/
+    ├── main/
+    │   ├── kotlin/io/bluetape4k/workshop/storage/
+    │   │   ├── StorageApplication.kt
+    │   │   ├── StorageService.kt         (interface)
+    │   │   ├── LocalStorageService.kt    (@Profile("local"))
+    │   │   ├── S3Config.kt               (@Profile("s3 | s3-presigned"))
+    │   │   ├── S3StorageService.kt       (@Profile("s3"))
+    │   │   └── S3PresignedStorageService.kt (@Profile("s3-presigned"))
+    │   └── resources/application.yml
+    └── test/
+        ├── kotlin/io/bluetape4k/workshop/storage/
+        │   ├── AbstractStorageServiceTest.kt
+        │   ├── LocalStorageServiceTest.kt
+        │   ├── S3StorageServiceTest.kt
+        │   └── S3PresignedStorageServiceTest.kt
+        └── resources/
+            ├── junit-platform.properties
+            └── logback-test.xml
+```


### PR DESCRIPTION
## Summary

Add new module `aws/storage-abstraction` demonstrating a pluggable storage strategy that switches between local filesystem, AWS S3, and S3 pre-signed URL backends via Spring Profile — without changing application code.

Closes #107

## Architecture

```
StorageService (interface)
  ├── LocalStorageService     @Profile("local")        — java.nio.file.Files
  ├── S3StorageService        @Profile("s3")           — AWS SDK v2 S3Client
  └── S3PresignedStorageService @Profile("s3-presigned") — S3Client + S3Presigner
```

## Key Points

- **Profile switching**: `local` / `s3` / `s3-presigned` selects the implementation
- **Coroutines**: All `suspend` methods; blocking I/O dispatched on `Dispatchers.IO`
- **FlociServer**: Uses `FlociServer.Launcher` singleton (replaces deprecated `LocalStackServer`)
- **Pre-signed URLs**: `S3Presigner` generates time-limited GET URLs containing `X-Amz-Expires=900`
- **Auto-config exclusion**: `bluetape4k S3AutoConfiguration` excluded to prevent region resolution failure on `local` profile

## Test Results

```
./gradlew :aws-storage-abstraction:test

LocalStorageServiceTest:       5 tests passed  (local profile, no Docker)
S3StorageServiceTest:          5 tests passed  (s3 profile, Floci container)
S3PresignedStorageServiceTest: 7 tests passed  (s3-presigned, presign URL assertions)
Total: 17 tests, 0 failures
```

## Files Changed

- `aws/storage-abstraction/build.gradle.kts`
- `aws/storage-abstraction/src/main/kotlin/io/bluetape4k/workshop/storage/`
  - `StorageApplication.kt`, `StorageService.kt`
  - `LocalStorageService.kt`, `S3Config.kt`, `S3StorageService.kt`, `S3PresignedStorageService.kt`
- `aws/storage-abstraction/src/main/resources/application.yml`
- `aws/storage-abstraction/src/test/kotlin/io/bluetape4k/workshop/storage/` (4 test files)
- `aws/storage-abstraction/src/test/resources/` (junit-platform.properties, logback-test.xml)
- `aws/storage-abstraction/README.md`
- `docs/lessons/2026-05-24-issue-107-storage-abstraction.md`