### PR TITLE
docs: strengthen messaging/redis advanced READMEs with bluetape4k patterns (#81)

### DIFF
--- a/docs/lessons/2026-05-24-issue-81-messaging-advanced.md
+++ b/docs/lessons/2026-05-24-issue-81-messaging-advanced.md
@@ -1,0 +1,87 @@
+# 2026-05-24 Messaging/Redis Advanced — BT Feature Documentation (Issue #81)
+
+## 작업 개요
+
+Issue #81 — 메시징/Redis 고급 모듈 README에 bluetape4k(BT) 기능 표, Before/After 코드 비교,
+Mermaid 다이어그램, 운영 주의사항을 추가했다.
+
+대상 모듈 (Issue #83 "basic" 커밋에서 누락된 2개 모듈):
+- `redis/cluster-demo` — `RedisClusterServer.Launcher`, `Launcher.LettuceLib`, `Fakers`, Mermaid 클러스터 토폴로지 다이어그램, 운영 주의사항
+- `redis/distributed-lock` — `RedisServer.Launcher`, `redissonClient {}` DSL, `getLockId()`, `SuspendedJobTester`, `MultithreadingTester`, NonCancellable unlock Before/After
+
+참고: `messaging/kafka`, `messaging/kafka-reply`, `redis/redisson-examples` 3개 모듈은
+커밋 `124f07c4` (Issue #83) 에서 이미 완료.
+
+---
+
+## 주요 발견
+
+### 1. RedisClusterServer.Launcher — 6노드 클러스터 원스텝 구동
+
+`bluetape4k-testcontainers`의 `RedisClusterServer.Launcher.redisCluster`는 3마스터+3슬레이브
+Redis Cluster를 단 한 줄로 자동 구동·종료하는 싱글톤이다.
+`GenericContainer` 6개를 수동 관리하고 `@DynamicPropertySource`로 노드 목록을 조합하던
+기존 방식을 완전히 대체한다.
+
+추가로 `Launcher.LettuceLib.clientResources(redisCluster)` 를 `@Bean`으로 등록하면
+Lettuce `ClientResources`가 컨테이너 포트에 맞게 자동 구성된다.
+
+### 2. Lettuce adaptive refresh — 필수 설정
+
+Redis Cluster 운영 시 노드 장애/재시작이 발생하면 클라이언트가 구버전 토폴로지를 계속
+참조하여 연결이 실패할 수 있다.
+`application.yml`에 `lettuce.cluster.refresh.adaptive: true` 와
+`dynamic-refresh-sources: true` 를 함께 설정해야 자동 갱신이 활성화된다.
+이 설정이 없으면 컨테이너 재시작 시 테스트도 간헐적으로 실패한다.
+
+### 3. Mac AirPlay 포트 충돌
+
+Redis Cluster는 기본적으로 7000–7005 포트를 사용한다.
+macOS Monterey 이후 AirPlay 수신기가 기본적으로 7000 포트를 점유하므로,
+로컬 개발 환경에서 포트 충돌이 발생할 수 있다.
+시스템 환경설정 → AirPlay 수신기 비활성화 후 재실행하면 해결된다.
+
+### 4. getLockId() — 코루틴 안전 FencedLock ID 2단계 취득 패턴
+
+`bluetape4k-redis` (`io.bluetape4k.redis.redisson.coroutines`) 패키지의
+`RedissonClient.getLockId(lockName)` 확장 함수는 Snowflake ID를 기반으로 코루틴 환경에서
+`RFencedLock`의 고유 ID를 안전하게 획득한다.
+
+Redisson 4.x에는 `tryLockAndGetTokenAsync(lockId)` 오버로드가 없으므로,
+2단계 패턴이 필수다:
+
+1. `redisson.getLockId(lockName)` — mlockId 획득 (Snowflake ID)
+2. `fLock.tryLockAsync(waitMs, leaseMs, MILLISECONDS, lockId).await()` — 코루틴 안전 lock 시도
+3. `fLock.tokenAsync.await()` — 펜싱 토큰 획득 (별도 단계)
+4. `withContext(NonCancellable) { fLock.unlockAsync(lockId).await() }` — finally 블록에서 반드시 NonCancellable로 감쌈
+
+### 5. NonCancellable unlock — 코루틴 취소 안전성
+
+`SuspendingFencedInventoryService`의 `finally` 블록에서 `unlockAsync(lockId).await()`를
+`withContext(NonCancellable)` 로 감싸지 않으면, 호출 코루틴이 취소될 때
+`CancellationException`이 `await()` 를 중단시켜 lock이 lease 만료까지 누출된다.
+
+이 패턴은 kotlin 공식 가이드의 "Suspending in finally" 주의사항과 동일한 근거다.
+suspend 함수가 있는 `finally` 블록에서는 반드시 `NonCancellable`을 사용해야 한다.
+
+### 6. `getLockId()` 아티팩트 위치 정정
+
+`getLockId()` 는 `bluetape4k-redisson` 이 아니라 `bluetape4k-redis`
+(`io.bluetape4k.redis.redisson.coroutines.getLockId`) 패키지에 있다.
+`redis/redisson-examples` README (Issue #83) 에는 `bluetape4k-redis`로 올바르게 기재되어 있으나,
+`redis/distributed-lock` 의 기존 Dependencies 섹션은 `bluetape4k-redisson`으로 잘못 기재되어 있었다.
+이번 작업에서 `bluetape4k-redis (coroutines package)` 로 수정했다.
+
+### 7. SuspendedJobTester workers×rounds 의미론
+
+`SuspendedJobTester().workers(N).rounds(R).add { block }`:
+- `N`개의 코루틴 워커가 각각 `R`번 블록을 실행
+- 총 시도 횟수 = `N × R`
+- 재고 100, 차감 10 테스트에서 `workers(20).rounds(1)` → 20회 시도 → 정확히 10회 성공
+
+## 커밋 범위
+
+변경된 파일:
+- `redis/cluster-demo/README.md` — BT 기능 표, Before/After, Mermaid 토폴로지 다이어그램, 운영 주의사항 추가
+- `redis/distributed-lock/README.md` — Used bluetape4k Features 표, Before/After (RedisServer.Launcher, NonCancellable unlock, SuspendedJobTester), Dependencies 섹션 보완
+- `docs/lessons/2026-05-24-issue-81-messaging-advanced.md` — 이 파일

--- a/redis/cluster-demo/README.md
+++ b/redis/cluster-demo/README.md
@@ -1,19 +1,52 @@
 # Redis Cluster Demo
 
-`bluetape4k-testcontainers` 의 `RedisClusterServer` 를 사용하여 Redis Cluster를 구성하고, 이를 Spring Data Redis의 Cluster Operations
-에 대한 예제입니다.
+`bluetape4k-testcontainers` 의 `RedisClusterServer.Launcher` 를 사용하여 Redis Cluster를 자동 구동하고,
+Spring Data Redis의 Cluster Operations를 검증하는 예제입니다.
 
 ## Redis Cluster 토폴로지
 
 ![Redis Cluster diagram](../../docs/images/readme-diagrams/redis-cluster-demo-diagram-01.png)
 
+```mermaid
+graph LR
+    subgraph "App / Test JVM"
+        App[RedisClusterApplication]
+        NS[NumberService]
+        BT[AbstractRedisClusterTest]
+    end
+
+    subgraph "bluetape4k-testcontainers"
+        Launcher[RedisClusterServer.Launcher.redisCluster]
+        LettuceLib[Launcher.LettuceLib.clientResources]
+    end
+
+    subgraph "Redis Cluster (Testcontainers)"
+        M1[Master 1\nslots 0–5460]
+        M2[Master 2\nslots 5461–10922]
+        M3[Master 3\nslots 10923–16383]
+        S1[Slave 1] --- M1
+        S2[Slave 2] --- M2
+        S3[Slave 3] --- M3
+    end
+
+    App --> Launcher
+    App --> LettuceLib
+    BT  --> App
+    NS  --> M1
+    NS  --> M2
+    NS  --> M3
+    Launcher -->|singleton autostart| M1
+    Launcher -->|singleton autostart| M2
+    Launcher -->|singleton autostart| M3
+```
+
 ## 주요 구성 요소
 
 | 클래스 / 파일 | 역할 |
 |---------------|------|
-| `RedisClusterApplication.kt` | Spring Boot 진입점 |
+| `RedisClusterApplication.kt` | Spring Boot 진입점 — `RedisClusterServer.Launcher.redisCluster` 싱글톤 구동 |
 | `NumberService.kt` | `clusterConnection` 으로 바이트 직렬화 기반 숫자 저장/조회 |
-| `AbstractRedisClusterTest.kt` | `@SpringBootTest` + Testcontainers RedisCluster 공통 베이스 |
+| `AbstractRedisClusterTest.kt` | `@SpringBootTest` + `KLoggingChannel` + `Fakers` 공통 베이스 |
 | `BasicUsageTest.kt` | 키-값 기본 CRUD 클러스터 테스트 |
 | `NumberServiceTest.kt` | `multiplyAndSave` / `get` 서비스 레이어 테스트 |
 | `application.yml` | 클러스터 노드 목록 + Lettuce adaptive refresh 설정 |
@@ -37,6 +70,72 @@ spring:
           max-idle: 8
 ```
 
+## bluetape4k 활용 기능
+
+| 기능 | 아티팩트 | 코드 위치 | 이점 |
+|---|---|---|---|
+| `RedisClusterServer.Launcher.redisCluster` | `bluetape4k-testcontainers` | `RedisClusterApplication` companion | Testcontainers Redis Cluster 싱글톤 — 6노드(3마스터+3슬레이브) 자동 구동·종료 |
+| `Launcher.LettuceLib.clientResources(redisCluster)` | `bluetape4k-testcontainers` | `RedisClusterApplication.lettuceClientResource()` | 컨테이너 포트에 맞춘 Lettuce `ClientResources` 원스텝 생성 |
+| `KLoggingChannel` | `bluetape4k-logging` | `RedisClusterApplication` companion, `NumberService` companion, `AbstractRedisClusterTest` companion | 코루틴 MDC 컨텍스트 포함 구조적 로깅 |
+| `Fakers.faker` / `Fakers.fixedString` | `bluetape4k-junit5` | `AbstractRedisClusterTest` | 재현 가능한 랜덤 키·값 생성 |
+| `bluetape4k-core` — `toByteArray()` / `toInt()` | `bluetape4k-core` | `NumberService` | Int ↔ ByteArray 변환 유틸리티 — 바이너리 클러스터 커맨드에서 활용 |
+
+## bluetape4k Before / After
+
+### `RedisClusterServer.Launcher` vs 수동 Testcontainers 클러스터 설정
+
+```kotlin
+// Before — GenericContainer 기반 수동 Redis Cluster 구성 (6컨테이너, DynamicPropertySource)
+@SpringBootTest
+class RedisClusterTest {
+    companion object {
+        // 마스터 3 + 슬레이브 3 = 6개 컨테이너 수동 관리
+        val node1 = GenericContainer("redis:7").withExposedPorts(6379)
+        val node2 = GenericContainer("redis:7").withExposedPorts(6379)
+        // ... node3~6 생략
+
+        @JvmStatic
+        @DynamicPropertySource
+        fun props(registry: DynamicPropertyRegistry) {
+            // 각 노드 포트를 수동으로 조합
+            registry.add("spring.data.redis.cluster.nodes") {
+                "${node1.host}:${node1.getMappedPort(6379)},..."
+            }
+        }
+    }
+}
+
+// After — RedisClusterServer.Launcher.redisCluster 싱글톤 (한 줄)
+@SpringBootApplication(proxyBeanMethods = false)
+class RedisClusterApplication {
+    companion object: KLoggingChannel() {
+        @JvmStatic
+        val redisCluster = RedisClusterServer.Launcher.redisCluster  // 6노드 클러스터 자동 구동
+    }
+
+    @Bean(destroyMethod = "shutdown")
+    fun lettuceClientResource(): ClientResources =
+        RedisClusterServer.Launcher.LettuceLib.clientResources(redisCluster)
+}
+```
+
+### `Fakers.fixedString` — 재현 가능한 랜덤 테스트 데이터
+
+```kotlin
+// Before — UUID 기반 (재현 불가)
+val key = UUID.randomUUID().toString()
+val value = RandomStringUtils.randomAlphanumeric(256)
+
+// After — bluetape4k Fakers.fixedString (고정 시드, 재현 가능)
+companion object: KLoggingChannel() {
+    @JvmStatic
+    fun randomKey(): String = Fakers.fixedString(32)
+
+    @JvmStatic
+    fun randomValue(): String = Fakers.fixedString(256)
+}
+```
+
 ## NumberService 동작 방식
 
 `StringRedisTemplate` 의 `clusterConnection` 을 직접 열어 바이너리 직렬화로 숫자를 저장합니다.
@@ -58,6 +157,14 @@ fun multiplyAndSave(number: Int) {
 | 마스터 2 | 5461 – 10922 | 슬레이브 2 |
 | 마스터 3 | 10923 – 16383 | 슬레이브 3 |
 
+## 운영 주의사항
+
+- **Mac AirPlay 포트 충돌**: Redis Cluster는 기본적으로 7000–7005 포트를 사용합니다.  
+  Mac에서 AirPlay 수신 모드가 활성화된 경우 7000 포트 충돌이 발생할 수 있습니다.  
+  시스템 환경설정 → AirPlay 수신기 비활성화 후 재시도하세요.
+- **Lettuce adaptive refresh**: `adaptive: true` 설정이 없으면 노드 장애 시 클러스터 토폴로지가 자동 갱신되지 않아 연결이 끊길 수 있습니다.
+- **Testcontainers 사전 조건**: Docker가 실행 중이어야 합니다. `RedisClusterServer.Launcher.redisCluster`는 최초 접근 시 컨테이너를 구동하며, JVM 종료 시 자동 정리됩니다.
+
 ## 빌드 및 테스트
 
 ```bash
@@ -67,3 +174,5 @@ fun multiplyAndSave(number: Int) {
 ## 참고
 
 * [Spring Data Redis-Cluster Examples](https://github.com/spring-projects/spring-data-examples/tree/main/redis/cluster)
+* [bluetape4k-testcontainers](https://github.com/bluetape4k/bluetape4k-projects)
+* [Lettuce Cluster Topology Refresh](https://lettuce.io/core/release/reference/index.html#redis-cluster.topology-refresh)

--- a/redis/distributed-lock/README.md
+++ b/redis/distributed-lock/README.md
@@ -218,10 +218,107 @@ For a stock-100/qty-10 test:
 
 ---
 
+## Used bluetape4k Features
+
+| Feature | Artifact | Code Location | Benefit |
+|---|---|---|---|
+| `RedisServer.Launcher.redis` | `bluetape4k-testcontainers` | `AbstractDistributedLockTest` companion | Testcontainers Redis singleton — one-line setup, no `@DynamicPropertySource` |
+| `redissonClient {}` DSL | `bluetape4k-redisson` | `AbstractDistributedLockTest.redisson` | Kotlin DSL for `RedissonClient` — eliminates `Config()` boilerplate |
+| `getLockId(lockName)` | `bluetape4k-redis` (`coroutines` package) | `SuspendingFencedInventoryService.deduct()` | Coroutine-safe Snowflake ID for `RFencedLock` identity — required for two-step async acquire |
+| `KLoggingChannel` | `bluetape4k-logging` | All companion objects | Coroutine-context-aware structured logging |
+| `requirePositiveNumber` | `bluetape4k-core` | `SuspendingFencedInventoryService.deduct()` | Inline argument validation — throws `IllegalArgumentException` with a clear message |
+| `SuspendedJobTester` | `bluetape4k-junit5` | `SuspendFencedLockTest` | Reproducible coroutine concurrency harness — deterministic race verification |
+| `MultithreadingTester` | `bluetape4k-junit5` | `DistributedLockTest` | Fixed-thread-pool concurrency verification for OS-thread lock scenarios |
+
+---
+
+## bluetape4k Before / After
+
+### `RedisServer.Launcher` vs Manual Testcontainers Redis
+
+```kotlin
+// Before — manual container + @DynamicPropertySource
+@SpringBootTest
+class LockTest {
+    companion object {
+        @Container
+        val redis = GenericContainer("redis:7").withExposedPorts(6379)
+
+        @JvmStatic
+        @DynamicPropertySource
+        fun props(registry: DynamicPropertyRegistry) {
+            registry.add("spring.redis.url") { "redis://${redis.host}:${redis.getMappedPort(6379)}" }
+        }
+    }
+}
+
+// After — bluetape4k singleton (one line in AbstractDistributedLockTest)
+abstract class AbstractDistributedLockTest {
+    companion object : KLoggingChannel() {
+        val redis = RedisServer.Launcher.redis          // auto-started, auto-cleaned up
+        val redisUrl: String get() = redis.url
+    }
+
+    protected val redisson: RedissonClient by lazy {
+        redissonClient {                                // bluetape4k DSL
+            useSingleServer().setAddress(redisUrl)
+        }
+    }
+}
+```
+
+### Coroutine-Native Fenced Lock — Two-Step Acquire + `NonCancellable` Unlock
+
+```kotlin
+// Before — blocking tryLockAndGetToken (blocks the calling thread)
+val token: Long = fLock.tryLockAndGetToken(waitMs, leaseMs, MILLISECONDS)
+try {
+    // work
+} finally {
+    fLock.unlock()  // may throw if coroutine was cancelled before this line
+}
+
+// After — suspend-friendly two-step acquire with NonCancellable unlock guard
+val lockId = redisson.getLockId(lockName)           // bluetape4k: Snowflake ID for coroutine identity
+val acquired = fLock.tryLockAsync(waitMs, leaseMs, MILLISECONDS, lockId).await()
+if (!acquired) return LockNotAcquired(lockName)
+val token: Long = fLock.tokenAsync.await()          // separate token step (no combined overload in Redisson 4.x)
+try {
+    /* work */
+} finally {
+    // CRITICAL: without NonCancellable, a cancelled coroutine never completes unlockAsync
+    // and the lock leaks until lease expiry
+    withContext(NonCancellable) {
+        fLock.unlockAsync(lockId).await()
+    }
+}
+```
+
+### `SuspendedJobTester` — Reproducible Coroutine Race Verification
+
+```kotlin
+// Before — manual coroutine launch (non-deterministic, hard to tune worker count)
+val results = (1..20).map {
+    async { suspendingService.deduct(inventoryId, qty = 10) }
+}.awaitAll()
+
+// After — bluetape4k SuspendedJobTester (fixed workers × rounds = total attempts)
+SuspendedJobTester()
+    .workers(20)    // 20 coroutine workers
+    .rounds(1)      // 1 round each → 20 total attempts, exactly 10 succeed (stock=100, qty=10)
+    .add {
+        suspendingService.deduct(inventoryId, qty = 10, waitMs = 3000L, leaseMs = 5000L)
+    }
+    .run()
+```
+
+---
+
 ## Dependencies
 
 - **Redisson** — `RLock`, `RFencedLock`, async API
 - **bluetape4k-redisson** — `getLockId()` (Snowflake ID), `redissonClient {}` DSL
+- **bluetape4k-redis** — `getLockId()` coroutines extension (`io.bluetape4k.redis.redisson.coroutines`)
 - **bluetape4k-coroutines** — `awaitSuspending()`, `io.bluetape4k.logging.coroutines`
 - **bluetape4k-testcontainers** — `RedisServer.Launcher.redis` Testcontainers singleton
 - **kotlinx.atomicfu** — `atomic(0L)` for `FencedResource.lastSeenToken`


### PR DESCRIPTION
## Summary

Completes Issue #81 — adds bluetape4k feature documentation to the two advanced messaging/redis modules that were **not** covered by the earlier #83 commit (`124f07c4`).

### Modules updated in this PR

| Module | Added |
|---|---|
| `redis/cluster-demo` | `## bluetape4k 활용 기능` table, Before/After (`RedisClusterServer.Launcher` vs manual 6-container setup), Mermaid cluster topology diagram, operational notes (Mac AirPlay port conflict, Lettuce adaptive refresh requirement) |
| `redis/distributed-lock` | `## Used bluetape4k Features` table, Before/After (`RedisServer.Launcher` singleton, two-step coroutine fenced lock with `getLockId()` + `NonCancellable` unlock, `SuspendedJobTester` vs manual coroutine launch) |
| `docs/lessons/2026-05-24-issue-81-messaging-advanced.md` | Lesson notes covering cluster topology, Lettuce adaptive refresh, `NonCancellable` unlock pattern, `getLockId()` artifact correction |

### Not in this PR (already done under #83)

- `messaging/kafka` — `KafkaServer.Launcher`, `KLoggingChannel` (commit `124f07c4`)
- `messaging/kafka-reply` — `CompletableFuture.onSuccess/onFailure`, `uninitialized()` (commit `124f07c4`)
- `redis/redisson-examples` — `RedissonCodecs.LZ4ForyComposite`, `VirtualThreadExecutor`, `MultithreadingTester`, `SuspendedJobTester`, `getLockId()` (commit `124f07c4`)

### Key findings documented

- `RedisClusterServer.Launcher.redisCluster` replaces manual 6-container Testcontainers setup
- `Launcher.LettuceLib.clientResources()` one-liner for cluster-aware Lettuce configuration
- Lettuce `adaptive: true` + `dynamic-refresh-sources: true` — required to survive node restarts
- Two-step coroutine fenced lock: `getLockId()` → `tryLockAsync` → `tokenAsync` → `withContext(NonCancellable) { unlockAsync }`
- `getLockId()` lives in `bluetape4k-redis` (`io.bluetape4k.redis.redisson.coroutines`), not `bluetape4k-redisson` — corrected in distributed-lock README

## No code changes — documentation only.