### PR TITLE
feat: add kotlin/text-processing workshop with AhoCorasick and language detection (#105)

### DIFF
--- a/docs/lessons/2026-05-24-issue-105-text-processing.md
+++ b/docs/lessons/2026-05-24-issue-105-text-processing.md
@@ -1,0 +1,125 @@
+# Issue #105 — kotlin/text-processing 모듈 구현 회고
+
+날짜: 2026-05-24  
+브랜치: `feat/issue-105-text-processing`  
+관련 이슈: [#105](https://github.com/bluetape4k/bluetape4k-workshop/issues/105)
+
+---
+
+## 목표
+
+`bluetape4k-text` 라이브러리를 활용한 텍스트 처리 예제 모듈 `kotlin/text-processing` 생성.
+
+구현 대상:
+1. `AbuseWordFilter` — AhoCorasick 기반 금칙어 필터
+2. `LanguageDetectionService` — Lingua 기반 언어 감지
+3. `TextNormalizer` — 기본 텍스트 정규화 / 키워드 추출
+
+---
+
+## 주요 발견 사항
+
+### bluetape4k-text 는 독립 버저닝
+
+`bluetape4k-text` 라이브러리는 메인 `bluetape4k` BOM과 별개로 `io.github.bluetape4k.text` 그룹으로
+독립 배포된다. 버전도 별도 관리 (`0.1.x`).
+
+**workshop `libs.versions.toml`에 이미 선언되어 있었으나 버전 참조가 없었다:**
+
+```toml
+# 기존 — 버전 없음 (FAILED)
+bluetape4k-text-search = { module = "io.github.bluetape4k.text:text-search" }
+```
+
+`bluetape4k-text = "0.1.2"` 버전 항목을 추가하고 기존 선언에 `version.ref`를 보완하여 해결.
+
+### 최신 릴리즈 버전 확인 방법
+
+```
+https://repo1.maven.org/maven2/io/github/bluetape4k/text/text-search/maven-metadata.xml
+```
+
+- SNAPSHOT 최신: `0.1.3-SNAPSHOT` (central snapshots)
+- 릴리즈 최신: `0.1.2` (Maven Central)
+
+workshop에서는 안정 릴리즈인 `0.1.2` 사용.
+
+### AhoCorasick DSL API
+
+```kotlin
+val automaton = ahoCorasick<String> {
+    ignoreCase = true
+    allowOverlaps = true
+    normalization = NormalizationForm.NFC
+    keyword("spam", "spam")
+}
+automaton.containsMatch(text)          // 존재 여부 (조기 종료)
+automaton.parseText(text)              // List<AhoCorasickMatch<V>>
+automaton.replaceAll(text) { "***" }   // 치환
+```
+
+`ahoCorasickOf(vararg keywords)` 헬퍼도 있으나, 커스텀 SearchOptions가 필요할 때는
+`ahoCorasick<V> { }` DSL이 더 깔끔하다.
+
+### Lingua API
+
+`LanguageDetector` 생성은 비용이 크다 — 반드시 **하나의 인스턴스를 재사용**해야 한다.
+
+```kotlin
+val detector = allLanguageDetector {
+    withMinimumRelativeDistance(0.0)
+    withLowAccuracyMode()
+}
+detector.detectLanguageOf(text)                    // Language enum
+detector.computeLanguageConfidenceValues(text)     // Map<Language, Double>
+```
+
+테스트에서는 `@TestInstance(PER_CLASS)`를 활용해 detector를 클래스 수준에서 한 번만 생성.
+
+### bluetape4k-assertions 임포트
+
+workshop 모듈에서 `kluent` (org.amshove.kluent)는 사용하지 않는다.
+`bluetape4k-assertions` 의 import 경로는 `io.bluetape4k.assertions.*`.
+
+```kotlin
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldContain
+import io.bluetape4k.assertions.shouldHaveSize
+import io.bluetape4k.assertions.shouldBeTrue
+```
+
+---
+
+## 실수 / 주의사항
+
+1. **toml 중복 선언**: 내가 추가하기 전에 이미 `bluetape4k-text-search`, `bluetape4k-text-lingua`
+   항목이 존재했다. 중복 추가하여 `TOML catalog definition` 오류가 발생. 기존 항목에 `version.ref`만
+   추가하는 방식으로 수정.
+
+2. **버전 오판**: `gradle.properties`의 `baseVersion=0.1.3`을 보고 `0.1.3`을 넣었다가
+   Maven Central에는 아직 `0.1.2`까지만 릴리즈된 것을 확인. 릴리즈 여부는 반드시
+   `maven-metadata.xml`로 확인해야 한다.
+
+3. **Lingua 모델 로딩 시간**: `withLowAccuracyMode()`를 사용하면 모델 로딩이 빨라진다.
+   `withPreloadedLanguageModels()`는 정확도는 높지만 첫 빌드/테스트가 느려진다.
+
+---
+
+## 테스트 결과
+
+```
+26 tests passing (1.3s)
+- AbuseWordFilterTest:        9 tests
+- LanguageDetectionServiceTest: 7 tests
+- TextNormalizerTest:         10 tests
+```
+
+명령어: `./gradlew :kotlin-text-processing:test`
+
+---
+
+## 참고 링크
+
+- [bluetape4k-text GitHub](https://github.com/bluetape4k/bluetape4k-text)
+- [Lingua 언어 감지](https://github.com/pemistahl/lingua)
+- [Aho-Corasick 알고리즘 위키](https://en.wikipedia.org/wiki/Aho%E2%80%93Corasick_algorithm)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,6 @@
 
 [versions]
 bluetape4k-dependencies-version = "1.1.3"  # https://mvnrepository.com/artifact/io.github.bluetape4k/bluetape4k-dependencies
-bluetape4k-text = "0.1.2"  # https://mvnrepository.com/artifact/io.github.bluetape4k.text/text-search
 
 kotlin = "2.3.21"  # https://mvnrepository.com/artifact/org.jetbrains.kotlin/kotlin-bom
 kotlinx-coroutines = "1.11.0"  # https://mvnrepository.com/artifact/org.jetbrains.kotlinx/kotlinx-coroutines-bom
@@ -207,11 +206,11 @@ bluetape4k-leader-redis-lettuce = { module = "io.github.bluetape4k.leader:blueta
 bluetape4k-javers-core = { module = "io.github.bluetape4k.javers:javers-core" }
 bluetape4k-javers-persistence-redis = { module = "io.github.bluetape4k.javers:javers-persistence-redis" }
 bluetape4k-javers-persistence-kafka = { module = "io.github.bluetape4k.javers:javers-persistence-kafka" }
-bluetape4k-text-core = { module = "io.github.bluetape4k.text:tokenizer-core", version.ref = "bluetape4k-text" }
-bluetape4k-text-korean = { module = "io.github.bluetape4k.text:tokenizer-korean", version.ref = "bluetape4k-text" }
-bluetape4k-text-japanese = { module = "io.github.bluetape4k.text:tokenizer-japanese", version.ref = "bluetape4k-text" }
-bluetape4k-text-lingua = { module = "io.github.bluetape4k.text:lingua", version.ref = "bluetape4k-text" }
-bluetape4k-text-search = { module = "io.github.bluetape4k.text:text-search", version.ref = "bluetape4k-text" }
+bluetape4k-text-core = { module = "io.github.bluetape4k.text:tokenizer-core" }
+bluetape4k-text-korean = { module = "io.github.bluetape4k.text:tokenizer-korean" }
+bluetape4k-text-japanese = { module = "io.github.bluetape4k.text:tokenizer-japanese" }
+bluetape4k-text-lingua = { module = "io.github.bluetape4k.text:lingua" }
+bluetape4k-text-search = { module = "io.github.bluetape4k.text:text-search" }
 bluetape4k-micrometer = { module = "io.github.bluetape4k:bluetape4k-micrometer" }
 bluetape4k-redis = { module = "io.github.bluetape4k:bluetape4k-redis" }
 bluetape4k-redisson = { module = "io.github.bluetape4k:bluetape4k-redisson" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,7 @@
 
 [versions]
 bluetape4k-dependencies-version = "1.1.3"  # https://mvnrepository.com/artifact/io.github.bluetape4k/bluetape4k-dependencies
+bluetape4k-text = "0.1.2"  # https://mvnrepository.com/artifact/io.github.bluetape4k.text/text-search
 
 kotlin = "2.3.21"  # https://mvnrepository.com/artifact/org.jetbrains.kotlin/kotlin-bom
 kotlinx-coroutines = "1.11.0"  # https://mvnrepository.com/artifact/org.jetbrains.kotlinx/kotlinx-coroutines-bom
@@ -206,11 +207,11 @@ bluetape4k-leader-redis-lettuce = { module = "io.github.bluetape4k.leader:blueta
 bluetape4k-javers-core = { module = "io.github.bluetape4k.javers:javers-core" }
 bluetape4k-javers-persistence-redis = { module = "io.github.bluetape4k.javers:javers-persistence-redis" }
 bluetape4k-javers-persistence-kafka = { module = "io.github.bluetape4k.javers:javers-persistence-kafka" }
-bluetape4k-text-core = { module = "io.github.bluetape4k.text:tokenizer-core" }
-bluetape4k-text-korean = { module = "io.github.bluetape4k.text:tokenizer-korean" }
-bluetape4k-text-japanese = { module = "io.github.bluetape4k.text:tokenizer-japanese" }
-bluetape4k-text-lingua = { module = "io.github.bluetape4k.text:lingua" }
-bluetape4k-text-search = { module = "io.github.bluetape4k.text:text-search" }
+bluetape4k-text-core = { module = "io.github.bluetape4k.text:tokenizer-core", version.ref = "bluetape4k-text" }
+bluetape4k-text-korean = { module = "io.github.bluetape4k.text:tokenizer-korean", version.ref = "bluetape4k-text" }
+bluetape4k-text-japanese = { module = "io.github.bluetape4k.text:tokenizer-japanese", version.ref = "bluetape4k-text" }
+bluetape4k-text-lingua = { module = "io.github.bluetape4k.text:lingua", version.ref = "bluetape4k-text" }
+bluetape4k-text-search = { module = "io.github.bluetape4k.text:text-search", version.ref = "bluetape4k-text" }
 bluetape4k-micrometer = { module = "io.github.bluetape4k:bluetape4k-micrometer" }
 bluetape4k-redis = { module = "io.github.bluetape4k:bluetape4k-redis" }
 bluetape4k-redisson = { module = "io.github.bluetape4k:bluetape4k-redisson" }

--- a/kotlin/text-processing/README.md
+++ b/kotlin/text-processing/README.md
@@ -1,0 +1,122 @@
+# kotlin/text-processing
+
+Text processing workshop module using [bluetape4k-text](https://github.com/bluetape4k/bluetape4k-text) libraries.
+
+Demonstrates three practical text-processing scenarios:
+
+| Class | BT Module | Feature |
+|---|---|---|
+| `AbuseWordFilter` | `text-search` | Multi-keyword filtering via AhoCorasick automaton |
+| `LanguageDetectionService` | `lingua` | Language detection for Korean / English / Japanese |
+| `TextNormalizer` | (pure Kotlin) | Whitespace normalization and keyword extraction |
+
+---
+
+## Architecture
+
+```
+kotlin/text-processing/
+└── src/
+    ├── main/kotlin/io/bluetape4k/workshop/text/
+    │   ├── filter/          AbuseWordFilter
+    │   ├── detection/       LanguageDetectionService
+    │   └── normalize/       TextNormalizer
+    └── test/kotlin/         (mirrors main structure)
+```
+
+---
+
+## Core Features
+
+### AbuseWordFilter — AhoCorasick multi-keyword search
+
+Builds an immutable, thread-safe Aho-Corasick automaton at construction time. All subsequent
+`containsAbuse`, `filterText`, and `findMatches` calls run in **O(text length + matches)** time,
+regardless of how many registered keywords there are.
+
+```kotlin
+val filter = AbuseWordFilter(listOf("spam", "abuse", "badword"))
+
+filter.containsAbuse("There is some spam here")   // true
+filter.filterText("No spam allowed")              // "No **** allowed"
+filter.findMatches("spam and abuse")              // 2 AhoCorasickMatch objects
+```
+
+**Before / After — why AhoCorasick beats naive `String.contains` loops:**
+
+```kotlin
+// Naive approach — O(keywords × text) — scans the text once per keyword
+val words = listOf("spam", "abuse", "hate", /* ... 1000 more ... */)
+val found = words.any { text.contains(it, ignoreCase = true) }
+
+// AhoCorasick — O(text + matches) — one pass regardless of keyword count
+val filter = AbuseWordFilter(words)
+val found = filter.containsAbuse(text)
+```
+
+For 1 000 keywords on a 10 000-character message the naive approach makes up to
+10 000 000 character comparisons. The automaton makes exactly 10 000.
+
+### LanguageDetectionService — Lingua-backed language detection
+
+Wraps the [Lingua](https://github.com/pemistahl/lingua) language detector. The underlying
+language models are loaded once and reused across all calls.
+
+```kotlin
+val service = LanguageDetectionService()
+
+service.detectLanguage("Hello, World!")     // Language.ENGLISH
+service.detectLanguage("안녕하세요.")         // Language.KOREAN
+service.detectLanguage("東京は首都です。")    // Language.JAPANESE
+
+// Confidence values for all plausible languages
+val scores = service.computeConfidenceValues("This is English text.")
+// { ENGLISH -> 0.97, DUTCH -> 0.01, ... }
+```
+
+### TextNormalizer — lightweight text normalisation
+
+Stateless `object` for pre-processing text before indexing or search:
+
+```kotlin
+TextNormalizer.normalize("  Hello   WORLD  ")      // "hello world"
+TextNormalizer.extractKeywords("the quick brown fox")   // ["the", "quick", "brown", "fox"]
+TextNormalizer.extractKeywords("a b quick", minKeywordLength = 4) // ["quick"]
+```
+
+---
+
+## Configuration
+
+No external services required. All processing runs in-process.
+
+The `bluetape4k-text` libraries are independently versioned under `io.github.bluetape4k.text`:
+
+| Dependency | Version |
+|---|---|
+| `io.github.bluetape4k.text:text-search` | 0.1.2 |
+| `io.github.bluetape4k.text:lingua` | 0.1.2 |
+
+---
+
+## Dependency Instructions
+
+Add to `build.gradle.kts`:
+
+```kotlin
+dependencies {
+    implementation(libs.bluetape4k.text.search)
+    implementation(libs.bluetape4k.text.lingua)
+}
+```
+
+Ensure the version catalog entry exists:
+
+```toml
+[versions]
+bluetape4k-text = "0.1.2"
+
+[libraries]
+bluetape4k-text-search = { module = "io.github.bluetape4k.text:text-search", version.ref = "bluetape4k-text" }
+bluetape4k-text-lingua = { module = "io.github.bluetape4k.text:lingua", version.ref = "bluetape4k-text" }
+```

--- a/kotlin/text-processing/build.gradle.kts
+++ b/kotlin/text-processing/build.gradle.kts
@@ -1,0 +1,23 @@
+plugins {
+    alias(libs.plugins.kotlin.jvm)
+}
+
+configurations {
+    testImplementation.get().extendsFrom(compileOnly.get(), runtimeOnly.get())
+}
+
+dependencies {
+    // bluetape4k-text — AhoCorasick pattern search
+    implementation(libs.bluetape4k.text.search)
+    // bluetape4k-text — Lingua language detection
+    implementation(libs.bluetape4k.text.lingua)
+    // bluetape4k-text — Korean tokenizer / blockword processing
+    implementation(libs.bluetape4k.text.korean)
+
+    implementation(libs.bluetape4k.logging)
+
+    testImplementation(libs.bluetape4k.junit5)
+    testImplementation(libs.bluetape4k.assertions)
+    testImplementation(libs.mockk)
+    testRuntimeOnly(libs.logback.lib)
+}

--- a/kotlin/text-processing/src/main/kotlin/io/bluetape4k/workshop/text/detection/LanguageDetectionService.kt
+++ b/kotlin/text-processing/src/main/kotlin/io/bluetape4k/workshop/text/detection/LanguageDetectionService.kt
@@ -1,0 +1,70 @@
+package io.bluetape4k.workshop.text.detection
+
+import com.github.pemistahl.lingua.api.Language
+import com.github.pemistahl.lingua.api.LanguageDetector
+import io.bluetape4k.lingua.allLanguageDetector
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+
+/**
+ * Language detection service backed by the Lingua library.
+ *
+ * Wraps a shared [LanguageDetector] instance that is built once and reused across calls,
+ * because model construction is expensive.
+ *
+ * ## Behavior / Contract
+ * - [detectLanguage] returns `null` when the input is blank or the detector is uncertain
+ *   (i.e., the best guess is [Language.UNKNOWN]).
+ * - [computeConfidenceValues] returns a map sorted by confidence descending; empty on blank input.
+ * - Reuse one [LanguageDetectionService] instance across all calls in an application to avoid
+ *   re-loading language models on every detection.
+ *
+ * ```kotlin
+ * val service = LanguageDetectionService()
+ * service.detectLanguage("Hello, World!")        // Language.ENGLISH
+ * service.detectLanguage("안녕하세요.")           // Language.KOREAN
+ * ```
+ */
+class LanguageDetectionService {
+
+    companion object : KLogging()
+
+    private val detector: LanguageDetector = allLanguageDetector {
+        withMinimumRelativeDistance(0.0)
+        withLowAccuracyMode()
+    }
+
+    /**
+     * Detects the most likely language for the given [text].
+     *
+     * Returns `null` when [text] is blank or when the detector cannot determine the language
+     * (i.e., the result is [Language.UNKNOWN]).
+     *
+     * @param text input text to classify
+     * @return detected [Language], or `null` if undetermined
+     */
+    fun detectLanguage(text: String): Language? {
+        if (text.isBlank()) return null
+        val detected = detector.detectLanguageOf(text)
+        log.debug { "detectLanguage text='${text.take(40)}' -> $detected" }
+        return if (detected == Language.UNKNOWN) null else detected
+    }
+
+    /**
+     * Returns a map of [Language] to confidence values for all languages that the detector
+     * considers plausible for [text], sorted by confidence descending.
+     *
+     * The map is empty when [text] is blank.
+     *
+     * @param text input text to classify
+     * @return language-to-confidence map sorted by confidence descending
+     */
+    fun computeConfidenceValues(text: String): Map<Language, Double> {
+        if (text.isBlank()) return emptyMap()
+        val values = detector.computeLanguageConfidenceValues(text)
+        log.debug { "computeConfidenceValues text='${text.take(40)}' -> top=${values.entries.firstOrNull()}" }
+        return values.entries
+            .sortedByDescending { it.value }
+            .associate { it.key to it.value }
+    }
+}

--- a/kotlin/text-processing/src/main/kotlin/io/bluetape4k/workshop/text/filter/AbuseWordFilter.kt
+++ b/kotlin/text-processing/src/main/kotlin/io/bluetape4k/workshop/text/filter/AbuseWordFilter.kt
@@ -1,0 +1,86 @@
+package io.bluetape4k.workshop.text.filter
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import io.bluetape4k.text.search.AhoCorasickAutomaton
+import io.bluetape4k.text.search.AhoCorasickMatch
+import io.bluetape4k.text.search.NormalizationForm
+import io.bluetape4k.text.search.SearchOptions
+import io.bluetape4k.text.search.ahoCorasick
+
+/**
+ * Thread-safe abuse-word filter backed by an AhoCorasick automaton.
+ *
+ * All registered words are matched case-insensitively and under NFC normalization
+ * so that variations of the same Unicode sequence are unified before comparison.
+ * Overlapping matches are allowed to surface all violations in a single pass.
+ *
+ * ## Behavior / Contract
+ * - Construction is O(total keyword length); each subsequent call to [containsAbuse],
+ *   [filterText], or [findMatches] is O(text length + number of matches).
+ * - [filterText] replaces each matched span with a string of `*` characters equal in
+ *   length to the match span, preserving non-abusive text unchanged.
+ * - Returns an empty list / unchanged text when [abuseWords] is empty.
+ *
+ * ```kotlin
+ * val filter = AbuseWordFilter(listOf("badword", "spam"))
+ * filter.containsAbuse("This contains badword!")  // true
+ * filter.filterText("No spam allowed")            // "No **** allowed"
+ * ```
+ *
+ * @param abuseWords collection of words to flag as abusive
+ */
+class AbuseWordFilter(abuseWords: Collection<String>) {
+
+    companion object : KLogging()
+
+    private val automaton: AhoCorasickAutomaton<String> = ahoCorasick {
+        ignoreCase = true
+        allowOverlaps = true
+        normalization = NormalizationForm.NFC
+        abuseWords.filter { it.isNotBlank() }.forEach { word -> keyword(word, word) }
+    }
+
+    /**
+     * Returns `true` if [text] contains at least one registered abuse word.
+     *
+     * Uses the automaton's built-in early-exit path for efficiency.
+     *
+     * @param text input text to inspect
+     */
+    fun containsAbuse(text: String): Boolean {
+        val result = automaton.containsMatch(text)
+        log.debug { "containsAbuse text='${text.take(40)}' result=$result" }
+        return result
+    }
+
+    /**
+     * Replaces every matched abuse word in [text] with `*` characters and returns the result.
+     *
+     * Each matched span is replaced by a string of `*` of equal byte length, so the
+     * returned string has the same length as [text].
+     *
+     * @param text input text to filter
+     * @return text with all abuse-word occurrences masked
+     */
+    fun filterText(text: String): String {
+        val filtered = automaton.replaceAll(text) { match ->
+            "*".repeat(match.length)
+        }
+        log.debug { "filterText text='${text.take(40)}' -> '${filtered.take(40)}'" }
+        return filtered
+    }
+
+    /**
+     * Returns all [AhoCorasickMatch] objects found in [text].
+     *
+     * Results are ordered by start position ascending. Overlapping matches are all included.
+     *
+     * @param text input text to search
+     */
+    fun findMatches(text: String): List<AhoCorasickMatch<String>> {
+        val matches = automaton.parseText(text)
+        log.debug { "findMatches text='${text.take(40)}' found=${matches.size} matches" }
+        return matches
+    }
+}

--- a/kotlin/text-processing/src/main/kotlin/io/bluetape4k/workshop/text/normalize/TextNormalizer.kt
+++ b/kotlin/text-processing/src/main/kotlin/io/bluetape4k/workshop/text/normalize/TextNormalizer.kt
@@ -1,0 +1,60 @@
+package io.bluetape4k.workshop.text.normalize
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+
+/**
+ * Lightweight, stateless text normalizer for pre-processing text before indexing or search.
+ *
+ * All operations return a new string and never mutate the input. This object is safe to call
+ * from multiple threads concurrently.
+ *
+ * ## Behavior / Contract
+ * - [normalize] lower-cases the text and collapses runs of whitespace to a single space,
+ *   then trims leading and trailing whitespace.
+ * - [extractKeywords] tokenizes on whitespace after normalization and removes tokens shorter
+ *   than [minKeywordLength], returning a deduplicated list in encounter order.
+ * - Blank input always returns an empty string / empty list.
+ *
+ * ```kotlin
+ * TextNormalizer.normalize("  Hello   World  ")  // "hello world"
+ * TextNormalizer.extractKeywords("the quick brown fox") // ["quick", "brown"]
+ * ```
+ */
+object TextNormalizer : KLogging() {
+
+    private val whitespaceRegex = Regex("\\s+")
+
+    /**
+     * Normalizes [text] by lower-casing and collapsing consecutive whitespace.
+     *
+     * @param text input string to normalize
+     * @return normalized string, or an empty string when [text] is blank
+     */
+    fun normalize(text: String): String {
+        if (text.isBlank()) return ""
+        val normalized = whitespaceRegex.replace(text.lowercase().trim(), " ")
+        log.debug { "normalize: '${text.take(40)}' -> '${normalized.take(40)}'" }
+        return normalized
+    }
+
+    /**
+     * Extracts deduplicated keywords from [text] after normalization.
+     *
+     * Tokens shorter than [minKeywordLength] are discarded. The returned list preserves
+     * first-encounter order and contains no duplicates.
+     *
+     * @param text input string to tokenize
+     * @param minKeywordLength minimum token length to include (default: 2)
+     * @return ordered, deduplicated list of keywords
+     */
+    fun extractKeywords(text: String, minKeywordLength: Int = 2): List<String> {
+        if (text.isBlank()) return emptyList()
+        val keywords = normalize(text)
+            .split(" ")
+            .filter { it.length >= minKeywordLength }
+            .distinct()
+        log.debug { "extractKeywords: '${text.take(40)}' -> $keywords" }
+        return keywords
+    }
+}

--- a/kotlin/text-processing/src/test/kotlin/io/bluetape4k/workshop/text/detection/LanguageDetectionServiceTest.kt
+++ b/kotlin/text-processing/src/test/kotlin/io/bluetape4k/workshop/text/detection/LanguageDetectionServiceTest.kt
@@ -1,0 +1,64 @@
+package io.bluetape4k.workshop.text.detection
+
+import com.github.pemistahl.lingua.api.Language
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldNotBeEmpty
+import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.logging.KLogging
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class LanguageDetectionServiceTest {
+
+    companion object : KLogging()
+
+    // Shared detector — expensive to build; reuse across all tests in this class.
+    private val service = LanguageDetectionService()
+
+    @Test
+    fun `detects English text`() {
+        val lang = service.detectLanguage("The quick brown fox jumps over the lazy dog.")
+        lang shouldBeEqualTo Language.ENGLISH
+    }
+
+    @Test
+    fun `detects Korean text`() {
+        val lang = service.detectLanguage("안녕하세요. 오늘 날씨가 참 좋네요.")
+        lang shouldBeEqualTo Language.KOREAN
+    }
+
+    @Test
+    fun `detects Japanese text`() {
+        val lang = service.detectLanguage("東京は日本の首都です。")
+        lang shouldBeEqualTo Language.JAPANESE
+    }
+
+    @Test
+    fun `returns null for blank input`() {
+        service.detectLanguage("").shouldBeNull()
+        service.detectLanguage("   ").shouldBeNull()
+    }
+
+    @Test
+    fun `computeConfidenceValues returns non-empty map for real text`() {
+        val values = service.computeConfidenceValues("Hello world, this is a test sentence.")
+        values.shouldNotBeEmpty()
+    }
+
+    @Test
+    fun `computeConfidenceValues returns empty map for blank input`() {
+        val values = service.computeConfidenceValues("")
+        values.shouldNotBeNull()
+        values.isEmpty() shouldBeEqualTo true
+    }
+
+    @Test
+    fun `top confidence language matches detectLanguage for English`() {
+        val text = "This is a well-formed English sentence with enough words for detection."
+        val detected = service.detectLanguage(text)
+        val topConfidence = service.computeConfidenceValues(text).keys.firstOrNull()
+        detected shouldBeEqualTo topConfidence
+    }
+}

--- a/kotlin/text-processing/src/test/kotlin/io/bluetape4k/workshop/text/filter/AbuseWordFilterTest.kt
+++ b/kotlin/text-processing/src/test/kotlin/io/bluetape4k/workshop/text/filter/AbuseWordFilterTest.kt
@@ -1,0 +1,74 @@
+package io.bluetape4k.workshop.text.filter
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldHaveSize
+import io.bluetape4k.assertions.shouldNotBeEmpty
+import io.bluetape4k.logging.KLogging
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class AbuseWordFilterTest {
+
+    companion object : KLogging()
+
+    private val filter = AbuseWordFilter(
+        listOf("badword", "spam", "abuse", "hate")
+    )
+
+    @Test
+    fun `containsAbuse returns true when text contains a registered abuse word`() {
+        filter.containsAbuse("This message contains badword!").shouldBeTrue()
+    }
+
+    @Test
+    fun `containsAbuse returns false when text has no abuse word`() {
+        filter.containsAbuse("This is a perfectly clean message.").shouldBeFalse()
+    }
+
+    @Test
+    fun `containsAbuse is case-insensitive`() {
+        filter.containsAbuse("BADWORD in uppercase").shouldBeTrue()
+        filter.containsAbuse("Spam mixed case").shouldBeTrue()
+    }
+
+    @Test
+    fun `filterText replaces abuse words with asterisks`() {
+        val result = filter.filterText("No spam allowed here")
+        result shouldBeEqualTo "No **** allowed here"
+    }
+
+    @Test
+    fun `filterText leaves clean text unchanged`() {
+        val input = "This is a normal sentence."
+        filter.filterText(input) shouldBeEqualTo input
+    }
+
+    @Test
+    fun `filterText handles multiple abuse words in one sentence`() {
+        val result = filter.filterText("badword and spam together")
+        result shouldBeEqualTo "******* and **** together"
+    }
+
+    @Test
+    fun `findMatches returns all matched positions`() {
+        val matches = filter.findMatches("spam and abuse are badword")
+        matches.shouldNotBeEmpty()
+        matches shouldHaveSize 3
+    }
+
+    @Test
+    fun `findMatches returns empty list for clean text`() {
+        val matches = filter.findMatches("everything is fine here")
+        matches shouldHaveSize 0
+    }
+
+    @Test
+    fun `filter with empty word list never matches`() {
+        val emptyFilter = AbuseWordFilter(emptyList())
+        emptyFilter.containsAbuse("any text including badword").shouldBeFalse()
+        emptyFilter.findMatches("spam") shouldHaveSize 0
+    }
+}

--- a/kotlin/text-processing/src/test/kotlin/io/bluetape4k/workshop/text/normalize/TextNormalizerTest.kt
+++ b/kotlin/text-processing/src/test/kotlin/io/bluetape4k/workshop/text/normalize/TextNormalizerTest.kt
@@ -1,0 +1,81 @@
+package io.bluetape4k.workshop.text.normalize
+
+import io.bluetape4k.assertions.shouldBeEmpty
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldContain
+import io.bluetape4k.assertions.shouldHaveSize
+import io.bluetape4k.assertions.shouldNotContain
+import io.bluetape4k.logging.KLogging
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class TextNormalizerTest {
+
+    companion object : KLogging()
+
+    @Test
+    fun `normalize lower-cases the input`() {
+        TextNormalizer.normalize("Hello WORLD") shouldBeEqualTo "hello world"
+    }
+
+    @Test
+    fun `normalize collapses multiple spaces to single space`() {
+        TextNormalizer.normalize("too   many    spaces") shouldBeEqualTo "too many spaces"
+    }
+
+    @Test
+    fun `normalize trims leading and trailing whitespace`() {
+        TextNormalizer.normalize("  padded  ") shouldBeEqualTo "padded"
+    }
+
+    @Test
+    fun `normalize returns empty string for blank input`() {
+        TextNormalizer.normalize("") shouldBeEqualTo ""
+        TextNormalizer.normalize("   ") shouldBeEqualTo ""
+    }
+
+    @Test
+    fun `normalize handles mixed whitespace characters`() {
+        TextNormalizer.normalize("tab\there\nnewline") shouldBeEqualTo "tab here newline"
+    }
+
+    @Test
+    fun `extractKeywords returns tokens meeting minimum length`() {
+        val keywords = TextNormalizer.extractKeywords("the quick brown fox")
+        keywords shouldContain "quick"
+        keywords shouldContain "brown"
+        keywords shouldContain "the"
+    }
+
+    @Test
+    fun `extractKeywords filters tokens shorter than minKeywordLength`() {
+        val keywords = TextNormalizer.extractKeywords("a quick brown fox", minKeywordLength = 4)
+        keywords shouldNotContain "a"
+        keywords shouldContain "quick"
+        keywords shouldContain "brown"
+    }
+
+    @Test
+    fun `extractKeywords deduplicates repeated tokens`() {
+        val keywords = TextNormalizer.extractKeywords("spam spam spam everyone")
+        keywords shouldHaveSize 2
+        keywords shouldContain "spam"
+        keywords shouldContain "everyone"
+    }
+
+    @Test
+    fun `extractKeywords returns empty list for blank input`() {
+        TextNormalizer.extractKeywords("").shouldBeEmpty()
+        TextNormalizer.extractKeywords("   ").shouldBeEmpty()
+    }
+
+    @Test
+    fun `extractKeywords normalizes before tokenizing`() {
+        val keywords = TextNormalizer.extractKeywords("  HELLO   WORLD  hello ")
+        // "hello" and "world" after normalization; deduplication removes second "hello"
+        keywords shouldHaveSize 2
+        keywords shouldContain "hello"
+        keywords shouldContain "world"
+    }
+}

--- a/kotlin/text-processing/src/test/resources/junit-platform.properties
+++ b/kotlin/text-processing/src/test/resources/junit-platform.properties
@@ -1,0 +1,6 @@
+junit.jupiter.extensions.autodetection.enabled=true
+junit.jupiter.testinstance.lifecycle.default=per_class
+
+junit.jupiter.execution.parallel.enabled=false
+junit.jupiter.execution.parallel.mode.default=same_thread
+junit.jupiter.execution.parallel.mode.classes.default=concurrent

--- a/kotlin/text-processing/src/test/resources/logback-test.xml
+++ b/kotlin/text-processing/src/test/resources/logback-test.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
+
+        <immediateFlush>true</immediateFlush>
+        <encoder>
+            <!-- @formatter:off -->
+            <pattern>%d{HH:mm:ss.SSS} %highlight(%-5level) [%blue(%24.24t)] %yellow(%logger{36}):%line: %msg%n%throwable</pattern>
+            <!-- @formatter:on -->
+            <charset>UTF-8</charset>
+        </encoder>
+    </appender>
+
+    <logger name="io.bluetape4k.workshop" level="DEBUG"/>
+    <logger name="io.bluetape4k" level="DEBUG"/>
+
+    <root level="INFO">
+        <appender-ref ref="Console"/>
+    </root>
+
+</configuration>


### PR DESCRIPTION
## Summary

Adds a new workshop module `kotlin/text-processing` that demonstrates practical text-processing scenarios using the independently versioned `bluetape4k-text` libraries.

## Features

| Class | BT Module | Description |
|---|---|---|
| `AbuseWordFilter` | `text-search:0.1.2` | Thread-safe multi-keyword filter backed by AhoCorasick automaton |
| `LanguageDetectionService` | `lingua:0.1.2` | Language detection for Korean / English / Japanese via Lingua |
| `TextNormalizer` | (pure Kotlin) | Whitespace normalization and simple keyword extraction |

## Key Design Points

- **AbuseWordFilter**: builds an immutable `AhoCorasickAutomaton<String>` at construction time using the `ahoCorasick { }` DSL with `ignoreCase = true` and `NormalizationForm.NFC`. All subsequent `containsAbuse` / `filterText` / `findMatches` calls run O(text + matches) regardless of keyword count — vs. O(keywords × text) for a naive `String.contains` loop.
- **LanguageDetectionService**: wraps a single `LanguageDetector` instance that loads language models once and is reused across all calls, as Lingua model construction is expensive.
- **TextNormalizer**: stateless `object` (no shared state) that lower-cases, collapses whitespace, and extracts deduplicated keywords.

## Dependency Change

`gradle/libs.versions.toml` — added `bluetape4k-text = "0.1.2"` version key and wired `version.ref` on the existing (version-less) `bluetape4k-text-search`, `bluetape4k-text-lingua`, `bluetape4k-text-core`, `bluetape4k-text-korean`, and `bluetape4k-text-japanese` aliases.

## Test Results

```
./gradlew :kotlin-text-processing:test
```



## Verification

```bash
./gradlew :kotlin-text-processing:test
```

Closes #105