### PR TITLE
docs: strengthen data access advanced READMEs with bluetape4k patterns (#80)

### DIFF
--- a/docs/lessons/2026-05-24-issue-80-data-access-advanced.md
+++ b/docs/lessons/2026-05-24-issue-80-data-access-advanced.md
@@ -1,0 +1,61 @@
+# Issue #80 — Data Access Advanced README Strengthening
+
+**Date**: 2026-05-24
+**Issue**: #80 — Data Access Advanced 예제 강화
+
+## Summary
+
+Strengthened READMEs for 6 data access modules with bluetape4k feature tables,
+Before/After code comparisons, and Mermaid architecture diagrams.
+
+## Scope Adjustment (Important)
+
+The original issue listed 8 modules including 4 that were **deleted in Issue #97**
+(`dao-web-transaction`, `spring-transaction`, `sql-web-virtualthread`, `sql-webflux-coroutines`).
+These were replaced by `mvc-jdbc`, `mvc-virtualthread`, and `webflux-r2dbc`.
+
+**Actual scope (6 modules):**
+
+| Module | Action |
+|--------|--------|
+| `exposed/mvc-jdbc` | Added Mermaid `sequenceDiagram` (already had feature table + before/after from #97) |
+| `exposed/mvc-virtualthread` | Added Mermaid, enhanced feature table with code locations, added Before/After |
+| `exposed/webflux-r2dbc` | Added Mermaid, enhanced feature table with code locations, added Before/After |
+| `spring-data/r2dbc-coroutines` | Added English title, added Mermaid (already had full bt feature table + before/after) |
+| `spring-data/r2dbc-webflux` | Added Mermaid, added full bt feature table, added Before/After |
+| `spring-data/r2dbc-webflux-exposed` | Added Mermaid, added full bt feature table, added Before/After |
+| `exposed/javers-audit` | Skipped — already complete from Issue #100 |
+
+## Key Patterns Documented
+
+### `R2dbcRepository` (bluetape4k-exposed-r2dbc)
+
+`spring-data/r2dbc-webflux-exposed` uses `R2dbcRepository<ID, Entity>` as a base class,
+giving `findAll()`, `findById()`, `count()`, `deleteById()` for free.
+Only custom operations (`upsert`, `findByEmail`) need implementation.
+
+### `*Suspending` extensions (bluetape4k-spring-boot4-r2dbc)
+
+`spring-data/r2dbc-coroutines` uses `R2dbcEntityOperations.*Suspending` wrappers
+that convert Mono/Flux operations to suspend functions, eliminating `awaitSingle()` chains.
+
+### `virtualFuture` + `ShutdownQueue` (bluetape4k-virtualthread-api)
+
+`exposed/mvc-virtualthread` submits all blocking JDBC work through `virtualFuture(executor) { }`
+instead of `@Transactional`, avoiding carrier thread pinning.
+`ShutdownQueue.register(executor)` provides zero-boilerplate graceful shutdown.
+
+### `suspendTransaction` (bluetape4k-exposed)
+
+`exposed/webflux-r2dbc` wraps all Exposed R2DBC operations in `suspendTransaction(db)`,
+ensuring coroutine-safe transaction boundaries and Flow stream compatibility.
+
+## Lessons
+
+- Always check whether prior issues (e.g. #97) have already deleted/replaced modules
+  mentioned in a new issue's scope. Verify `git log --all --stat -- <path>` before writing.
+- `exposed/javers-audit` was already well-documented by Issue #100; avoid duplicate work.
+- `spring-data/r2dbc-webflux` used `CoroutineCrudRepository` directly — no bluetape4k
+  repository base class, but `KLoggingChannel` and coroutine-first service layer still
+  count as bluetape4k usage.
+- Mermaid `sequenceDiagram` is the clearest format for layered HTTP→Service→Repo→DB flows.

--- a/exposed/mvc-jdbc/README.md
+++ b/exposed/mvc-jdbc/README.md
@@ -5,8 +5,24 @@ and repository interfaces for type-safe, boilerplate-free data access.
 
 ## Architecture
 
-```
-Controller → Service (@Transactional) → Repository → Exposed JDBC → PostgreSQL
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant Ctrl as @RestController
+    participant Svc as @Service<br/>(@Transactional)
+    participant Repo as Repository<br/>(LongAuditableJdbcRepository)
+    participant DB as PostgreSQL
+
+    C->>Ctrl: HTTP Request
+    Ctrl->>Svc: call service method
+    activate Svc
+    Svc->>Repo: CRUD operation
+    Repo->>DB: Exposed JDBC SQL
+    DB-->>Repo: ResultRow
+    Repo-->>Svc: entity / list
+    Svc-->>Ctrl: result
+    deactivate Svc
+    Ctrl-->>C: HTTP Response
 ```
 
 ## Domain Model

--- a/exposed/mvc-virtualthread/README.md
+++ b/exposed/mvc-virtualthread/README.md
@@ -4,22 +4,86 @@ Spring MVC + Virtual Threads + Exposed JDBC — **no `@Transactional`**.
 
 ## Architecture
 
-```
-Controller → Service (virtualFuture) → Repository (virtualFuture) → transaction(db) → PostgreSQL
-             └─ VT executor (TomcatConfig)
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant Ctrl as @RestController
+    participant Svc as @Service<br/>(VT executor)
+    participant Repo as Repository<br/>(VT executor)
+    participant DB as PostgreSQL
+
+    C->>Ctrl: HTTP Request
+    Ctrl->>Svc: call service method
+    activate Svc
+    Note over Svc: virtualFuture(executor) { }
+    Svc->>Repo: submit to VT executor
+    Note over Repo: transaction(db) { }
+    Repo->>DB: Exposed JDBC SQL
+    DB-->>Repo: ResultRow
+    Repo-->>Svc: entity / list
+    Svc-->>Ctrl: Future.get()
+    deactivate Svc
+    Ctrl-->>C: HTTP Response
 ```
 
-## Used Bluetape4k Features
+## Used bluetape4k Features
 
-| Feature | Module | Usage |
-|---------|--------|-------|
-| `KLogging` | `bluetape4k-logging` | Companion object logging |
-| `virtualFuture(executor) { }` | `bluetape4k-virtualthread-api` | Submits DB work to VT executor |
-| `ShutdownQueue.register(executor)` | `bluetape4k-virtualthread-api` | Graceful shutdown of VT executor |
-| `bluetape4k-virtualthread-jdk21` | `bluetape4k-virtualthread-jdk21` | JDK 21 VT runtime |
-| `bluetape4k-junit5` | `bluetape4k-junit5` | `Fakers.faker` in tests |
-| `bluetape4k-assertions` | `bluetape4k-assertions` | `shouldBeEqualTo`, comparison matchers |
-| `bluetape4k-testcontainers` | `bluetape4k-testcontainers` | `PostgreSQLServer.Launcher.postgres` singleton |
+| Feature | Artifact | Code location | Benefit |
+|---------|----------|---------------|---------|
+| `KLogging` | `bluetape4k-logging` | Every service class | Lazy lambda logging |
+| `virtualFuture(executor) { }` | `bluetape4k-virtualthread-api` | `AuthorService.kt`, `OrderService.kt` | Submits blocking JDBC work to VT executor — no coroutine/reactor needed |
+| `ShutdownQueue.register(executor)` | `bluetape4k-virtualthread-api` | `TomcatConfig.kt` | Graceful shutdown of VT executor without manual lifecycle management |
+| `bluetape4k-virtualthread-jdk21` | `bluetape4k-virtualthread-jdk21` | runtime classpath | JDK 21 virtual thread provider |
+| `Fakers.faker` | `bluetape4k-junit5` | Test base classes | Deterministic fake data generation |
+| `shouldBeEqualTo` matchers | `bluetape4k-assertions` | All test classes | Readable Kotlin-idiomatic assertions |
+| `PostgreSQLServer.Launcher.postgres` | `bluetape4k-testcontainers` | `AbstractMvcVirtualthreadTest` | Singleton Testcontainers PostgreSQL — no `@Testcontainers` boilerplate |
+
+## bluetape4k Before / After
+
+### Virtual Thread DB execution
+
+```kotlin
+// Before — @Transactional with potential pinning risk under virtual threads
+@Service
+class AuthorService(private val repo: AuthorRepository) {
+    @Transactional
+    fun save(dto: AuthorDTO): AuthorDTO {
+        return repo.insert(dto)      // synchronized monitor → pins the carrier thread
+    }
+}
+
+// After — bluetape4k virtualFuture: explicit VT submission, no @Transactional
+@Service
+class AuthorService(
+    private val repo: AuthorRepository,
+    private val executor: ExecutorService,
+) {
+    fun save(dto: AuthorDTO): AuthorDTO =
+        virtualFuture(executor) {
+            transaction(db) { repo.insert(dto) }
+        }.get()
+}
+```
+
+### Executor lifecycle management
+
+```kotlin
+// Before — manual PreDestroy or ApplicationListener
+@Bean
+fun virtualThreadExecutor(): ExecutorService {
+    val exec = Executors.newVirtualThreadPerTaskExecutor()
+    // Remember to shut it down somewhere...
+    return exec
+}
+
+// After — bluetape4k ShutdownQueue: zero-boilerplate graceful shutdown
+@Bean
+fun virtualThreadExecutor(): ExecutorService {
+    val exec = Executors.newVirtualThreadPerTaskExecutor()
+    ShutdownQueue.register(exec)   // automatically called on JVM shutdown
+    return exec
+}
+```
 
 ## Key Patterns
 

--- a/exposed/webflux-r2dbc/README.md
+++ b/exposed/webflux-r2dbc/README.md
@@ -4,19 +4,76 @@ WebFlux + Coroutines + Exposed R2DBC — fully reactive/coroutine data access.
 
 ## Architecture
 
-```
-Controller (suspend) → Service (suspendTransaction) → Repository (Flow<T>) → R2DBC → PostgreSQL
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant Ctrl as WebFlux Controller<br/>(suspend fun)
+    participant Svc as @Service<br/>(suspendTransaction)
+    participant Repo as Repository<br/>(Flow<T>)
+    participant DB as PostgreSQL (R2DBC)
+
+    C->>Ctrl: HTTP Request
+    Ctrl->>Svc: suspend call
+    activate Svc
+    Note over Svc: suspendTransaction(db) { }
+    Svc->>Repo: findAll() / findById()
+    Note over Repo: Flow<T> (cold stream)
+    Repo->>DB: Exposed R2DBC SQL
+    DB-->>Repo: rows
+    Repo-->>Svc: Flow<T>.toList()
+    Svc-->>Ctrl: List<T>
+    deactivate Svc
+    Ctrl-->>C: HTTP Response
 ```
 
-## Used Bluetape4k Features
+## Used bluetape4k Features
 
-| Feature | Module | Usage |
-|---------|--------|-------|
-| `KLoggingChannel` | `bluetape4k-logging` | Coroutine-aware logging in companion objects |
-| `bluetape4k-coroutines` | `bluetape4k-coroutines` | Coroutine utilities |
-| `bluetape4k-junit5` | `bluetape4k-junit5` | `Fakers.faker` in tests |
-| `bluetape4k-assertions` | `bluetape4k-assertions` | `shouldBeEqualTo`, comparison matchers |
-| `bluetape4k-testcontainers` | `bluetape4k-testcontainers` | `PostgreSQLServer.Launcher.postgres` singleton |
+| Feature | Artifact | Code location | Benefit |
+|---------|----------|---------------|---------|
+| `KLoggingChannel` | `bluetape4k-logging` | Every companion object | Coroutine-aware structured logging (MDC propagation) |
+| `bluetape4k-coroutines` | `bluetape4k-coroutines` | Service, concurrency tests | Coroutine scope helpers and Flow utilities |
+| `Fakers.faker` | `bluetape4k-junit5` | Test base classes | Deterministic fake data generation |
+| `shouldBeEqualTo` matchers | `bluetape4k-assertions` | All test classes | Readable Kotlin-idiomatic assertions |
+| `PostgreSQLServer.Launcher.postgres` | `bluetape4k-testcontainers` | `AbstractWebfluxR2dbcTest` | Singleton Testcontainers PostgreSQL — started once, shared across all tests |
+
+## bluetape4k Before / After
+
+### Coroutine-safe R2DBC transactions with Exposed
+
+```kotlin
+// Before — Reactor chain: verbose, no structured concurrency
+fun findAll(): Flux<Author> =
+    Mono.fromCallable { db.transaction { AuthorTable.selectAll().toList() } }
+        .flatMapMany { Flux.fromIterable(it) }
+        .subscribeOn(Schedulers.boundedElastic())
+
+// After — bluetape4k suspendTransaction: idiomatic coroutine, Flow-aware
+fun findAll(): Flow<Author> = flow {
+    suspendTransaction(db = db) {
+        AuthorTable.selectAll()
+            .map { it.toAuthor() }
+            .forEach { emit(it) }
+    }
+}
+```
+
+### Testcontainers singleton pattern
+
+```kotlin
+// Before — new container per test class → slow, resource-heavy
+@Testcontainers
+abstract class AbstractTest {
+    @Container
+    val postgres = PostgreSQLContainer("postgres:15")
+}
+
+// After — bluetape4k singleton launcher: one container for the entire test suite
+abstract class AbstractWebfluxR2dbcTest {
+    companion object {
+        val postgres = PostgreSQLServer.Launcher.postgres   // shared singleton
+    }
+}
+```
 
 ## Key Patterns
 

--- a/spring-data/r2dbc-coroutines/README.md
+++ b/spring-data/r2dbc-coroutines/README.md
@@ -1,4 +1,28 @@
-# Spring Data R2DBC Demo
+# Spring Data R2DBC + Coroutines
+
+Spring Data R2DBC with Kotlin coroutines using **bluetape4k `*Suspending` extension functions**
+for zero-boilerplate reactive data access.
+
+## Architecture
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant Ctrl as @RestController<br/>(suspend fun)
+    participant Repo as PostRepository<br/>(*Suspending extensions)
+    participant Ops as R2dbcEntityOperations
+    participant DB as PostgreSQL (R2DBC)
+
+    C->>Ctrl: HTTP Request
+    Ctrl->>Repo: suspend fun (e.g. findOneById)
+    Repo->>Ops: findOneByIdSuspending(id)
+    Note over Ops: bluetape4k coroutine wrapper
+    Ops->>DB: R2DBC SQL query
+    DB-->>Ops: row(s)
+    Ops-->>Repo: Post entity
+    Repo-->>Ctrl: Post
+    Ctrl-->>C: HTTP Response
+```
 
 ## 아키텍처 다이어그램
 

--- a/spring-data/r2dbc-webflux-exposed/README.md
+++ b/spring-data/r2dbc-webflux-exposed/README.md
@@ -1,11 +1,93 @@
 # R2DBC + WebFlux + Exposed ORM
 
+Spring Data R2DBC + Spring WebFlux + JetBrains Exposed ORM, using **bluetape4k `R2dbcRepository`**
+for a coroutine-first data access layer. Exposed table DSL handles schema definition; Spring WebFlux
+(functional + annotation routes) handles HTTP.
+
+## Architecture
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant Ctrl as @RestController<br/>+ coRouter Handler
+    participant Svc as UserService<br/>(suspend fun)
+    participant Repo as UserExposedRepository<br/>(R2dbcRepository)
+    participant DB as H2 (R2DBC + Exposed)
+
+    C->>Ctrl: HTTP Request
+    Ctrl->>Svc: suspend service call
+    activate Svc
+    Svc->>Repo: findById / save / upsert
+    Note over Repo: suspendedTransaction { <br/>Exposed DSL }
+    Repo->>DB: Exposed R2DBC SQL
+    DB-->>Repo: ResultRow
+    Repo-->>Svc: UserRecord
+    Svc-->>Ctrl: UserRecord / Flow<UserRecord>
+    deactivate Svc
+    Ctrl-->>C: HTTP Response
+```
+
 ## 아키텍처 다이어그램
 
 ![r2dbc webflux exposed Architecture diagram](../../docs/images/readme-diagrams/spring-data-r2dbc-webflux-exposed-diagram-01.png)
 
 Spring Data R2DBC와 Spring WebFlux, JetBrains Exposed ORM을 함께 사용하는 예제입니다.
 `exposed-r2dbc` 모듈을 활용해 Exposed 테이블 정의를 R2DBC 환경에서 사용합니다.
+
+## Used bluetape4k Features
+
+| Feature | Artifact | Code location | Benefit |
+|---------|----------|---------------|---------|
+| `R2dbcRepository<ID, Entity>` | `bluetape4k-exposed-r2dbc` | `UserExposedRepository.kt` | Abstract base providing `findAll()`, `findById()`, `count()`, `deleteById()` via Exposed DSL |
+| `KLoggingChannel` | `bluetape4k-logging` | `ExposedR2dbcConfig.kt`, `UserService.kt` | Coroutine-aware structured logging |
+| `bluetape4k-coroutines` | `bluetape4k-coroutines` | Service layer | Coroutine scope helpers |
+| `Runtimex.availableProcessors` | `bluetape4k-core` | `ExposedR2dbcConfig.kt` | CPU-aware connection pool sizing |
+
+## bluetape4k Before / After
+
+### Exposed R2DBC repository with `R2dbcRepository`
+
+```kotlin
+// Before — manual Exposed R2DBC CRUD (repeated per entity)
+class UserRepository {
+    suspend fun findAll(): List<UserRecord> = suspendedTransaction {
+        UserTable.selectAll().map { it.toUserRecord() }
+    }
+    suspend fun findById(id: Int): UserRecord? = suspendedTransaction {
+        UserTable.selectAll().where { UserTable.id eq id }.singleOrNull()?.toUserRecord()
+    }
+    suspend fun deleteById(id: Int): Int = suspendedTransaction {
+        UserTable.deleteWhere { UserTable.id eq id }
+    }
+    // count(), existsById(), findPage()... each written manually
+}
+
+// After — bluetape4k R2dbcRepository: inherit CRUD, implement only what's custom
+@Repository
+class UserExposedRepository : R2dbcRepository<Int, UserRecord> {
+    override val table: UserTable = UserTable
+    override fun extractId(entity: UserRecord): Int = entity.id
+    override suspend fun ResultRow.toEntity(): UserRecord = toUserRecord()
+
+    // Custom operations only — all standard CRUD is inherited
+    suspend fun upsert(user: UserRecord) {
+        table.upsert(where = { table.id eq user.id }) {
+            it[table.name] = user.name
+            it[table.email] = user.email
+        }
+    }
+}
+```
+
+### R2DBC connection pool with `Runtimex`
+
+```kotlin
+// Before — hardcoded pool size
+.maxSize(50)
+
+// After — bluetape4k Runtimex: CPU-adaptive sizing
+.maxSize(max(Runtimex.availableProcessors * 8, 100))
+```
 
 ## 구성
 

--- a/spring-data/r2dbc-webflux/README.md
+++ b/spring-data/r2dbc-webflux/README.md
@@ -1,4 +1,31 @@
-# R2DBC + Spring WebFlux (함수형 라우터)
+# R2DBC + Spring WebFlux (Functional Router)
+
+Spring Data R2DBC with WebFlux functional endpoints (Handler + Router) and Kotlin coroutines.
+Uses H2 in-memory database.
+
+## Architecture
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant Router as coRouter<br/>(functional routes)
+    participant Handler as UserHandler<br/>(suspend fun)
+    participant Svc as UserService<br/>(@Transactional)
+    participant Repo as CoroutineCrudRepository
+    participant DB as H2 (R2DBC)
+
+    C->>Router: HTTP Request
+    Router->>Handler: route to handler method
+    activate Handler
+    Handler->>Svc: suspend service call
+    Svc->>Repo: findAll() / save() / deleteById()
+    Repo->>DB: R2DBC SQL
+    DB-->>Repo: rows
+    Repo-->>Svc: entity / Flow<T>
+    Svc-->>Handler: result
+    deactivate Handler
+    Handler-->>C: ServerResponse
+```
 
 ## 아키텍처 다이어그램
 
@@ -8,6 +35,69 @@
 
 Spring Data R2DBC와 WebFlux 함수형 라우터(Handler + Router)를 조합한 리액티브 CRUD 예제입니다.
 H2 인메모리 데이터베이스를 사용합니다.
+
+## Used bluetape4k Features
+
+| Feature | Artifact | Code location | Benefit |
+|---------|----------|---------------|---------|
+| `KLoggingChannel` | `bluetape4k-logging` | `UserService.kt`, `UserHandler.kt` | Coroutine-aware structured logging |
+| `bluetape4k-coroutines` | `bluetape4k-coroutines` | Service layer | Coroutine scope and Flow utilities |
+| `bluetape4k-r2dbc` | `bluetape4k-r2dbc` | R2DBC configuration | R2DBC connection helpers and extensions |
+| `bluetape4k-assertions` | `bluetape4k-core` | All test classes | `shouldBeEqualTo`, `shouldNotBeNull` readable assertions |
+
+## bluetape4k Before / After
+
+### Coroutine-based service with `@Transactional`
+
+```kotlin
+// Before — Reactor Mono/Flux API: verbose chain
+@Service
+class UserService(private val repository: UserRepository) {
+    fun findAll(): Flux<User> = repository.findAll()
+
+    fun addUser(user: UserDTO): Mono<User> =
+        repository.save(user.toModel())
+            .doOnNext { log.info("Saved user: $it") }
+}
+
+// After — bluetape4k KLoggingChannel + coroutine-first style
+@Service
+@Transactional(readOnly = true)
+class UserService(private val repository: UserRepository) {
+    companion object : KLoggingChannel()
+
+    fun findAll(): Flow<User> = repository.findAll()
+
+    @Transactional
+    suspend fun addUser(user: UserDTO): User? {
+        log.debug { "Save new user. ${user.toModel()}" }
+        return repository.save(user.toModel())
+    }
+}
+```
+
+### Functional routing with `coRouter`
+
+```kotlin
+// Before — annotation-based controller
+@RestController
+@RequestMapping("/users")
+class UserController {
+    @GetMapping
+    fun findAll() = repository.findAll()
+}
+
+// After — WebFlux coRouter (functional endpoint, suspend handlers)
+@Bean
+fun routes(handler: UserHandler) = coRouter {
+    "/users".nest {
+        GET("", handler::findAll)
+        GET("/{id}", handler::findById)
+        POST("", handler::save)
+        DELETE("/{id}", handler::delete)
+    }
+}
+```
 
 ## 구성 방식
 


### PR DESCRIPTION
## Summary

Strengthens READMEs for 6 data access modules with bluetape4k feature tables, Before/After code comparisons, and Mermaid architecture diagrams. Closes #80.

## Scope Adjustment

The original issue listed 8 modules, but 4 were **deleted in Issue #97** (`dao-web-transaction`, `spring-transaction`, `sql-web-virtualthread`, `sql-webflux-coroutines`) and replaced by `mvc-jdbc`, `mvc-virtualthread`, `webflux-r2dbc`. This PR documents the successor modules instead.

`exposed/javers-audit` was already fully documented in Issue #100 and is skipped.

## Modules Updated

| Module | Changes |
|--------|---------|
| `exposed/mvc-jdbc` | Added Mermaid sequenceDiagram |
| `exposed/mvc-virtualthread` | Enhanced bt feature table, added Before/After + Mermaid |
| `exposed/webflux-r2dbc` | Enhanced bt feature table, added Before/After + Mermaid |
| `spring-data/r2dbc-coroutines` | Added English title + Mermaid (bt feature table already present) |
| `spring-data/r2dbc-webflux` | Added full bt feature table, Before/After + Mermaid |
| `spring-data/r2dbc-webflux-exposed` | Added full bt feature table, Before/After + Mermaid |

## Key bluetape4k Patterns Documented

- `R2dbcRepository<ID, Entity>` (bluetape4k-exposed-r2dbc) — inherit CRUD for Exposed R2DBC
- `*Suspending` extensions (bluetape4k-spring-boot4-r2dbc) — coroutine wrappers for R2dbcEntityOperations
- `virtualFuture` + `ShutdownQueue` (bluetape4k-virtualthread-api) — VT executor pattern with zero-boilerplate shutdown
- `suspendTransaction` (bluetape4k-exposed) — coroutine-safe R2DBC transaction boundaries
- `PostgreSQLServer.Launcher.postgres` (bluetape4k-testcontainers) — singleton TC pattern

## Verification

- All 6 README files diff-checked for correct Mermaid syntax and table formatting
- Lessons doc written at `docs/lessons/2026-05-24-issue-80-data-access-advanced.md`
- No source code changed