### PR TITLE
feat: add exposed/javers-audit workshop for change history tracking (#100)

### DIFF
--- a/docs/lessons/2026-05-24-issue-100-javers-audit.md
+++ b/docs/lessons/2026-05-24-issue-100-javers-audit.md
@@ -1,0 +1,66 @@
+# 2026-05-24 Issue #100 — exposed/javers-audit 구현 교훈
+
+## 개요
+
+JaVers를 활용한 엔티티 변경 이력 추적 워크샵 모듈 (`exposed/javers-audit`) 구현.
+
+## 주요 결정
+
+### API 탐색 먼저
+
+작업 지시서에 API 추측이 포함되어 있었음. 실제 소스를 먼저 읽어서 확인:
+
+- `JaversExtensions.kt` → `latestSnapshotOrNull<T>(id)` 확인
+- `DiffExtensions.kt` → `diff.changesByType<ValueChange>()` — reified inline 확장
+- `CdoSnapshot.type` (not `.snapshotType`) — `SnapshotType` enum
+- `SnapshotType` import: `org.javers.core.metamodel.\`object\`.SnapshotType`
+
+### 의존성 alias 확인
+
+Workshop `libs.versions.toml`에 javers 항목 없음 → `chore/catalog-javers-text` 브랜치에 이미 추가됨. `issue-100-javers-audit` 워크트리가 동일한 카탈로그를 사용하므로 `libs.bluetape4k.javers.core` 사용 가능.
+
+JaVers direct dependency (`org.javers:javers-core`)는 `bluetape4k-javers-core`의 transitive로 제공됨 — 별도 alias 불필요.
+
+### 테스트 assertion 패키지
+
+`org.amshove.kluent` 가 아닌 `io.bluetape4k.assertions` 사용:
+
+```kotlin
+// 잘못된 것 (kluent — bluetape4k-assertions에 없음)
+import org.amshove.kluent.shouldBeEqualTo
+
+// 올바른 것
+import io.bluetape4k.assertions.shouldBeEqualTo
+```
+
+`shouldBeEqualTo`, `shouldHaveSize`는 infix, `shouldBeTrue()` / `shouldBeFalse()` / `shouldBeNull()` / `shouldNotBeNull()`은 일반 함수.
+
+`shouldNotBeNull()`은 kotlin contract로 smart-cast를 지원하므로 이후 `!!` 없이 사용 가능.
+
+### 로깅 람다 import
+
+`KLogging`의 `log`는 `org.slf4j.Logger`. 람다 형식 `log.debug { }` 사용 시 명시적 import 필요:
+
+```kotlin
+import io.bluetape4k.logging.debug
+```
+
+없으면 Kotlin 컴파일러가 SLF4J의 `debug(String)` 오버로드로 해석해서 타입 오류 발생.
+
+### Exposed v1 import 경로
+
+```kotlin
+import org.jetbrains.exposed.v1.core.eq          // eq 연산자
+import org.jetbrains.exposed.v1.jdbc.deleteWhere  // deleteWhere
+import org.jetbrains.exposed.v1.jdbc.upsert       // upsert
+import org.jetbrains.exposed.v1.jdbc.SchemaUtils  // SchemaUtils
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+```
+
+`SqlExpressionBuilder.eq` 는 deprecated — 최상위 `eq` import 사용.
+
+## 완료 조건 달성
+
+- 8개 테스트 모두 통과 (failures=0, errors=0)
+- detekt: 0 issues
+- Spring/Testcontainers 없이 순수 JaVers + Exposed + H2 인메모리

--- a/exposed/javers-audit/README.md
+++ b/exposed/javers-audit/README.md
@@ -1,0 +1,104 @@
+# exposed/javers-audit
+
+JaVers entity change-history auditing integrated with JetBrains Exposed JDBC and an H2 in-memory database.
+
+## Architecture
+
+```mermaid
+graph TD
+    Client["Client Code"] --> Service["ProductAuditService"]
+
+    Service -->|commit / compare| Javers["JaVers\n(in-memory repository)"]
+    Service -->|upsert / delete| Exposed["Exposed JDBC\n(H2 in-memory)"]
+
+    Javers -->|findSnapshots| Snapshots["CdoSnapshot list"]
+    Javers -->|getLatestSnapshot| Latest["CdoSnapshot (latest)"]
+    Javers -->|compare| Diff["Diff (ValueChange list)"]
+
+    Exposed --> DB["H2 ProductTable"]
+```
+
+## Core Features
+
+| Feature | Description |
+|---|---|
+| Change tracking | Every `save` / `delete` call creates a JaVers commit; the full snapshot history is queryable by entity id |
+| Diff computation | `diff(old, new)` returns a structured `Diff` with typed `ValueChange` entries — no manual audit table required |
+| In-memory store | Uses JaVers built-in in-memory repository — no external infrastructure needed for tests or demos |
+| Exposed persistence | Side-by-side upsert/delete into an Exposed `ProductTable` shows how audit history coexists with normal JDBC storage |
+
+## Before / After — Manual Audit Table vs JaVers
+
+**Before (manual audit log table)**
+
+```sql
+CREATE TABLE product_audit_log (
+    id         BIGINT AUTO_INCREMENT PRIMARY KEY,
+    product_id BIGINT       NOT NULL,
+    changed_at TIMESTAMP    NOT NULL,
+    author     VARCHAR(100) NOT NULL,
+    old_price  DECIMAL(19,4),
+    new_price  DECIMAL(19,4),
+    old_cat    VARCHAR(100),
+    new_cat    VARCHAR(100)
+);
+```
+
+Every time a column changes you add an INSERT to the audit table. You also need to compare old/new values manually and keep the schema in sync with the entity.
+
+**After (JaVers)**
+
+```kotlin
+val javers = JaversBuilder.javers().build()
+javers.commit("alice", product)           // snapshot stored automatically
+val history = javers.findSnapshots(
+    QueryBuilder.byInstanceId(productId, Product::class.java).build()
+)
+val diff = javers.compare(oldProduct, newProduct)
+val priceChanges = diff.changesByType<ValueChange>()
+    .filter { it.propertyName == "price" }
+```
+
+JaVers tracks all properties automatically, generates a queryable snapshot tree, and provides typed diff access — with no additional schema maintenance.
+
+## Usage
+
+```kotlin
+// Build JaVers with in-memory repository
+val javers = JaversBuilder.javers().build()
+val service = ProductAuditService(javers)
+
+// Create and persist a product
+val product = Product(id = 1L, name = "Widget", price = BigDecimal("9.99"), category = "Tools")
+service.save("alice", product)
+
+// Update price and persist
+val updated = product.copy(price = BigDecimal("12.99"))
+service.save("alice", updated)
+
+// Query full history
+val history = service.getHistory(1L)          // 2 snapshots: INITIAL + UPDATE
+
+// Compute diff between two versions
+val diff = service.diff(product, updated)
+val changes = diff.changesByType<ValueChange>()  // [ValueChange: price 9.99 → 12.99]
+
+// Latest snapshot
+val latest = service.getLatestSnapshot(1L)
+
+// Soft-delete with terminal snapshot
+service.delete("alice", updated)
+```
+
+## Configuration
+
+No external configuration is required. Pass any `Javers` instance to `ProductAuditService`. For production use, replace the in-memory repository with a JDBC or Redis-backed one from the `bluetape4k-javers` library.
+
+## Dependencies
+
+```kotlin
+implementation("io.github.bluetape4k.javers:javers-core")  // bluetape4k JaVers integration
+implementation("org.jetbrains.exposed:exposed-core")
+implementation("org.jetbrains.exposed:exposed-jdbc")
+runtimeOnly("com.h2database:h2")
+```

--- a/exposed/javers-audit/build.gradle.kts
+++ b/exposed/javers-audit/build.gradle.kts
@@ -1,0 +1,18 @@
+plugins {
+    alias(libs.plugins.kotlin.jvm)
+}
+
+dependencies {
+    // bluetape4k JaVers integration
+    implementation(libs.bluetape4k.javers.core)
+
+    // JetBrains Exposed
+    implementation(libs.exposed.core)
+    implementation(libs.exposed.jdbc)
+
+    // H2 in-memory database
+    runtimeOnly(libs.h2.v2)
+
+    // Test
+    testImplementation(libs.bluetape4k.assertions)
+}

--- a/exposed/javers-audit/src/main/kotlin/io/bluetape4k/workshop/exposed/javers/model/Product.kt
+++ b/exposed/javers-audit/src/main/kotlin/io/bluetape4k/workshop/exposed/javers/model/Product.kt
@@ -1,0 +1,31 @@
+package io.bluetape4k.workshop.exposed.javers.model
+
+import org.javers.core.metamodel.annotation.Id
+import org.javers.core.metamodel.annotation.TypeName
+import java.io.Serializable
+import java.math.BigDecimal
+
+/**
+ * A product entity tracked by JaVers for change-history auditing.
+ *
+ * ## Behavior / Contract
+ * - [id] is the JaVers entity key; snapshots are keyed by this value.
+ * - [price] must be non-negative.
+ * - All instances are immutable value objects; use [copy] for updates.
+ *
+ * ```kotlin
+ * val product = Product(id = 1L, name = "Widget", price = BigDecimal("9.99"), category = "Tools")
+ * val updated = product.copy(price = BigDecimal("12.99"))
+ * ```
+ */
+@TypeName("Product")
+data class Product(
+    @Id val id: Long,
+    val name: String,
+    val price: BigDecimal,
+    val category: String,
+): Serializable {
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}

--- a/exposed/javers-audit/src/main/kotlin/io/bluetape4k/workshop/exposed/javers/model/ProductTable.kt
+++ b/exposed/javers-audit/src/main/kotlin/io/bluetape4k/workshop/exposed/javers/model/ProductTable.kt
@@ -1,0 +1,32 @@
+package io.bluetape4k.workshop.exposed.javers.model
+
+import org.jetbrains.exposed.v1.core.Table
+
+/**
+ * Exposed table definition for [Product] persistence.
+ *
+ * ## Behavior / Contract
+ * - Uses H2-compatible column types.
+ * - [id] is the primary key; uniqueness is enforced at the DB level.
+ * - [price] stored as DECIMAL(19,4) to avoid floating-point rounding.
+ *
+ * ```kotlin
+ * transaction {
+ *     SchemaUtils.create(ProductTable)
+ *     ProductTable.insert { row ->
+ *         row[id] = 1L
+ *         row[name] = "Widget"
+ *         row[price] = BigDecimal("9.99")
+ *         row[category] = "Tools"
+ *     }
+ * }
+ * ```
+ */
+object ProductTable: Table("products") {
+    val id = long("id")
+    val name = varchar("name", 255)
+    val price = decimal("price", precision = 19, scale = 4)
+    val category = varchar("category", 100)
+
+    override val primaryKey = PrimaryKey(id)
+}

--- a/exposed/javers-audit/src/main/kotlin/io/bluetape4k/workshop/exposed/javers/service/ProductAuditService.kt
+++ b/exposed/javers-audit/src/main/kotlin/io/bluetape4k/workshop/exposed/javers/service/ProductAuditService.kt
@@ -1,0 +1,99 @@
+package io.bluetape4k.workshop.exposed.javers.service
+
+import io.bluetape4k.javers.latestSnapshotOrNull
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import io.bluetape4k.workshop.exposed.javers.model.Product
+import io.bluetape4k.workshop.exposed.javers.model.ProductTable
+import org.javers.core.Javers
+import org.javers.core.diff.Diff
+import org.javers.core.metamodel.`object`.CdoSnapshot
+import org.javers.repository.jql.QueryBuilder
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.deleteWhere
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.jetbrains.exposed.v1.jdbc.upsert
+
+/**
+ * Service that combines JaVers change-history auditing with Exposed JDBC persistence.
+ *
+ * ## Behavior / Contract
+ * - [save] commits the product to JaVers (in-memory repository) and upserts it into the Exposed table.
+ * - [getHistory] returns all JaVers snapshots for the given product id, oldest-first.
+ * - [getLatestSnapshot] returns the most recent JaVers snapshot, or null if never saved.
+ * - [diff] computes a JaVers [Diff] between two product instances without persisting either.
+ * - [delete] removes the row from Exposed and records a terminal snapshot in JaVers.
+ *
+ * ```kotlin
+ * val service = ProductAuditService(JaversBuilder.javers().build())
+ * val product = Product(1L, "Widget", BigDecimal("9.99"), "Tools")
+ * service.save("user1", product)
+ * val history = service.getHistory(1L)
+ * ```
+ *
+ * @property javers JaVers instance backed by an in-memory repository.
+ */
+class ProductAuditService(
+    private val javers: Javers,
+) {
+    companion object: KLogging()
+
+    /**
+     * Commits [product] to JaVers and upserts the row in [ProductTable].
+     *
+     * @param author Identifies the change author recorded in the JaVers commit metadata.
+     * @param product The product to persist and audit.
+     */
+    fun save(author: String, product: Product) {
+        require(author.isNotBlank()) { "author must not be blank" }
+        javers.commit(author, product)
+        transaction {
+            ProductTable.upsert {
+                it[id] = product.id
+                it[name] = product.name
+                it[price] = product.price
+                it[category] = product.category
+            }
+        }
+        log.debug { "Saved and audited product id=${product.id} by $author" }
+    }
+
+    /**
+     * Returns all JaVers snapshots for the given [productId], oldest-first.
+     */
+    fun getHistory(productId: Long): List<CdoSnapshot> {
+        val query = QueryBuilder.byInstanceId(productId, Product::class.java)
+            .build()
+        return javers.findSnapshots(query)
+            .sortedBy { it.commitMetadata.commitDate }
+    }
+
+    /**
+     * Returns the latest JaVers snapshot for [productId], or null if no commits exist.
+     */
+    fun getLatestSnapshot(productId: Long): CdoSnapshot? =
+        javers.latestSnapshotOrNull<Product>(productId)
+
+    /**
+     * Computes and returns a JaVers [Diff] between [oldProduct] and [newProduct].
+     *
+     * Neither object is persisted.
+     */
+    fun diff(oldProduct: Product, newProduct: Product): Diff =
+        javers.compare(oldProduct, newProduct)
+
+    /**
+     * Deletes the [product] row from Exposed and records a terminal JaVers commit.
+     *
+     * @param author Identifies the change author.
+     * @param product The product to delete.
+     */
+    fun delete(author: String, product: Product) {
+        require(author.isNotBlank()) { "author must not be blank" }
+        javers.commitShallowDelete(author, product)
+        transaction {
+            ProductTable.deleteWhere { ProductTable.id eq product.id }
+        }
+        log.debug { "Deleted and audited product id=${product.id} by $author" }
+    }
+}

--- a/exposed/javers-audit/src/test/kotlin/io/bluetape4k/workshop/exposed/javers/ProductAuditServiceTest.kt
+++ b/exposed/javers-audit/src/test/kotlin/io/bluetape4k/workshop/exposed/javers/ProductAuditServiceTest.kt
@@ -1,0 +1,146 @@
+package io.bluetape4k.workshop.exposed.javers
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldHaveSize
+import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.javers.diff.changesByType
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.workshop.exposed.javers.model.Product
+import io.bluetape4k.workshop.exposed.javers.model.ProductTable
+import io.bluetape4k.workshop.exposed.javers.service.ProductAuditService
+import org.javers.core.JaversBuilder
+import org.javers.core.diff.changetype.ValueChange
+import org.javers.core.metamodel.`object`.SnapshotType
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.SchemaUtils
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.math.BigDecimal
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ProductAuditServiceTest {
+
+    companion object: KLogging()
+
+    private val javers = JaversBuilder.javers().build()
+    private lateinit var service: ProductAuditService
+
+    @BeforeEach
+    fun setUp() {
+        Database.connect("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1", driver = "org.h2.Driver")
+        transaction {
+            SchemaUtils.create(ProductTable)
+        }
+        service = ProductAuditService(javers)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        transaction {
+            SchemaUtils.drop(ProductTable)
+        }
+    }
+
+    @Test
+    fun `save product creates a single initial snapshot`() {
+        val product = Product(id = 1L, name = "Widget", price = BigDecimal("9.99"), category = "Tools")
+
+        service.save("alice", product)
+
+        val history = service.getHistory(1L)
+        history shouldHaveSize 1
+        history.first().type shouldBeEqualTo SnapshotType.INITIAL
+    }
+
+    @Test
+    fun `save product twice creates two snapshots with second as UPDATE`() {
+        val original = Product(id = 2L, name = "Gadget", price = BigDecimal("19.99"), category = "Electronics")
+        val updated = original.copy(price = BigDecimal("24.99"))
+
+        service.save("bob", original)
+        service.save("bob", updated)
+
+        val history = service.getHistory(2L)
+        history shouldHaveSize 2
+        history[0].type shouldBeEqualTo SnapshotType.INITIAL
+        history[1].type shouldBeEqualTo SnapshotType.UPDATE
+    }
+
+    @Test
+    fun `diff detects price change between two versions`() {
+        val original = Product(id = 3L, name = "Sprocket", price = BigDecimal("5.00"), category = "Parts")
+        val updated = original.copy(price = BigDecimal("7.50"))
+
+        val diff = service.diff(original, updated)
+
+        diff.hasChanges().shouldBeTrue()
+        val priceChange = diff.changesByType<ValueChange>()
+            .firstOrNull { it.propertyName == "price" }
+        priceChange.shouldNotBeNull()
+        priceChange.left shouldBeEqualTo BigDecimal("5.00")
+        priceChange.right shouldBeEqualTo BigDecimal("7.50")
+    }
+
+    @Test
+    fun `diff reports no changes when product is unchanged`() {
+        val product = Product(id = 4L, name = "Bolt", price = BigDecimal("0.99"), category = "Hardware")
+
+        val diff = service.diff(product, product.copy())
+
+        diff.hasChanges().shouldBeFalse()
+    }
+
+    @Test
+    fun `getLatestSnapshot returns null before any save`() {
+        service.getLatestSnapshot(999L).shouldBeNull()
+    }
+
+    @Test
+    fun `getLatestSnapshot returns most recent state after multiple saves`() {
+        val v1 = Product(id = 5L, name = "Cog", price = BigDecimal("3.00"), category = "Parts")
+        val v2 = v1.copy(category = "Mechanical Parts")
+        val v3 = v2.copy(price = BigDecimal("3.50"))
+
+        service.save("carol", v1)
+        service.save("carol", v2)
+        service.save("carol", v3)
+
+        val snapshot = service.getLatestSnapshot(5L)
+        snapshot.shouldNotBeNull()
+        snapshot.getPropertyValue("category") shouldBeEqualTo "Mechanical Parts"
+        snapshot.getPropertyValue("price") shouldBeEqualTo BigDecimal("3.50")
+    }
+
+    @Test
+    fun `delete records a TERMINAL snapshot`() {
+        val product = Product(id = 6L, name = "Pin", price = BigDecimal("0.10"), category = "Hardware")
+        service.save("dave", product)
+
+        service.delete("dave", product)
+
+        val history = service.getHistory(6L)
+        history shouldHaveSize 2
+        history.last().type shouldBeEqualTo SnapshotType.TERMINAL
+    }
+
+    @Test
+    fun `diff detects category change`() {
+        val original = Product(id = 7L, name = "Lever", price = BigDecimal("15.00"), category = "Mechanical")
+        val updated = original.copy(category = "Industrial")
+
+        val diff = service.diff(original, updated)
+
+        diff.hasChanges().shouldBeTrue()
+        val categoryChange = diff.changesByType<ValueChange>()
+            .firstOrNull { it.propertyName == "category" }
+        categoryChange.shouldNotBeNull()
+        categoryChange.left shouldBeEqualTo "Mechanical"
+        categoryChange.right shouldBeEqualTo "Industrial"
+    }
+}

--- a/exposed/javers-audit/src/test/resources/junit-platform.properties
+++ b/exposed/javers-audit/src/test/resources/junit-platform.properties
@@ -1,0 +1,6 @@
+junit.jupiter.extensions.autodetection.enabled=true
+junit.jupiter.testinstance.lifecycle.default=per_class
+
+junit.jupiter.execution.parallel.enabled=false
+junit.jupiter.execution.parallel.mode.default=same_thread
+junit.jupiter.execution.parallel.mode.classes.default=concurrent

--- a/exposed/javers-audit/src/test/resources/logback-test.xml
+++ b/exposed/javers-audit/src/test/resources/logback-test.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
+        <immediateFlush>true</immediateFlush>
+        <encoder>
+            <!-- @formatter:off -->
+            <pattern>%d{HH:mm:ss.SSS} %highlight(%-5level) [%blue(%24.24t)] %yellow(%logger{36}):%line: %msg%n%throwable</pattern>
+            <!-- @formatter:on -->
+            <charset>UTF-8</charset>
+        </encoder>
+    </appender>
+
+    <logger name="io.bluetape4k.workshop" level="DEBUG"/>
+    <logger name="io.bluetape4k" level="DEBUG"/>
+    <logger name="org.javers" level="INFO"/>
+
+    <root level="INFO">
+        <appender-ref ref="Console"/>
+    </root>
+</configuration>


### PR DESCRIPTION
## Summary

Add new workshop module `exposed/javers-audit` demonstrating JaVers entity change-history auditing integrated with JetBrains Exposed JDBC and H2 in-memory database.

Closes #100

## Changes

- **`exposed/javers-audit/`** — new Gradle submodule (path `:exposed-javers-audit`)
  - `Product` data class with `@TypeName`/`@Id` JaVers annotations and `Serializable`
  - `ProductTable` Exposed table (long PK, `decimal(19,4)` price column)
  - `ProductAuditService`: `save`, `getHistory`, `getLatestSnapshot`, `diff`, `delete`
  - Uses `bluetape4k-javers-core` extensions: `latestSnapshotOrNull`, `changesByType`
- **`exposed/javers-audit/README.md`** — Mermaid architecture diagram, Before/After comparison, usage examples
- **`docs/lessons/2026-05-24-issue-100-javers-audit.md`** — API discovery notes, correct imports, lessons learned

## Architecture

```
Client → ProductAuditService → JaVers (in-memory)  → snapshots/diff
                             → Exposed JDBC (H2)    → ProductTable rows
```

No Spring Boot or Testcontainers required. Pure in-memory setup.

## Test Results

```
./gradlew :exposed-javers-audit:test
```

- 8 tests, 0 failures, 0 errors
- Tests cover: INITIAL snapshot, UPDATE snapshot, TERMINAL snapshot (delete), diff with price change, diff with category change, no-change diff, null snapshot before save, latest snapshot after multiple saves

## Verification

```bash
# Run module tests
./gradlew :exposed-javers-audit:test

# Run detekt
./gradlew detekt

# Build only this module
./gradlew :exposed-javers-audit:build
```

## Key Implementation Notes

- `CdoSnapshot.type` property (not `.snapshotType`) returns `SnapshotType` enum
- `import io.bluetape4k.logging.debug` required for lambda `log.debug { }` form
- `import org.jetbrains.exposed.v1.core.eq` — top-level operator (not deprecated `SqlExpressionBuilder.eq`)
- Test assertions use `io.bluetape4k.assertions` (not kluent)