### PR TITLE
docs: strengthen async/reactive advanced READMEs with bluetape4k patterns (#88)

### DIFF
--- a/docs/lessons/2026-05-24-issue-88-async-reactive-advanced.md
+++ b/docs/lessons/2026-05-24-issue-88-async-reactive-advanced.md
@@ -1,0 +1,68 @@
+# Issue #88: Async/Reactive Advanced README Enhancement
+
+## Overview
+
+Enhanced 6 module READMEs in bluetape4k-workshop with `Used bluetape4k Features` tables,
+`Before/After` code snippets, Mermaid sequence diagrams, and cancellation/structured-concurrency
+sections. No code changes — documentation only.
+
+## Updated Modules
+
+| Module | Action | Key bluetape4k APIs |
+|---|---|---|
+| `vertx/coroutines` | Added Mermaid diagram + cancellation section | `suspendHandler`, `coAwait()`, `CoroutineVerticle` scope |
+| `vertx/vertx-sqlclient` | Added Mermaid diagram + cancellation section | `withSuspendTransaction`, `testWithSuspendTransaction`, `MySQL8Server.Launcher` |
+| `vertx/vertx-webclient` | Added Mermaid diagram + cancellation section | `suspendHandler`, `Jackson`, `coAwait()` |
+| `spring-data/r2dbc-examples` | Full rewrite with table, Before/After, Mermaid, cancellation | `connectionFactoryInitializer`, `buildExampleMatcher`, `KLoggingChannel` |
+| `spring-data/mongodb-coroutines` | Full rewrite with table, Before/After, Mermaid, cancellation | `MongoDBServer.Launcher`, `Flow.log()`, `runSuspendIO`, `KLoggingChannel` |
+| `spring-data/mongodb-transactions` | Full rewrite with table, Before/After, Mermaid, cancellation | `MongoDBServer.Launcher`, `uninitialized()`, `@Transactional suspend fun` |
+
+## Methodology: Grounded on Real Imports
+
+Features tables and Before/After snippets were authored from real `import io.bluetape4k.*`
+analysis of each module's source files. The task brief mentioned `bluetape4k-mongodb` API but
+no such dependency exists in the build files; documented only what the code actually imports.
+
+## Key Findings
+
+### `spring-data/r2dbc-examples`
+
+- `bluetape4k-r2dbc` provides `connectionFactoryInitializer { }` DSL for building
+  `ConnectionFactoryInitializer` beans with a lambda — reduces boilerplate.
+- `bluetape4k-spring-boot4-r2dbc` provides `buildExampleMatcher(vararg props)` for
+  type-safe QBE (Query-by-Example) matcher construction.
+- R2DBC `CoroutineCrudRepository` Flow cancellation propagates back to the R2DBC publisher,
+  returning connections to the pool on scope cancellation.
+
+### `spring-data/mongodb-coroutines`
+
+- `MongoDBServer.Launcher.mongoDB` singleton is used in `MongoClientConfig` and
+  `ReactiveMongoConfig` — all tests share one Testcontainers instance.
+- `io.bluetape4k.coroutines.flow.extensions.log` (`Flow.log("label")`) is used in
+  `FlowAndCoroutineTest` for debug-level per-element logging.
+- `io.bluetape4k.junit5.coroutines.runSuspendIO` is the test runner in flow/coroutine tests.
+- `@Tailable` cursor exposed as `Flux<Person>` can be bridged to `Flow` with backpressure.
+
+### `spring-data/mongodb-transactions`
+
+- `@Transactional suspend fun` with `ReactiveMongoTransactionManager` works because
+  `kotlinx-coroutines-reactor` bridges Reactor Context (session) into coroutine context via
+  `ReactorContext` element.
+- `io.bluetape4k.support.uninitialized()` replaces `lateinit var` for `@Autowired` test fields.
+- Coroutine cancellation during `@Transactional suspend fun` triggers rollback — Spring AOP
+  detects `CancellationException` and aborts the transaction.
+
+### Vertx modules (보강)
+
+- `CoroutineVerticle` scope cancellation on undeploy cancels all child `launch { }` coroutines.
+- `coAwait()` cancellation propagates to the underlying Vert.x `Future` — aborts in-flight
+  DB queries and HTTP requests, returning resources to their pools.
+- `vertx.dispatcher()` in `coroutineContext` keeps Vert.x API calls on the event loop thread.
+
+## Documentation Principles Applied
+
+1. **Real code grounding**: import analysis — no fabricated APIs.
+2. **Honest Before/After**: Before shows standard library approach; After shows bluetape4k benefit.
+3. **Korean section headers**: preserved existing Korean style per workspace CLAUDE.md policy.
+4. **Additive for vertx**: existing vertx tables/Before-After preserved; Mermaid and cancellation
+   sections added without disturbing the content already written in issue #86.

--- a/spring-data/mongodb-coroutines/README.md
+++ b/spring-data/mongodb-coroutines/README.md
@@ -14,9 +14,34 @@ MongoDB 관련 작업을 `Spring Data Mongo` 와 Kotlin Coroutines 으로 수행
 
 * [Spring Data MongoDB - Reactive examples](https://github.com/spring-projects/spring-data-examples/tree/main/mongodb/reactive)
 
+## 처리 흐름
+
+```mermaid
+sequenceDiagram
+    participant Test
+    participant Repo as CoroutineCrudRepository
+    participant ReactiveOps as ReactiveMongoOperations
+    participant Mongo as MongoDB (Testcontainers)
+
+    Test->>Repo: findPersonByFirstname(name): Person? (suspend)
+    Repo->>ReactiveOps: Mono publisher (findOne)
+    ReactiveOps->>Mongo: query
+    Mongo-->>ReactiveOps: document
+    ReactiveOps-->>Repo: Mono<Person>
+    Repo-->>Test: Person? (awaitSingleOrNull — suspend)
+
+    Test->>Repo: findAllByFirstname(name): Flow<Person>
+    Repo->>ReactiveOps: Flux publisher (find)
+    ReactiveOps->>Mongo: query (tailable / regular)
+    Mongo-->>ReactiveOps: documents (backpressure)
+    ReactiveOps-->>Repo: Flux<Person>
+    Repo-->>Test: Flow<Person> (asFlow — backpressure-aware)
+    Test->>Test: flow.toList() — collected under coroutine scope
+```
+
 ## 설명
 
-## Value defaulting on entity construction
+### Value defaulting on entity construction
 
 Kotlin allows defaulting for constructor- and method arguments.
 Defaulting allows usage of substitute values if a field in the document is absent or simply `null`.
@@ -32,51 +57,32 @@ val walter = operations.findOne<Document>(query(where("lastname").isEqualTo("Whi
 assertThat(walter.firstname).isEqualTo("Walter")
 ```
 
-## Kotlin Extensions
+### Kotlin Extensions
 
 Spring Data exposes methods accepting a target type to either query for or to project results values on.
-Kotlin represents classes with its own type, `KClass` which can be an obstacle when attempting to obtain a Java `Class`
-type.
+Kotlin represents classes with its own type, `KClass` which can be an obstacle when attempting to obtain a Java `Class` type.
 
-Spring Data ships with extensions that add overloads for methods accepting a type parameter by either leveraging
-generics or accepting `KClass` directly.
+Spring Data ships with extensions that add overloads for methods accepting a type parameter by either leveraging generics or accepting `KClass` directly.
 
 ```kotlin
 operations.getCollectionName<Person>()
-
 operations.getCollectionName(Person::class)
 ```
 
-## Nullability
+### Nullability
 
 Declaring repository interfaces using Kotlin allows expressing nullability constraints on arguments and return types.
-Spring Data evaluates nullability of arguments and return types and reacts to these. Passing `null` to a non-nullable
-argument raises an `IllegalArgumentException`, as you're already used to from Kotlin. Spring Data helps you also to
-prevent `null` in query results. If you wish to return a nullable result, use Kotlin's nullability marker `?`. To
-prevent `null` results, declare the return type of a query method as non-nullable. In the case a query yields no result,
-a non-nullable query method throws `EmptyResultDataAccessException`.
+Spring Data evaluates nullability of arguments and return types and reacts to these. Passing `null` to a non-nullable argument raises an `IllegalArgumentException`. Spring Data helps you also to prevent `null` in query results. If you wish to return a nullable result, use Kotlin's nullability marker `?`.
 
 ```kotlin
 interface PersonRepository: CrudRepository<Person, String> {
-
-    /**
-     * Query method declaring a nullable return type that allows to return null values.
-     */
     fun findOneOrNoneByFirstname(firstname: String): Person?
-
-    /**
-     * Query method declaring a nullable argument.
-     */
     fun findNullableByFirstname(firstname: String?): Person?
-
-    /**
-     * Query method requiring a result. Throws [org.springframework.dao.EmptyResultDataAccessException] if no result is found.
-     */
     fun findOneByFirstname(firstname: String): Person
 }
 ```
 
-## Type-Safe Kotlin Mongo Query DSL
+### Type-Safe Kotlin Mongo Query DSL
 
 Using the `Criteria` extensions allows to write type-safe queries via an idiomatic API.
 
@@ -84,16 +90,123 @@ Using the `Criteria` extensions allows to write type-safe queries via an idiomat
 operations.find<Person>(Query(Person::firstname isEqualTo "Tyrion"))
 ```
 
-## Coroutines and Flow support
+### Coroutines and Flow support
 
 ```kotlin
-runBlocking {
-    operations.find<Person>(Query(where("firstname").isEqualTo("Tyrion"))).awaitSingle()
+// suspend 함수로 단일 결과 조회
+val person = operations.findAll<Person>().awaitSingle()
+
+// Flow로 스트리밍 조회 (backpressure 지원)
+val persons = operations.findAll<Person>().asFlow().toList()
+```
+
+## 사용된 bluetape4k 기능
+
+| 기능 | 아티팩트 | 코드 위치 | 이점 |
+|---|---|---|---|
+| `MongoDBServer.Launcher.mongoDB` | `bluetape4k-testcontainers` | `MongoClientConfig.kt`, `ReactiveMongoConfig.kt` | Testcontainers MongoDB 싱글톤 — JVM 전체에서 컨테이너 한 번만 기동 |
+| `KLoggingChannel` | `bluetape4k-logging` | 모든 companion object | 코루틴 컨텍스트 포함 구조적 로깅 |
+| `runSuspendIO { }` | `bluetape4k-junit5` | `FlowAndCoroutineTest` | `Dispatchers.IO`에서 suspend 테스트 실행 — IO 블로킹 없이 코루틴 테스트 |
+| `Flow.log("label")` | `bluetape4k-coroutines` | `FlowAndCoroutineTest` | Flow 각 요소에 구조적 로그 출력 — 디버깅/추적 단순화 |
+| `Fakers.faker` | `bluetape4k-junit5` | `AbstractMongodbTest` | 테스트 데이터 생성기 — 재사용 가능한 fake 인스턴스 제공 |
+| `shouldBeEqualTo` | `bluetape4k-core` | 테스트 전체 | 가독성 높은 단언문 |
+
+## bluetape4k Before / After
+
+### `MongoDBServer.Launcher` vs 직접 컨테이너 생성
+
+```kotlin
+// Before — 테스트 클래스마다 새 MongoDBContainer 기동
+@Testcontainers
+class MyTest {
+    companion object {
+        @Container
+        val mongo = MongoDBContainer("mongo:6.0")  // 매번 새 컨테이너
+    }
+}
+
+// After — bluetape4k 싱글톤 런처 (JVM 전체에서 하나의 컨테이너 재사용)
+class MongoClientConfig: AbstractMongoClientConfiguration() {
+    override fun configureClientSettings(builder: MongoClientSettings.Builder) {
+        builder.applyConnectionString(
+            ConnectionString(MongoDBServer.Launcher.mongoDB.connectionString)
+        )  // 이미 기동된 인스턴스를 반환 — 컨테이너 재기동 없음
+    }
 }
 ```
 
+### `Flow.log("label")` vs 수동 로깅
+
 ```kotlin
-runBlocking {
-    operations.findAll<Person>().asFlow().toList()
+// Before — 각 요소에 로그를 찍으려면 onEach + 수동 로그 호출
+val persons = operations.findAll<Person>()
+    .asFlow()
+    .onEach { log.debug { "person=$it" } }
+    .toList()
+
+// After — bluetape4k Flow.log() (구조적 로그 자동)
+val persons = operations.findAll<Person>().asFlow()
+    .log("persons")   // 각 emit/complete/error 자동 로깅
+    .toList()
+```
+
+### `runSuspendIO { }` vs runBlocking + Dispatchers.IO
+
+```kotlin
+// Before — 테스트에서 IO 디스패처 지정 및 블로킹 래핑
+@Test
+fun `find person`() {
+    runBlocking(Dispatchers.IO) {
+        val person = operations.insert<Person>().one(newPerson()).awaitSingle()
+        // ...
+    }
 }
+
+// After — bluetape4k runSuspendIO (JUnit 5 확장 + IO 디스패처 내장)
+@Test
+fun `find person`() = runSuspendIO {
+    val person = operations.insert<Person>().one(newPerson()).awaitSingle()
+    // 테스트 컨텍스트에서 바로 suspend 함수 호출 가능
+}
+```
+
+## 취소·구조적 동시성·컨텍스트 전파
+
+### `CoroutineCrudRepository` Flow와 취소 전파
+
+`PersonCoroutineRepository.findAllByFirstname()` 이 반환하는 `Flow<Person>` 은
+Reactor `Flux`를 `asFlow()` 로 변환한 것입니다. 코루틴 스코프가 취소되면 upstream `Flux`
+구독도 즉시 취소되어 MongoDB 커서가 반환됩니다.
+
+```kotlin
+val job = launch {
+    repository.findAllByFirstname("Tyrion")   // Flow<Person>
+        .collect { person ->
+            // 이 collect가 실행 중 job.cancel() 호출 시
+            // Flow 수집 중단 + MongoDB 커서 자동 해제
+        }
+}
+delay(50)
+job.cancel()   // 취소 신호가 Flow → Flux → MongoDB 커서까지 전파됨
+```
+
+### `@Tailable` 커서와 백프레셔
+
+`PersonCoroutineRepository.findWithTailableCursorBy()` 는 MongoDB tailable 커서를
+`Flux<Person>` 으로 노출합니다. 이를 `.asFlow()` 로 변환하면 코루틴 백프레셔
+(`buffer`, `conflate` 연산자)를 활용해 소비 속도를 제어할 수 있습니다.
+
+```kotlin
+repository.findWithTailableCursorBy()
+    .asFlow()
+    .buffer(capacity = 10)          // 최대 10개 버퍼링
+    .collect { person ->
+        processSlowly(person)       // 소비가 느려도 tailable 커서가 대기
+    }
+```
+
+## 빌드 및 테스트
+
+```bash
+./gradlew :spring-data-mongodb-coroutines:test
 ```

--- a/spring-data/mongodb-transactions/README.md
+++ b/spring-data/mongodb-transactions/README.md
@@ -12,117 +12,227 @@ MongoDB 관련 작업을 `Spring Data Mongo` 와 Kotlin Coroutines 으로 수행
 
 * [Spring Data MongoDB - Transaction sample](https://github.com/spring-projects/spring-data-examples/tree/main/mongodb/transactions/README.md)
 
+## 처리 흐름
+
+```mermaid
+sequenceDiagram
+    participant Test
+    participant Service as CoroutineManagedTransitionService
+    participant Repo as CoroutineProcessRepository
+    participant ReactiveOps as ReactiveMongoOperations
+    participant TxMgr as ReactiveMongoTransactionManager
+    participant DB as MongoDB (Testcontainers Replica Set)
+
+    Test->>Service: run(id) — @Transactional suspend
+    Service->>TxMgr: begin transaction (ClientSession)
+    TxMgr-->>Service: Reactor Context (session bound)
+
+    Service->>Repo: findById(id) — suspend
+    Repo->>DB: query (within session)
+    DB-->>Repo: Process document
+    Repo-->>Service: Process
+
+    Service->>ReactiveOps: update state → ACTIVE
+    ReactiveOps->>DB: update (within session)
+
+    alt verify() 성공 (id % 3 != 0)
+        Service->>ReactiveOps: update state → DONE
+        ReactiveOps->>DB: update (within session)
+        Service->>TxMgr: commit
+        TxMgr-->>Test: State.DONE
+    else verify() 실패 (id % 3 == 0)
+        Service->>TxMgr: rollback (IllegalStateException)
+        TxMgr->>DB: rollback → State remains CREATED
+        TxMgr-->>Test: IllegalStateException
+    end
+```
+
 ## 설명
 
-## Running the Sample
+### Running the Sample
 
-The sample uses multiple embedded MongoDB processes in
-a [MongoDB replica set](https://docs.mongodb.com/manual/replication/).
-It contains test for both the synchronous and the reactive transaction support in the `sync` / `reactive` packages.
+The sample uses a MongoDB Testcontainers container.
+It contains tests for synchronous, reactive, and coroutine transaction support
+in the `imperative` / `reactive` / `coroutine` packages.
 
-You may run the examples directly from your IDE or use maven on the command line.
+### Sync Transactions
 
-**INFO:** The operations to download the required MongoDB binaries and spin up the cluster can take some time. Please
-be patient.
+`MongoTransactionManager` is the gateway to the well known Spring transaction support.
+The `MongoTransactionManager` binds a `ClientSession` to the thread.
 
-## Sync Transactions
-
-`MongoTransactionManager` is the gateway to the well known Spring transaction support. It lets applications use
-[the managed transaction features of Spring](http://docs.spring.io/spring/docs/{springVersion}/spring-framework-reference/data-access.html#transaction).
-The `MongoTransactionManager` binds a `ClientSession` to the thread. `MongoTemplate` detects the session and operates
-on these resources which are associated with the transaction accordingly. `MongoTemplate` can also participate in
-other, ongoing transactions.
-
-```java
-
-@Configuration
-static class Config extends AbstractMongoConfiguration {
-
-    @Bean
-    MongoTransactionManager transactionManager(MongoDbFactory dbFactory) {
-        return new MongoTransactionManager(dbFactory);
-    }
-
-    // ...
-}
-
-@Component
-public class TransitionService {
-
+```kotlin
+@Service
+class TransitionService {
     @Transactional
-    public void run(Integer id) {
-
-        Process process = lookup(id);
-
-        if (!State.CREATED.equals(process.getState())) {
-            return;
-        }
-
-        start(process);
-        verify(process);
-        finish(process);
+    fun run(id: Int) {
+        val process = lookup(id)
+        if (process.state != State.CREATED) return
+        start(process)
+        verify(process)
+        finish(process)
     }
 }
 ```
 
-## Programmatic Reactive transactions
+### Programmatic Reactive Transactions
 
-`ReactiveMongoTemplate` offers dedicated methods (like `inTransaction()`) for operating within a transaction without
-having to worry about the
-commit/abort actions depending on the operations outcome.
+`ReactiveMongoTemplate` offers dedicated methods (like `inTransaction()`) for operating within a transaction.
 
-**NOTE:** Please note that you cannot preform meta operations, like collection creation within a transaction.
-
-```java
-
+```kotlin
 @Service
-public class ReactiveTransitionService {
-
-    public Mono<Integer> run(Integer id) {
-
-        return template.inTransaction().execute(action -> {
-
-            return lookup(id) //
-                    .filter(State.CREATED::equals)
-                    .flatMap(process -> start(action, process))
-                    .flatMap(this::verify)
-                    .flatMap(process -> finish(action, process));
-
-        }).next().map(Process::getId);
-    }
+class ReactiveTransitionService {
+    fun run(id: Int): Mono<Int> =
+        template.inTransaction().execute { action ->
+            lookup(id)
+                .filter { State.CREATED == it.state }
+                .flatMap { process -> start(action, process) }
+                .flatMap { this::verify }
+                .flatMap { process -> finish(action, process) }
+        }.next().map { it.id }
 }
 ```
 
-## Declarative Reactive transactions
+### Declarative Reactive Transactions
 
-`ReactiveMongoTransactionManager` is the gateway to the reactive Spring transaction support. It lets applications use
-[the managed transaction features of Spring](http://docs.spring.io/spring/docs/{springVersion}/spring-framework-reference/data-access.html#transaction).
-The `ReactiveMongoTransactionManager` adds the `ClientSession` to
+`ReactiveMongoTransactionManager` adds the `ClientSession` to
 the `reactor.util.context.Context`. `ReactiveMongoTemplate` detects the session and operates
-on these resources which are associated with the transaction accordingly.
+on these resources accordingly.
 
-```java
-@EnableTransactionManagement
-class Config extends AbstractReactiveMongoConfiguration {
+### Coroutine Transactions
 
-	@Bean
-	ReactiveTransactionManager transactionManager(ReactiveMongoDatabaseFactory factory) {
-		return new ReactiveMongoTransactionManager(factory);
-	}
-	
-	// ...
+`CoroutineManagedTransitionService`는 `@Transactional suspend fun` 과
+`ReactiveMongoTransactionManager` 를 조합합니다.
+`kotlinx-coroutines-reactor`의 `ReactorContext` 가 Reactor Context (트랜잭션 세션)를
+코루틴 컨텍스트와 자동으로 연결합니다.
+
+```kotlin
+@Service
+class CoroutineManagedTransitionService(
+    private val repository: CoroutineProcessRepository,
+    private val operations: ReactiveMongoOperations,
+) {
+    @Transactional
+    suspend fun run(id: Int) {
+        val process = lookup(id)
+        if (process.state != State.CREATED) return
+        start(process)   // update → ACTIVE
+        verify(process)  // throws on id % 3 == 0 → triggers rollback
+        finish(process)  // update → DONE
+    }
+}
+```
+
+## 사용된 bluetape4k 기능
+
+| 기능 | 아티팩트 | 코드 위치 | 이점 |
+|---|---|---|---|
+| `MongoDBServer.Launcher.mongoDB` | `bluetape4k-testcontainers` | `AbstractMongodbTest` | Testcontainers MongoDB 싱글톤 — 레플리카 셋 포함 JVM 전체 공유 |
+| `KLoggingChannel` | `bluetape4k-logging` | `CoroutineManagedTransitionService`, 테스트 | 코루틴 컨텍스트 포함 구조적 로깅 |
+| `log.debug { }` / `log.warn { }` | `bluetape4k-logging` | 테스트 전체 | 람다 기반 지연 평가 로그 메시지 — 비활성 레벨에서 문자열 생성 없음 |
+| `uninitialized()` | `bluetape4k-core` | 테스트 전체 | `@Autowired` 필드의 lateinit 대체 — 타입 안전 초기화 마커 |
+| `shouldBeEqualTo`, `shouldNotBeNull` | `bluetape4k-core` | 테스트 전체 | 가독성 높은 단언문 |
+| `Fakers.faker` | `bluetape4k-junit5` | `AbstractMongodbTest` | 테스트 데이터 생성기 — 재사용 가능한 fake 인스턴스 |
+
+## bluetape4k Before / After
+
+### `MongoDBServer.Launcher` vs 직접 컨테이너 생성
+
+```kotlin
+// Before — AbstractReactiveMongoConfiguration에서 직접 MongoClient 생성
+class TestConfig: AbstractReactiveMongoConfiguration() {
+    @Bean
+    override fun reactiveMongoClient(): MongoClient {
+        // 직접 연결 문자열 관리 — 포트 충돌, 클린업 책임
+        return MongoClients.create("mongodb://localhost:27017")
+    }
 }
 
+// After — bluetape4k 싱글톤 런처 (클린업 자동)
+abstract class AbstractMongodbTest {
+    companion object: KLoggingChannel() {
+        val mongodb by lazy { MongoDBServer.Launcher.mongoDB }
+        fun createReactiveMongoClient() =
+            MongoClients.create(mongodb.url)  // 한 번 기동된 인스턴스 재사용
+    }
+}
+```
 
-@Service
-class ReactiveManagedTransitionService {
+### `uninitialized()` vs lateinit var
 
-	@Transactional
-	public Mono<Integer> run(Integer id) {
+```kotlin
+// Before — lateinit var (초기화 전 접근 시 UnitializedPropertyAccessException)
+@Autowired
+private lateinit var managedTransitionService: CoroutineManagedTransitionService
 
-		return lookup(id)
-				.flatMap(process -> start(template, process))
-				.flatMap(it -> verify(it)) //
-				.flatMap(process -> finish(template, process))
-				.map(Process::getId);
-	}
+// After — bluetape4k uninitialized() (타입 안전 마커, 명시적 의도 표현)
+@Autowired
+private val managedTransitionService: CoroutineManagedTransitionService = uninitialized()
+```
+
+### `@Transactional suspend fun` vs Reactor 체이닝 트랜잭션
+
+```kotlin
+// Before — Reactor 방식 (flatMap 체이닝으로 트랜잭션 구성)
+fun run(id: Int): Mono<Int> =
+    template.inTransaction().execute { action ->
+        lookup(id)
+            .filter { State.CREATED == it.state }
+            .flatMap { start(action, it) }
+            .flatMap { verify(it) }
+            .flatMap { finish(action, it) }
+    }.next().map { it.id }
+
+// After — 코루틴 방식 (@Transactional suspend fun, 순차 코드)
+@Transactional
+suspend fun run(id: Int) {
+    val process = lookup(id)
+    if (process.state != State.CREATED) return
+    start(process)    // 예외 발생 시 자동 rollback
+    verify(process)   // id % 3 == 0 → IllegalStateException → rollback
+    finish(process)
+}
+```
+
+## 취소·구조적 동시성·컨텍스트 전파
+
+### `@Transactional` + 코루틴 컨텍스트
+
+`ReactiveMongoTransactionManager`는 트랜잭션 세션을 Reactor `Context` 에 저장합니다.
+`kotlinx-coroutines-reactor`는 `ReactorContext` 요소를 통해 이 Context 를
+코루틴 컨텍스트와 연결하므로, `@Transactional suspend fun` 내부에서 호출된
+모든 `awaitSingle()` / `awaitFirst()` 이 동일 세션에서 실행됩니다.
+
+### 코루틴 취소와 트랜잭션 롤백
+
+`@Transactional suspend fun` 실행 중 코루틴이 취소되면 (예: timeout 또는 부모 스코프 취소),
+Spring AOP 트랜잭션 인터셉터가 `CancellationException` 을 감지하고 롤백을 수행합니다.
+
+```kotlin
+// 타임아웃으로 인한 취소 → 트랜잭션 자동 롤백
+withTimeout(500) {
+    service.run(processId)  // 500ms 초과 시 CancellationException → rollback
+}
+```
+
+### 테스트에서의 검증 패턴
+
+```kotlin
+@Test
+fun `coroutine transaction commit and rollback`() = runTest {
+    repeat(10) {
+        val process = managedTransitionService.newProcess()
+        try {
+            managedTransitionService.run(process.id)
+            stateInDb(process) shouldBeEqualTo State.DONE       // 커밋 확인
+        } catch (e: IllegalStateException) {
+            stateInDb(process) shouldBeEqualTo State.CREATED    // 롤백 확인
+        }
+    }
+}
+```
+
+## 빌드 및 테스트
+
+```bash
+./gradlew :spring-data-mongodb-transactions:test
+```

--- a/spring-data/r2dbc-examples/README.md
+++ b/spring-data/r2dbc-examples/README.md
@@ -14,7 +14,7 @@
 * [Spring Data R2DBC and Kotlin Coroutines](https://xebia.com/blog/spring-data-r2dbc-and-kotlin-coroutines/)
 * [Kotlin + Spring Webflux + R2DBC](https://dgahn.tistory.com/8)
 
-This projects shows some sample usage of the work-in-progress R2DBC support for Spring Data.
+This project shows some sample usage of the work-in-progress R2DBC support for Spring Data.
 
 ### Interesting bits to look at
 
@@ -39,32 +39,131 @@ An `Example` takes a data object (usually the entity object or a subtype of it) 
 properties.
 You can use Query by Example with Repositories.
 
-```java
-interface PersonRepository extends ReactiveCrudRepository<Person, Long>, ReactiveQueryByExampleExecutor<Person> {
+```kotlin
+interface PersonRepository:
+    CoroutineCrudRepository<Person, Long>,
+    CoroutineQueryByExampleExecutor<Person>
+
+val example = Example.of(Person("", "Snow", 0))
+repository.findAll(example).toList()
+
+val matcher = ExampleMatcher.buildExampleMatcher(Person::lastname.name)
+    .withMatcher(Person::lastname.name, GenericPropertyMatchers.exact())
+    .withIgnoreNullValues()
+val example = Example.of(Person("", "White", 0), matcher)
+repository.count(example)
+```
+
+## 처리 흐름
+
+```mermaid
+sequenceDiagram
+    participant Test
+    participant CoroutineRepo as CoroutineCrudRepository
+    participant R2DBC as R2DBC Driver (H2)
+    participant DB as In-Memory H2
+
+    Test->>CoroutineRepo: findAll() : Flow<Customer>
+    CoroutineRepo->>R2DBC: SELECT (reactive publisher)
+    R2DBC-->>CoroutineRepo: Flux<Row>
+    CoroutineRepo-->>Test: Flow<Customer> (backpressure-aware)
+    Test->>Test: flow.toList() — collect under coroutine scope
+
+    Test->>CoroutineRepo: save(customer) — suspend
+    CoroutineRepo->>R2DBC: INSERT (Mono publisher)
+    R2DBC->>DB: execute SQL
+    DB-->>R2DBC: rows updated
+    R2DBC-->>CoroutineRepo: Mono<Customer>
+    CoroutineRepo-->>Test: Customer (suspend, no callback)
+```
+
+## 사용된 bluetape4k 기능
+
+| 기능 | 아티팩트 | 코드 위치 | 이점 |
+|---|---|---|---|
+| `connectionFactoryInitializer { }` | `bluetape4k-r2dbc` | `ApplicationConfiguration.kt` | `ConnectionFactoryInitializer` 생성 DSL — 보일러플레이트 설정 코드 축소 |
+| `buildExampleMatcher(vararg props)` | `bluetape4k-spring-boot4-r2dbc` | `PersonRepositoryIntegrationTest` | QBE `ExampleMatcher` DSL — 프로퍼티명 문자열 없이 타입 안전하게 매처 구성 |
+| `asLong()` / `toUtf8Bytes()` | `bluetape4k-core` | `ApplicationConfiguration.kt` | `Row` 컬럼 값 변환 / 문자열 → UTF-8 바이트 변환 확장 함수 |
+| `KLoggingChannel` | `bluetape4k-logging` | 모든 companion object | 코루틴 컨텍스트 포함 구조적 로깅 |
+| `shouldBeEqualTo`, `shouldNotBeNull` | `bluetape4k-core` | 테스트 전체 | 가독성 높은 단언문 (`shouldBeEqualTo`, `shouldContainSame` 등) |
+
+## bluetape4k Before / After
+
+### `connectionFactoryInitializer { }` vs 직접 빈 생성
+
+```kotlin
+// Before — 표준 Spring R2DBC 방식 (빈 생성 직접 작성)
+@Bean
+fun initializer(connectionFactory: ConnectionFactory): ConnectionFactoryInitializer {
+    val initializer = ConnectionFactoryInitializer()
+    initializer.setConnectionFactory(connectionFactory)
+    val populator = ResourceDatabasePopulator()
+    populator.addScript(ClassPathResource("schema.sql"))
+    initializer.setDatabasePopulator(populator)
+    return initializer
+}
+
+// After — bluetape4k DSL (간결한 람다 빌더)
+@Bean
+fun initializer(connectionFactory: ConnectionFactory): ConnectionFactoryInitializer =
+    connectionFactoryInitializer(connectionFactory) {
+        setDatabasePopulator(ResourceDatabasePopulator(ByteArrayResource(sql.toUtf8Bytes())))
+    }
+```
+
+### `buildExampleMatcher` vs ExampleMatcher 직접 구성
+
+```kotlin
+// Before — 표준 ExampleMatcher (프로퍼티명 문자열 직접 입력)
+val matcher = ExampleMatcher.matching()
+    .withIgnorePaths("age")
+    .withMatcher("lastname", GenericPropertyMatchers.exact())
+    .withIgnoreNullValues()
+
+// After — bluetape4k buildExampleMatcher (타입 안전 프로퍼티 참조)
+val matcher = ExampleMatcher.buildExampleMatcher(Person::lastname.name)
+    .withMatcher(Person::lastname.name, GenericPropertyMatchers.exact())
+    .withIgnoreNullValues()
+```
+
+## 취소·구조적 동시성·컨텍스트 전파
+
+### R2DBC Flow와 코루틴 취소
+
+`CoroutineCrudRepository`의 `Flow` 반환 메서드는 코루틴 취소 신호를 R2DBC 발행자에 전파합니다.
+테스트에서 `runTest { }` 블록이 시간 초과되거나 예외가 발생하면, `Flow<Customer>`를 수집하던 구독이 자동으로 취소되어
+DB 커넥션 풀에 커넥션이 반환됩니다.
+
+```kotlin
+// Flow 취소 전파 예시
+runTest {
+    val job = launch {
+        repository.findAll()        // Flux → Flow 변환
+            .collect { customer ->
+                // 이 collect 람다가 실행 중일 때 job.cancel() 호출 시
+                // R2DBC 구독이 즉시 취소되고 커넥션이 풀에 반환됨
+            }
+    }
+    delay(100)
+    job.cancel()  // → R2DBC upstream Flux도 취소됨
 }
 ```
 
-```java
-Example<Person> example = Example.of(new Person("Jon", "Snow"));
-        repo.
+### `@Transactional` + 코루틴 컨텍스트 전파
 
-findAll(example);
+`TransactionalService`는 `@Transactional suspend fun` 을 사용합니다.
+Spring R2DBC는 Reactor Context를 통해 트랜잭션 컨텍스트를 전파하며,
+`kotlinx-coroutines-reactor`의 `ReactorContext` 요소가 이를 코루틴 컨텍스트와 연결합니다.
 
-
-ExampleMatcher matcher = ExampleMatcher.matching().
-        .
-
-withMatcher("firstname",endsWith())
-        .
-
-withMatcher("lastname",startsWith().
-
-ignoreCase());
-
-Example<Person> example = Example.of(new Person("Jon", "Snow"), matcher);
-        repo.
-
-count(example);
+```kotlin
+// TransactionalService.kt
+@Transactional
+suspend fun insert(customer: Customer): Customer =
+    repository.save(customer)  // 동일 트랜잭션 컨텍스트에서 실행
 ```
 
-This example contains shows the usage with `PersonRepositoryIntegrationTests`.
+## 빌드 및 테스트
+
+```bash
+./gradlew :spring-data-r2dbc-examples:test
+```

--- a/vertx/coroutines/README.md
+++ b/vertx/coroutines/README.md
@@ -6,6 +6,25 @@ Vert.x 를 Kotlin Coroutines 와 함께 사용하는 예제입니다.
 
 ![coroutines Sequence Flow diagram](../../docs/images/readme-diagrams/vertx-coroutines-sequence-01.png)
 
+```mermaid
+sequenceDiagram
+    participant Client as HTTP Client
+    participant Router as Vert.x Router
+    participant Handler as suspendHandler { }
+    participant Pool as JDBCPool
+    participant DB as H2 In-Memory
+
+    Client->>Router: GET /movie/:id
+    Router->>Handler: RoutingContext (suspend lambda)
+    Handler->>Pool: preparedQuery(...).execute(tuple).coAwait()
+    Note over Handler,Pool: Future<RowSet> → suspend (non-blocking)
+    Pool->>DB: SQL query
+    DB-->>Pool: RowSet
+    Pool-->>Handler: RowSet (resumed)
+    Handler-->>Router: ctx.response().end(json)
+    Router-->>Client: 200 OK + JSON
+```
+
 ## Vert.x 코루틴 통합 설명
 
 `CoroutineVerticle`을 상속하면 Vert.x 이벤트 루프 위에서 `suspend` 함수를 직접 사용할 수 있습니다.
@@ -104,6 +123,66 @@ fun `test route`(vertx: Vertx, testContext: VertxTestContext) = runSuspendTest {
     vertx.withSuspendTestContext(testContext) {
         vertx.deployVerticle(MainVerticle()).coAwait()
         // 순차 코드로 테스트 작성 — 예외 시 testContext.failNow() 자동 호출
+    }
+}
+```
+
+## 취소·구조적 동시성·컨텍스트 전파
+
+### `CoroutineVerticle` 스코프와 언디플로이
+
+`CoroutineVerticle` 은 `CoroutineScope` 를 구현합니다.
+`Verticle`이 언디플로이되면 해당 스코프가 취소되어, `start()` 내부에서 시작된
+모든 자식 코루틴이 즉시 취소됩니다. 이를 통해 구조적 동시성 (structured concurrency) 이 보장됩니다.
+
+```kotlin
+class MainVerticle: CoroutineVerticle() {
+    override suspend fun start() {
+        // 이 스코프(CoroutineVerticle)가 취소되면
+        // launch { ... } 자식 코루틴도 모두 취소됨
+        launch {
+            // 백그라운드 작업 (예: 주기적 캐시 갱신)
+        }
+        // Router 등록 ...
+    }
+}
+// vertx.undeploy(deploymentId) → MainVerticle 스코프 취소 → launch 블록 취소
+```
+
+### `coAwait()` 취소 동작
+
+`Future<T>.coAwait()` 는 코루틴이 취소되면 Vert.x `Future` 를 즉시 취소합니다.
+DB 쿼리 대기 중 HTTP 연결이 끊어져도 커넥션 풀에 커넥션이 정상 반환됩니다.
+
+```kotlin
+router.get("/movie/:id").suspendHandler { ctx ->
+    // 이 suspend 블록 실행 중 ctx.request()가 abort되면
+    // pool.preparedQuery(...).execute(...).coAwait() 가 CancellationException 발생
+    // → JDBCPool 커넥션 자동 반환
+    val rows = pool.preparedQuery("SELECT TITLE FROM MOVIE WHERE ID=?")
+        .execute(Tuple.of(ctx.pathParam("id")))
+        .coAwait()
+    ctx.response().end(Json.obj { }.encode())
+}
+```
+
+### `vertx.dispatcher()` 컨텍스트 전파
+
+`CoroutineVerticle` 내부에서는 `coroutineContext` 에 `vertx.dispatcher()` 가 포함되어
+Vert.x 이벤트 루프 스레드에서 코루틴이 실행됩니다.
+`withContext(vertx.dispatcher())` 를 명시적으로 사용하면 이벤트 루프를 벗어난 컨텍스트에서
+Vert.x API를 안전하게 호출할 수 있습니다.
+
+```kotlin
+// 다른 디스패처에서 Vert.x API 호출이 필요할 때
+suspend fun queryAndRespond(ctx: RoutingContext) {
+    val result = withContext(Dispatchers.IO) {
+        // 블로킹 I/O 처리
+        blockingComputation()
+    }
+    // Vert.x 이벤트 루프로 복귀하여 응답
+    withContext(vertx.dispatcher()) {
+        ctx.response().end(result)
     }
 }
 ```

--- a/vertx/vertx-sqlclient/README.md
+++ b/vertx/vertx-sqlclient/README.md
@@ -4,6 +4,36 @@
 
 ![Reactive SQL diagram](../../docs/images/readme-diagrams/vertx-vertx-sqlclient-sequence-01.png)
 
+```mermaid
+sequenceDiagram
+    participant Test
+    participant Helper as withSuspendTransaction { }
+    participant Pool as JDBCPool / MySQLPool
+    participant Conn as SqlConnection
+    participant DB as MySQL (Testcontainers)
+
+    Test->>Helper: pool.withSuspendTransaction { conn -> }
+    Helper->>Pool: begin transaction
+    Pool->>DB: START TRANSACTION
+    DB-->>Pool: OK
+    Pool-->>Helper: SqlConnection
+
+    Helper->>Conn: conn.query(...).execute().coAwait()
+    Conn->>DB: SQL (within transaction)
+    DB-->>Conn: RowSet
+    Conn-->>Helper: RowSet (suspended resume)
+
+    alt 정상 완료
+        Helper->>Pool: commit
+        Pool->>DB: COMMIT
+        DB-->>Test: success
+    else 예외 발생
+        Helper->>Pool: rollback
+        Pool->>DB: ROLLBACK
+        DB-->>Test: exception re-thrown
+    end
+```
+
 [Vert.x Sql Client](https://vertx.io/docs/vertx-sql-client/java/) 와
 [MyBatis Dynamic SQL](https://mybatis.org/mybatis-dynamic-sql/docs/introduction.html) 을
 사용하여 Async/Non-Blocking 방식으로 데이터베이스를 사용하는 예제입니다.
@@ -118,4 +148,54 @@ abstract class AbstractSqlClientTest {
         val mysql = MySQL8Server.Launcher.mysql  // 이미 기동된 인스턴스 반환
     }
 }
+```
+
+## 취소·구조적 동시성·컨텍스트 전파
+
+### `withSuspendTransaction { }` 취소와 자동 롤백
+
+트랜잭션 블록 실행 중 코루틴이 취소되면 `withSuspendTransaction` 은 롤백을 수행합니다.
+예를 들어 부모 스코프가 타임아웃으로 취소되거나 HTTP 클라이언트가 연결을 끊어도
+DB 커넥션이 정상적으로 트랜잭션 롤백 후 풀에 반환됩니다.
+
+```kotlin
+// 타임아웃으로 인한 취소 → 자동 롤백
+withTimeout(200) {
+    pool.withSuspendTransaction { conn ->
+        conn.query("INSERT INTO items VALUES (...)").execute().coAwait()
+        delay(500)  // 타임아웃 초과 → CancellationException
+        // 블록 종료 전 예외 발생 → 자동 ROLLBACK
+    }
+}
+// INSERT가 DB에 남지 않음
+```
+
+### `testWithSuspendTransaction` 테스트 격리 보장
+
+테스트 간 상태 오염을 방지하기 위해 `testWithSuspendTransaction` 은
+블록 완료 여부와 무관하게 항상 롤백합니다. 이로써 각 테스트는 독립적인 초기 상태를 보장받습니다.
+
+```kotlin
+@Test
+fun `데이터 삽입 테스트`(vertx: Vertx, testContext: VertxTestContext) = runSuspendIO {
+    vertx.testWithSuspendTransaction(testContext, pool) {
+        val rows = pool.preparedQuery("INSERT INTO users VALUES (?, ?)")
+            .execute(Tuple.of(1, "Alice"))
+            .coAwait()
+        rows.rowCount() shouldBeEqualTo 1
+        // 블록 완료 후 자동 롤백 → 다음 테스트에 영향 없음
+    }
+}
+```
+
+### Vert.x `Pool` 백프레셔
+
+`MySQLPool` / `JDBCPool` 은 최대 커넥션 수를 제한합니다.
+코루틴의 `coAwait()` 는 풀에 커넥션이 없을 때 비블로킹 대기 (backpressure) 를 수행합니다.
+스레드를 블로킹하지 않으므로 단일 이벤트 루프 스레드에서 수백 개의 동시 요청을 처리할 수 있습니다.
+
+## 빌드 및 테스트
+
+```bash
+./gradlew :vertx-vertx-sqlclient:test
 ```

--- a/vertx/vertx-webclient/README.md
+++ b/vertx/vertx-webclient/README.md
@@ -7,6 +7,23 @@ Spring의 WebClient와 비슷한 기능을 제공하지만, Reactor 를 사용�
 
 ![HTTP Request Processing diagram](../../docs/images/readme-diagrams/vertx-vertx-webclient-sequence-01.png)
 
+```mermaid
+sequenceDiagram
+    participant Caller as suspend caller
+    participant Client as WebClient
+    participant Future as Vert.x Future<HttpResponse>
+    participant Server as HTTP Server (CoroutineVerticle)
+
+    Caller->>Client: client.get(port, host, path).send()
+    Note over Client,Future: Returns Future<HttpResponse>
+    Client->>Future: Future (non-blocking)
+    Caller->>Future: .coAwait() — suspend (no thread blocked)
+    Future->>Server: HTTP GET request
+    Server-->>Future: HTTP response
+    Future-->>Caller: HttpResponse (resumed)
+    Caller->>Caller: response.body() — direct access
+```
+
 ## 주요 기능
 
 | 기능 | 설명 |
@@ -141,4 +158,69 @@ import io.bluetape4k.jackson3.Jackson
 
 val json = Jackson.defaultJsonMapper.writeValueAsString(user)
 val user = Jackson.defaultJsonMapper.readValue(json, User::class.java)
+```
+
+## 취소·구조적 동시성·컨텍스트 전파
+
+### `coAwait()` 취소와 HTTP 요청 중단
+
+`Future<T>.coAwait()` 는 코루틴 취소 신호를 수신하면 진행 중인 HTTP 요청을 중단합니다.
+클라이언트가 타임아웃으로 취소되거나 부모 스코프가 취소될 때 소켓 리소스가 즉시 반환됩니다.
+
+```kotlin
+// withTimeout으로 HTTP 요청에 타임아웃 적용
+withTimeout(500) {
+    val response = client
+        .get(port, "localhost", "/slow-endpoint")
+        .send()
+        .coAwait()   // 500ms 초과 시 CancellationException
+                     // → HTTP 요청 중단, 소켓 반환
+    response.body()
+}
+```
+
+### `CoroutineVerticle` 언디플로이와 WebClient 정리
+
+`CoroutineVerticle` 을 언디플로이하면 `CoroutineScope` 가 취소됩니다.
+`start()` 에서 시작된 자식 코루틴 (예: `launch { ... }`) 이 모두 취소되므로
+WebClient 요청이 진행 중이어도 스코프 취소 시 정상적으로 중단됩니다.
+
+```kotlin
+class CoroutineServer: CoroutineVerticle() {
+    private lateinit var client: WebClient
+
+    override suspend fun start() {
+        client = WebClient.create(vertx)
+        vertx.createHttpServer()
+            .requestHandler { ... }
+            .listen(9988)
+            .coAwait()
+    }
+
+    override suspend fun stop() {
+        client.close()   // 언디플로이 시 WebClient 명시적 정리
+    }
+}
+```
+
+### `suspendHandler` 내 컨텍스트 전파
+
+`suspendHandler { ctx -> }` 블록 내에서 `coroutineContext` 는 Vert.x 이벤트 루프의
+`vertx.dispatcher()` 를 포함합니다. 이를 통해 Vert.x API 호출 (예: `EventBus`, `FileSystem`) 이
+올바른 스레드에서 수행됨을 보장합니다.
+
+```kotlin
+router.get("/proxy").suspendHandler { ctx ->
+    // Vert.x dispatcher 컨텍스트에서 실행
+    val upstream = client.get(8081, "backend", "/data")
+        .send()
+        .coAwait()
+    ctx.response().end(upstream.body())   // 동일 이벤트 루프 스레드에서 응답
+}
+```
+
+## 빌드 및 테스트
+
+```bash
+./gradlew :vertx-vertx-webclient:test
 ```


### PR DESCRIPTION
## Summary

Closes #88

Strengthened 6 module READMEs with **Used bluetape4k Features** tables, **Before/After** code
snippets, **Mermaid sequence diagrams**, and **cancellation / structured concurrency / context
propagation** sections. No production code changes — documentation only.

## Changed Modules

| Module | Changes |
|---|---|
| `vertx/coroutines` | Mermaid sequence diagram + cancellation section |
| `vertx/vertx-sqlclient` | Mermaid sequence diagram + cancellation section |
| `vertx/vertx-webclient` | Mermaid sequence diagram + cancellation section |
| `spring-data/r2dbc-examples` | Full: bluetape4k table, Before/After, Mermaid, cancellation |
| `spring-data/mongodb-coroutines` | Full: bluetape4k table, Before/After, Mermaid, cancellation |
| `spring-data/mongodb-transactions` | Full: bluetape4k table, Before/After, Mermaid, cancellation |

## Key bluetape4k APIs Documented

- **vertx**: `suspendHandler`, `coAwait()`, `withSuspendTransaction`, `testWithSuspendTransaction`, `CoroutineVerticle` scope lifecycle
- **r2dbc-examples**: `connectionFactoryInitializer { }`, `buildExampleMatcher`, `KLoggingChannel`
- **mongodb-coroutines**: `MongoDBServer.Launcher.mongoDB`, `Flow.log()`, `runSuspendIO`
- **mongodb-transactions**: `MongoDBServer.Launcher`, `uninitialized()`, `@Transactional suspend fun` + rollback on `CancellationException`

## Lesson File

Added `docs/lessons/2026-05-24-issue-88-async-reactive-advanced.md` documenting findings and methodology.

## Verification

All documented APIs were verified against actual `import io.bluetape4k.*` statements in source files.
No fabricated API references.