### PR TITLE
feat: add messaging/transactional-outbox workshop for Transactional Outbox pattern (#99)

### DIFF
--- a/docs/lessons/2026-05-24-transactional-outbox-pattern.md
+++ b/docs/lessons/2026-05-24-transactional-outbox-pattern.md
@@ -1,0 +1,30 @@
+# Transactional Outbox Pattern — Issue #99
+
+## Context
+
+Adding a workshop example showing how to atomically publish domain events to Kafka using the Transactional Outbox pattern.
+
+## Problem
+
+Naive approach: write to DB then publish to Kafka — if Kafka fails after DB commit, the event is lost. If DB fails after Kafka send, duplicate events occur.
+
+## Solution (Outbox Pattern)
+
+1. Write domain state + outbox event in **one DB transaction**
+2. Background scheduler polls `outbox_events` table for PENDING events
+3. Publishes to Kafka, marks event PUBLISHED
+4. On failure: increment retryCount; after MAX_RETRY → DEAD_LETTER
+
+## Key Decisions
+
+- **`@MockkBean(relaxed = true)`** instead of `@MockkSpyBean` — Spring Boot auto-configured `KafkaTemplate` uses type erasure; spy cannot match `KafkaTemplate<String, String>` by exact generic type
+- **`tools.jackson.databind.ObjectMapper`** — Jackson 3.x changed package from `com.fasterxml.jackson` to `tools.jackson`; must import from correct package
+- **`@Bean fun objectMapper()`** — Spring Boot 4 starter (`webmvc.lib` alias) does not always auto-configure `tools.jackson.databind.ObjectMapper`; explicit bean avoids `UnsatisfiedDependencyException`
+- **Single `.where { cond1 and cond2 }`** — Exposed v1 `andWhere {}` returns a type that breaks `.map { it[...] }` receiver inference; combine all conditions in one `.where {}` block
+
+## Verification
+
+```
+7 tests passing (10.7s)
+./gradlew :messaging-transactional-outbox:test
+```

--- a/messaging/transactional-outbox/README.md
+++ b/messaging/transactional-outbox/README.md
@@ -1,0 +1,157 @@
+# Transactional Outbox Pattern — bluetape4k Workshop
+
+Demonstrates the **Transactional Outbox** pattern using Kotlin, Spring Boot 4, JetBrains Exposed, and Kafka.
+The pattern guarantees that domain state changes and the corresponding Kafka events are written atomically — no dual-write problem, no silent message loss.
+
+---
+
+## Architecture
+
+```mermaid
+sequenceDiagram
+    participant C  as Client
+    participant CT as OrderController
+    participant OS as OrderService
+    participant DB as PostgreSQL
+    participant SC as OutboxPublisher (Scheduler)
+    participant K  as Kafka
+
+    C->>CT: POST /api/orders
+    CT->>OS: placeOrder(customerId, product, qty)
+    OS->>DB: BEGIN TRANSACTION
+    OS->>DB: INSERT INTO orders (status=PENDING)
+    OS->>DB: INSERT INTO outbox_events (status=PENDING, payload=JSON)
+    OS->>DB: COMMIT
+    OS-->>CT: OrderResponse
+    CT-->>C: 201 Created
+
+    loop every 2 s
+        SC->>DB: SELECT id FROM outbox_events WHERE status IN (PENDING, FAILED)
+        SC->>SC: publishEvent(id) per row
+        SC->>DB: BEGIN TRANSACTION (REQUIRES_NEW)
+        SC->>K: KafkaTemplate.send("order-events", aggregateId, payload).get()
+        SC->>DB: UPDATE outbox_events SET status=PUBLISHED, processed_at=NOW()
+        SC->>DB: COMMIT
+    end
+```
+
+---
+
+## Problem / Solution
+
+### Before — Naive dual-write (broken)
+
+```kotlin
+// WRONG: two independent I/O operations — no atomicity guarantee
+orderRepository.save(order)          // succeeds
+kafkaTemplate.send("order-events", …) // crashes → event lost forever
+```
+
+If the process crashes between the two calls the Kafka message is silently dropped.
+If the Kafka send succeeds but the DB write fails the message is produced without a matching order row.
+
+### After — Transactional Outbox (correct)
+
+```kotlin
+// RIGHT: one transaction, two table writes
+@Transactional
+fun placeOrder(…): OrderResponse {
+    val orderId = OrderTable.insertAndGetId { … }          // domain row
+    OutboxEventTable.insert { … }                          // outbox row (same tx)
+    return getOrderResponse(orderId.value)
+}
+```
+
+The background `OutboxPublisher` polls `outbox_events`, publishes to Kafka, and marks the row `PUBLISHED` — all in a separate `REQUIRES_NEW` transaction per event.
+If Kafka is temporarily unavailable the row stays `FAILED` and is retried up to `MAX_RETRY` (3) times before moving to `DEAD_LETTER`.
+
+---
+
+## Key Concepts
+
+| Concept | Detail |
+|---------|--------|
+| **Atomic write** | Order row + outbox event row share one ACID transaction. Either both land or neither does. |
+| **At-least-once delivery** | The scheduler retries `PENDING`/`FAILED` events until they reach `PUBLISHED`. Consumers **must** be idempotent. |
+| **Idempotent publisher** | `publishEvent(id)` returns `false` immediately when the event is already `PUBLISHED`, preventing double-sends on concurrent scheduler runs. |
+| **Dead-letter escalation** | After `MAX_RETRY` (3) failed attempts the event moves to `DEAD_LETTER` for manual inspection or a dedicated DLQ consumer. |
+| **REQUIRES_NEW retry counter** | `incrementRetry` and `markPublished` run in their own nested transactions so the retry count is always persisted even when the outer transaction rolls back. |
+
+---
+
+## bluetape4k Features Used
+
+| Feature | Module | Code Reference | Benefit |
+|---------|--------|----------------|---------|
+| `KLogging` | `bluetape4k-logging` | `OrderService`, `OutboxPublisher` | Structured, context-aware logging with zero boilerplate |
+| `requireNotBlank`, `requirePositiveNumber` | `bluetape4k-core` | `OrderService.placeOrder` | Validated, self-documenting input contracts |
+| `PostgreSQLServer.Launcher` | `bluetape4k-testcontainers` | `AbstractOutboxTest` | Zero-config singleton PostgreSQL container shared across all tests |
+| `KafkaServer.Launcher` | `bluetape4k-testcontainers` | `AbstractOutboxTest` | Zero-config singleton Kafka container shared across all tests |
+| `Fakers.faker` | `bluetape4k-junit5` | `AbstractOutboxTest` | Realistic, locale-aware test data without hard-coded strings |
+
+---
+
+## Outbox Table Schema
+
+```sql
+CREATE TABLE outbox_events (
+    id             BIGSERIAL    PRIMARY KEY,
+    aggregate_type VARCHAR(100) NOT NULL,          -- e.g. "Order"
+    aggregate_id   VARCHAR(100) NOT NULL,          -- string PK of the domain entity
+    event_type     VARCHAR(100) NOT NULL,          -- e.g. "OrderPlaced", "OrderStatusChanged"
+    payload        TEXT         NOT NULL,          -- JSON-serialised event payload
+    status         VARCHAR(20)  NOT NULL DEFAULT 'PENDING',  -- PENDING | PUBLISHED | FAILED | DEAD_LETTER
+    retry_count    INT          NOT NULL DEFAULT 0,
+    created_at     TIMESTAMP    NOT NULL DEFAULT NOW(),
+    processed_at   TIMESTAMP                       -- set when status → PUBLISHED
+);
+```
+
+Managed by Exposed's `SchemaUtils.create()` at application startup via `ExposedConfig`.
+
+---
+
+## Test Coverage
+
+| Test | Scenario |
+|------|----------|
+| `placeOrder creates order and outbox event in same transaction` | Verifies the atomic write — one order row and one outbox event row per `placeOrder` call |
+| `POST api-orders creates order and returns 201` | HTTP layer smoke test — controller wires correctly to service |
+| `PUT api-orders-id-status updates order status` | Status transition via REST produces `200 OK` with updated body |
+| `publishEvent publishes to Kafka and marks event PUBLISHED` | Happy path — Kafka send succeeds, row transitions to `PUBLISHED` |
+| `failed publish increments retry count and sets status FAILED` | Kafka unavailable — `retryCount` increments to 1, status becomes `FAILED` |
+| `event exceeding max retries moves to DEAD_LETTER` | After `MAX_RETRY - 1` existing failures one more failure sets status to `DEAD_LETTER` |
+| `duplicate publish call is idempotent` | Second `publishEvent` call on an already-`PUBLISHED` event returns `false`, status unchanged |
+
+---
+
+## Run
+
+### Prerequisites
+
+Docker must be running — Testcontainers starts PostgreSQL and Kafka automatically.
+
+### Tests
+
+```bash
+# Run all tests in this module
+./gradlew :messaging-transactional-outbox:test
+
+# Run a specific test class
+./gradlew :messaging-transactional-outbox:test \
+    --tests "io.bluetape4k.workshop.messaging.outbox.OutboxTransactionTest"
+
+# Run with verbose output
+./gradlew :messaging-transactional-outbox:test --info
+```
+
+### Application (standalone)
+
+Set environment variables pointing to a running PostgreSQL and Kafka instance, then:
+
+```bash
+./gradlew :messaging-transactional-outbox:bootRun
+```
+
+The scheduler starts automatically and polls `outbox_events` every 2 seconds.
+Swagger UI is available at `http://localhost:8080/swagger-ui/index.html`.

--- a/messaging/transactional-outbox/build.gradle.kts
+++ b/messaging/transactional-outbox/build.gradle.kts
@@ -1,0 +1,77 @@
+plugins {
+    alias(libs.plugins.kotlin.spring)
+    alias(libs.plugins.spring.boot)
+}
+
+springBoot {
+    mainClass.set("io.bluetape4k.workshop.messaging.outbox.OutboxApplicationKt")
+}
+
+configurations {
+    testImplementation.get().extendsFrom(compileOnly.get(), runtimeOnly.get())
+}
+
+dependencies {
+    testImplementation(project(":shared"))
+    testImplementation(libs.bluetape4k.junit5)
+    testImplementation(libs.bluetape4k.assertions)
+    testImplementation(libs.mockk)
+    testImplementation(libs.springmockk)
+
+    // Logging
+    implementation(libs.bluetape4k.logging)
+
+    // Exposed — transactional DB access
+    implementation(libs.exposed.core)
+    implementation(libs.exposed.jdbc)
+    implementation(libs.jetbrains.exposed.java.time)
+    implementation(libs.jetbrains.exposed.spring.boot4.starter)
+    implementation(libs.jetbrains.exposed.spring7.transaction)
+
+    // DB
+    implementation(libs.hikaricp)
+    runtimeOnly(libs.postgresql.driver)
+
+    // Kafka
+    implementation(libs.kafka.clients)
+    implementation(libs.spring.kafka.lib)
+    testImplementation(libs.spring.kafka.test)
+
+    // Testcontainers
+    testImplementation(libs.bluetape4k.testcontainers)
+    testImplementation(libs.testcontainers.postgresql)
+    testImplementation(libs.testcontainers.kafka)
+
+    // Serialization
+    implementation(libs.bluetape4k.jackson3)
+    implementation(libs.jackson3.module.kotlin)
+    implementation(libs.jackson3.module.blackbird)
+
+    // Spring Boot
+    implementation(libs.spring.boot.autoconfigure.lib)
+    annotationProcessor(libs.spring.boot.autoconfigure.processor)
+    annotationProcessor(libs.spring.boot.configuration.processor)
+    developmentOnly(libs.spring.boot.devtools)
+    implementation(libs.spring.boot.starter.actuator)
+    implementation(libs.spring.boot.starter.validation)
+    implementation(libs.spring.boot.starter.webmvc.lib)
+    testImplementation(libs.spring.boot.starter.webmvc.test)
+    testImplementation(libs.spring.boot.starter.webflux.lib)
+    testImplementation(libs.spring.boot.starter.test) {
+        exclude(group = "junit", module = "junit")
+        exclude(group = "org.junit.vintage", module = "junit-vintage-engine")
+        exclude(module = "mockito-core")
+    }
+
+    // Coroutines
+    implementation(libs.bluetape4k.coroutines)
+    implementation(libs.kotlinx.coroutines.core.lib)
+    testImplementation(libs.kotlinx.coroutines.test.lib)
+
+    // Observability
+    implementation(libs.micrometer.core)
+    implementation(libs.micrometer.registry.prometheus)
+
+    // SpringDoc
+    implementation(libs.springdoc.openapi.starter.webmvc.ui)
+}

--- a/messaging/transactional-outbox/src/main/kotlin/io/bluetape4k/workshop/messaging/outbox/OutboxApplication.kt
+++ b/messaging/transactional-outbox/src/main/kotlin/io/bluetape4k/workshop/messaging/outbox/OutboxApplication.kt
@@ -1,0 +1,13 @@
+package io.bluetape4k.workshop.messaging.outbox
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
+import org.springframework.scheduling.annotation.EnableScheduling
+
+@SpringBootApplication
+@EnableScheduling
+class OutboxApplication
+
+fun main(args: Array<String>) {
+    runApplication<OutboxApplication>(*args)
+}

--- a/messaging/transactional-outbox/src/main/kotlin/io/bluetape4k/workshop/messaging/outbox/api/OrderController.kt
+++ b/messaging/transactional-outbox/src/main/kotlin/io/bluetape4k/workshop/messaging/outbox/api/OrderController.kt
@@ -1,0 +1,89 @@
+package io.bluetape4k.workshop.messaging.outbox.api
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.workshop.messaging.outbox.domain.OrderService
+import io.bluetape4k.workshop.messaging.outbox.domain.OutboxEventTable
+import io.bluetape4k.workshop.messaging.outbox.outbox.OutboxEvent
+import io.bluetape4k.workshop.messaging.outbox.outbox.OutboxStatus
+import jakarta.validation.Valid
+import org.jetbrains.exposed.v1.core.SortOrder
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.springframework.http.HttpStatus
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * REST controller exposing order management and outbox demo endpoints.
+ *
+ * ## Endpoints
+ * | Method | Path                          | Description                         |
+ * |--------|-------------------------------|-------------------------------------|
+ * | POST   | `/api/orders`                 | Place a new order                   |
+ * | PUT    | `/api/orders/{id}/status`     | Update an order's status            |
+ * | GET    | `/api/orders/{id}`            | Get a single order                  |
+ * | GET    | `/api/orders`                 | List all orders                     |
+ * | GET    | `/api/orders/outbox/pending`  | List pending outbox events (demo)   |
+ */
+@RestController
+@RequestMapping("/api/orders")
+class OrderController(
+    private val orderService: OrderService,
+) {
+    companion object : KLogging()
+
+    /** Place a new order; returns HTTP 201 with the created [OrderResponse]. */
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    fun placeOrder(@Valid @RequestBody request: OrderRequest): OrderResponse =
+        orderService.placeOrder(request.customerId, request.product, request.quantity)
+
+    /** Transition an existing order to a new status. */
+    @PutMapping("/{id}/status")
+    fun updateStatus(
+        @PathVariable id: Long,
+        @RequestBody request: UpdateStatusRequest,
+    ): OrderResponse = orderService.updateStatus(id, request.status)
+
+    /** Get a single order by its primary key. */
+    @GetMapping("/{id}")
+    fun getOrder(@PathVariable id: Long): OrderResponse = orderService.getOrder(id)
+
+    /** List all orders. */
+    @GetMapping
+    fun getAllOrders(): List<OrderResponse> = orderService.getAllOrders()
+
+    /**
+     * Demo endpoint: returns outbox events that are still pending or failed.
+     *
+     * Useful for observing the outbox table state before the scheduler runs.
+     */
+    @GetMapping("/outbox/pending")
+    @Transactional(readOnly = true)
+    fun getPendingOutboxEvents(): List<OutboxEvent> =
+        OutboxEventTable.selectAll()
+            .where {
+                (OutboxEventTable.status eq OutboxStatus.PENDING)
+            }
+            .orderBy(OutboxEventTable.createdAt to SortOrder.ASC)
+            .map { row ->
+                OutboxEvent(
+                    id = row[OutboxEventTable.id].value,
+                    aggregateType = row[OutboxEventTable.aggregateType],
+                    aggregateId = row[OutboxEventTable.aggregateId],
+                    eventType = row[OutboxEventTable.eventType],
+                    payload = row[OutboxEventTable.payload],
+                    status = row[OutboxEventTable.status],
+                    retryCount = row[OutboxEventTable.retryCount],
+                    createdAt = row[OutboxEventTable.createdAt],
+                    processedAt = row[OutboxEventTable.processedAt],
+                )
+            }
+}

--- a/messaging/transactional-outbox/src/main/kotlin/io/bluetape4k/workshop/messaging/outbox/api/OrderRequest.kt
+++ b/messaging/transactional-outbox/src/main/kotlin/io/bluetape4k/workshop/messaging/outbox/api/OrderRequest.kt
@@ -1,0 +1,36 @@
+package io.bluetape4k.workshop.messaging.outbox.api
+
+import io.bluetape4k.workshop.messaging.outbox.domain.OrderStatus
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.NotBlank
+import java.io.Serializable
+
+/**
+ * HTTP request body for placing a new order.
+ *
+ * @property customerId Identifier of the ordering customer; must not be blank.
+ * @property product    Product name; must not be blank.
+ * @property quantity   Number of units; must be at least 1.
+ */
+data class OrderRequest(
+    @field:NotBlank val customerId: String,
+    @field:NotBlank val product: String,
+    @field:Min(1) val quantity: Int,
+) : Serializable {
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+/**
+ * HTTP request body for updating an order's status.
+ *
+ * @property status The new [OrderStatus] to transition the order to.
+ */
+data class UpdateStatusRequest(
+    val status: OrderStatus,
+) : Serializable {
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}

--- a/messaging/transactional-outbox/src/main/kotlin/io/bluetape4k/workshop/messaging/outbox/api/OrderResponse.kt
+++ b/messaging/transactional-outbox/src/main/kotlin/io/bluetape4k/workshop/messaging/outbox/api/OrderResponse.kt
@@ -1,0 +1,30 @@
+package io.bluetape4k.workshop.messaging.outbox.api
+
+import io.bluetape4k.workshop.messaging.outbox.domain.OrderStatus
+import java.io.Serializable
+import java.time.LocalDateTime
+
+/**
+ * HTTP response body representing a single order.
+ *
+ * @property id         Primary key of the order.
+ * @property customerId Identifier of the ordering customer.
+ * @property product    Product name.
+ * @property quantity   Number of units ordered.
+ * @property status     Current [OrderStatus].
+ * @property createdAt  Wall-clock time of order creation.
+ * @property updatedAt  Wall-clock time of last status change.
+ */
+data class OrderResponse(
+    val id: Long,
+    val customerId: String,
+    val product: String,
+    val quantity: Int,
+    val status: OrderStatus,
+    val createdAt: LocalDateTime,
+    val updatedAt: LocalDateTime,
+) : Serializable {
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}

--- a/messaging/transactional-outbox/src/main/kotlin/io/bluetape4k/workshop/messaging/outbox/config/ExposedConfig.kt
+++ b/messaging/transactional-outbox/src/main/kotlin/io/bluetape4k/workshop/messaging/outbox/config/ExposedConfig.kt
@@ -1,0 +1,30 @@
+package io.bluetape4k.workshop.messaging.outbox.config
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.info
+import io.bluetape4k.workshop.messaging.outbox.domain.OrderTable
+import io.bluetape4k.workshop.messaging.outbox.domain.OutboxEventTable
+import org.jetbrains.exposed.v1.jdbc.SchemaUtils
+import org.springframework.boot.ApplicationArguments
+import org.springframework.boot.ApplicationRunner
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * Creates the [OrderTable] and [OutboxEventTable] database schemas on startup.
+ *
+ * Uses `SchemaUtils.createMissingTablesAndColumns` so it is safe to run against an
+ * existing database — columns and tables that already exist are left untouched.
+ */
+@Component
+class ExposedConfig : ApplicationRunner {
+
+    companion object : KLogging()
+
+    @Transactional
+    override fun run(args: ApplicationArguments) {
+        log.info { "Creating outbox schema tables if not present…" }
+        SchemaUtils.createMissingTablesAndColumns(OrderTable, OutboxEventTable)
+        log.info { "Schema initialisation complete." }
+    }
+}

--- a/messaging/transactional-outbox/src/main/kotlin/io/bluetape4k/workshop/messaging/outbox/config/KafkaConfig.kt
+++ b/messaging/transactional-outbox/src/main/kotlin/io/bluetape4k/workshop/messaging/outbox/config/KafkaConfig.kt
@@ -1,0 +1,25 @@
+package io.bluetape4k.workshop.messaging.outbox.config
+
+import io.bluetape4k.logging.KLogging
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.kafka.annotation.EnableKafka
+import tools.jackson.databind.ObjectMapper
+import tools.jackson.module.kotlin.jacksonObjectMapper
+
+/**
+ * Kafka and Jackson configuration for the Transactional Outbox pattern.
+ *
+ * `KafkaTemplate` is auto-configured by Spring Boot from `spring.kafka.*` properties.
+ * An explicit `ObjectMapper` bean is registered using the Kotlin Jackson module so
+ * domain services can serialize event payloads to JSON.
+ */
+@Configuration(proxyBeanMethods = false)
+@EnableKafka
+class KafkaConfig {
+
+    companion object : KLogging()
+
+    @Bean
+    fun objectMapper(): ObjectMapper = jacksonObjectMapper()
+}

--- a/messaging/transactional-outbox/src/main/kotlin/io/bluetape4k/workshop/messaging/outbox/domain/OrderService.kt
+++ b/messaging/transactional-outbox/src/main/kotlin/io/bluetape4k/workshop/messaging/outbox/domain/OrderService.kt
@@ -1,0 +1,153 @@
+package io.bluetape4k.workshop.messaging.outbox.domain
+
+import tools.jackson.databind.ObjectMapper
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import io.bluetape4k.support.requireNotBlank
+import io.bluetape4k.support.requirePositiveNumber
+import io.bluetape4k.workshop.messaging.outbox.api.OrderResponse
+import io.bluetape4k.workshop.messaging.outbox.outbox.OutboxStatus
+import org.jetbrains.exposed.v1.core.SortOrder
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.insertAndGetId
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.update
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+
+/**
+ * Domain service for [Order] lifecycle operations.
+ *
+ * Every mutating method writes both the domain row and an [OutboxEventTable] row inside
+ * a single database transaction — the Transactional Outbox pattern.  The scheduler
+ * ([io.bluetape4k.workshop.messaging.outbox.outbox.OutboxPublisher]) polls the outbox
+ * table and publishes pending events to Kafka asynchronously.
+ */
+@Service
+@Transactional
+class OrderService(
+    private val objectMapper: ObjectMapper,
+) {
+    companion object : KLogging()
+
+    /**
+     * Places a new order and records an `OrderPlaced` outbox event atomically.
+     *
+     * @param customerId Non-blank customer identifier.
+     * @param product    Non-blank product name.
+     * @param quantity   Positive unit count.
+     * @return [OrderResponse] reflecting the persisted order.
+     */
+    fun placeOrder(customerId: String, product: String, quantity: Int): OrderResponse {
+        customerId.requireNotBlank("customerId")
+        product.requireNotBlank("product")
+        quantity.requirePositiveNumber("quantity")
+
+        val orderId = OrderTable.insertAndGetId {
+            it[OrderTable.customerId] = customerId
+            it[OrderTable.product] = product
+            it[OrderTable.quantity] = quantity
+            it[OrderTable.status] = OrderStatus.PENDING
+        }
+
+        log.debug { "Placed order id=${orderId.value} for customer=$customerId product=$product qty=$quantity" }
+
+        val payloadMap = mapOf(
+            "orderId" to orderId.value,
+            "customerId" to customerId,
+            "product" to product,
+            "quantity" to quantity,
+            "status" to OrderStatus.PENDING.name,
+        )
+        val payload = objectMapper.writeValueAsString(payloadMap)
+
+        OutboxEventTable.insert {
+            it[OutboxEventTable.aggregateType] = "Order"
+            it[OutboxEventTable.aggregateId] = orderId.value.toString()
+            it[OutboxEventTable.eventType] = "OrderPlaced"
+            it[OutboxEventTable.payload] = payload
+            it[OutboxEventTable.status] = OutboxStatus.PENDING
+        }
+
+        return getOrderResponse(orderId.value)
+    }
+
+    /**
+     * Updates an order's status and records an `OrderStatusChanged` outbox event atomically.
+     *
+     * @param orderId The order to update.
+     * @param status  The new [OrderStatus].
+     * @return [OrderResponse] reflecting the updated order.
+     * @throws NoSuchElementException if no order exists with [orderId].
+     */
+    fun updateStatus(orderId: Long, status: OrderStatus): OrderResponse {
+        val now = LocalDateTime.now()
+        val rows = OrderTable.update({ OrderTable.id eq orderId }) {
+            it[OrderTable.status] = status
+            it[OrderTable.updatedAt] = now
+        }
+        if (rows == 0) throw NoSuchElementException("Order $orderId not found")
+
+        log.debug { "Updated order id=$orderId status=$status" }
+
+        val payloadMap = mapOf(
+            "orderId" to orderId,
+            "status" to status.name,
+        )
+        val payload = objectMapper.writeValueAsString(payloadMap)
+
+        OutboxEventTable.insert {
+            it[OutboxEventTable.aggregateType] = "Order"
+            it[OutboxEventTable.aggregateId] = orderId.toString()
+            it[OutboxEventTable.eventType] = "OrderStatusChanged"
+            it[OutboxEventTable.payload] = payload
+            it[OutboxEventTable.status] = OutboxStatus.PENDING
+        }
+
+        return getOrderResponse(orderId)
+    }
+
+    /**
+     * Retrieves a single order by id.
+     *
+     * @throws NoSuchElementException if no order exists with [orderId].
+     */
+    @Transactional(readOnly = true)
+    fun getOrder(orderId: Long): OrderResponse = getOrderResponse(orderId)
+
+    /** Returns all orders, ordered by id ascending. */
+    @Transactional(readOnly = true)
+    fun getAllOrders(): List<OrderResponse> =
+        OrderTable.selectAll().orderBy(OrderTable.id to SortOrder.ASC).map { row ->
+            OrderResponse(
+                id = row[OrderTable.id].value,
+                customerId = row[OrderTable.customerId],
+                product = row[OrderTable.product],
+                quantity = row[OrderTable.quantity],
+                status = row[OrderTable.status],
+                createdAt = row[OrderTable.createdAt],
+                updatedAt = row[OrderTable.updatedAt],
+            )
+        }
+
+    // ── Internal helpers ─────────────────────────────────────────────────────
+
+    private fun getOrderResponse(orderId: Long): OrderResponse {
+        val row = OrderTable.selectAll()
+            .where { OrderTable.id eq orderId }
+            .singleOrNull()
+            ?: throw NoSuchElementException("Order $orderId not found")
+
+        return OrderResponse(
+            id = row[OrderTable.id].value,
+            customerId = row[OrderTable.customerId],
+            product = row[OrderTable.product],
+            quantity = row[OrderTable.quantity],
+            status = row[OrderTable.status],
+            createdAt = row[OrderTable.createdAt],
+            updatedAt = row[OrderTable.updatedAt],
+        )
+    }
+}

--- a/messaging/transactional-outbox/src/main/kotlin/io/bluetape4k/workshop/messaging/outbox/domain/OrderStatus.kt
+++ b/messaging/transactional-outbox/src/main/kotlin/io/bluetape4k/workshop/messaging/outbox/domain/OrderStatus.kt
@@ -1,0 +1,17 @@
+package io.bluetape4k.workshop.messaging.outbox.domain
+
+/**
+ * Represents the lifecycle status of an [Order].
+ *
+ * ## States
+ * - [PENDING]   — order placed, not yet confirmed
+ * - [CONFIRMED] — order accepted by the system
+ * - [SHIPPED]   — order dispatched
+ * - [CANCELLED] — order cancelled before shipment
+ */
+enum class OrderStatus {
+    PENDING,
+    CONFIRMED,
+    SHIPPED,
+    CANCELLED,
+}

--- a/messaging/transactional-outbox/src/main/kotlin/io/bluetape4k/workshop/messaging/outbox/domain/OrderTable.kt
+++ b/messaging/transactional-outbox/src/main/kotlin/io/bluetape4k/workshop/messaging/outbox/domain/OrderTable.kt
@@ -1,0 +1,26 @@
+package io.bluetape4k.workshop.messaging.outbox.domain
+
+import org.jetbrains.exposed.v1.core.dao.id.LongIdTable
+import org.jetbrains.exposed.v1.javatime.CurrentDateTime
+import org.jetbrains.exposed.v1.javatime.datetime
+
+/**
+ * Exposed table for [Order] entities.
+ *
+ * ## Schema
+ * - `id`          — auto-increment Long primary key
+ * - `customer_id` — identifier of the placing customer
+ * - `product`     — product name
+ * - `quantity`    — ordered quantity (positive)
+ * - `status`      — current [OrderStatus], defaults to [OrderStatus.PENDING]
+ * - `created_at`  — wall-clock time of row creation
+ * - `updated_at`  — wall-clock time of last update
+ */
+object OrderTable : LongIdTable("orders") {
+    val customerId = varchar("customer_id", 100)
+    val product = varchar("product", 255)
+    val quantity = integer("quantity")
+    val status = enumerationByName("status", 20, OrderStatus::class).default(OrderStatus.PENDING)
+    val createdAt = datetime("created_at").defaultExpression(CurrentDateTime)
+    val updatedAt = datetime("updated_at").defaultExpression(CurrentDateTime)
+}

--- a/messaging/transactional-outbox/src/main/kotlin/io/bluetape4k/workshop/messaging/outbox/domain/OutboxEventTable.kt
+++ b/messaging/transactional-outbox/src/main/kotlin/io/bluetape4k/workshop/messaging/outbox/domain/OutboxEventTable.kt
@@ -1,0 +1,36 @@
+package io.bluetape4k.workshop.messaging.outbox.domain
+
+import io.bluetape4k.workshop.messaging.outbox.outbox.OutboxStatus
+import org.jetbrains.exposed.v1.core.dao.id.LongIdTable
+import org.jetbrains.exposed.v1.javatime.CurrentDateTime
+import org.jetbrains.exposed.v1.javatime.datetime
+
+/**
+ * Exposed table for outbox events used by the Transactional Outbox pattern.
+ *
+ * Each row is written atomically in the same transaction that mutates the domain
+ * aggregate.  A background scheduler ([io.bluetape4k.workshop.messaging.outbox.outbox.OutboxPublisher])
+ * polls [OutboxStatus.PENDING] (and [OutboxStatus.FAILED]) rows, publishes them to
+ * Kafka, then marks them [OutboxStatus.PUBLISHED].
+ *
+ * ## Schema
+ * - `id`             — auto-increment Long primary key
+ * - `aggregate_type` — domain type, e.g. `"Order"`
+ * - `aggregate_id`   — string representation of the aggregate PK
+ * - `event_type`     — discriminator, e.g. `"OrderPlaced"`, `"OrderStatusChanged"`
+ * - `payload`        — JSON-serialised event payload
+ * - `status`         — current [OutboxStatus], defaults to [OutboxStatus.PENDING]
+ * - `retry_count`    — number of failed publish attempts
+ * - `created_at`     — wall-clock time of row creation
+ * - `processed_at`   — wall-clock time of successful publish (nullable)
+ */
+object OutboxEventTable : LongIdTable("outbox_events") {
+    val aggregateType = varchar("aggregate_type", 100)
+    val aggregateId = varchar("aggregate_id", 100)
+    val eventType = varchar("event_type", 100)
+    val payload = text("payload")
+    val status = enumerationByName("status", 20, OutboxStatus::class).default(OutboxStatus.PENDING)
+    val retryCount = integer("retry_count").default(0)
+    val createdAt = datetime("created_at").defaultExpression(CurrentDateTime)
+    val processedAt = datetime("processed_at").nullable()
+}

--- a/messaging/transactional-outbox/src/main/kotlin/io/bluetape4k/workshop/messaging/outbox/outbox/OutboxEvent.kt
+++ b/messaging/transactional-outbox/src/main/kotlin/io/bluetape4k/workshop/messaging/outbox/outbox/OutboxEvent.kt
@@ -1,0 +1,35 @@
+package io.bluetape4k.workshop.messaging.outbox.outbox
+
+import java.io.Serializable
+import java.time.LocalDateTime
+
+/**
+ * DTO projection of an [io.bluetape4k.workshop.messaging.outbox.domain.OutboxEventTable] row.
+ *
+ * Carried by [OutboxPublisher] from the database to Kafka.
+ *
+ * @property id            Primary key from `outbox_events`
+ * @property aggregateType Domain type, e.g. `"Order"`
+ * @property aggregateId   String representation of the aggregate PK
+ * @property eventType     Discriminator string, e.g. `"OrderPlaced"`
+ * @property payload       JSON-serialised event body
+ * @property status        Current [OutboxStatus]
+ * @property retryCount    Number of failed publish attempts
+ * @property createdAt     Row creation time
+ * @property processedAt   Time of successful publish, or null
+ */
+data class OutboxEvent(
+    val id: Long,
+    val aggregateType: String,
+    val aggregateId: String,
+    val eventType: String,
+    val payload: String,
+    val status: OutboxStatus,
+    val retryCount: Int,
+    val createdAt: LocalDateTime,
+    val processedAt: LocalDateTime?,
+) : Serializable {
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}

--- a/messaging/transactional-outbox/src/main/kotlin/io/bluetape4k/workshop/messaging/outbox/outbox/OutboxPublisher.kt
+++ b/messaging/transactional-outbox/src/main/kotlin/io/bluetape4k/workshop/messaging/outbox/outbox/OutboxPublisher.kt
@@ -1,0 +1,147 @@
+package io.bluetape4k.workshop.messaging.outbox.outbox
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import io.bluetape4k.logging.error
+import io.bluetape4k.logging.warn
+import io.bluetape4k.workshop.messaging.outbox.domain.OutboxEventTable
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.less
+import org.jetbrains.exposed.v1.core.or
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.update
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+
+/**
+ * Scheduled background component that polls [OutboxEventTable] for [OutboxStatus.PENDING]
+ * (and [OutboxStatus.FAILED]) events and publishes them to Kafka.
+ *
+ * ## Retry semantics
+ * On a failed publish attempt, [retryCount] is incremented in a **separate**
+ * `REQUIRES_NEW` transaction so the counter survives the outer transaction rollback.
+ * Once [retryCount] reaches [MAX_RETRY] the event transitions to [OutboxStatus.DEAD_LETTER].
+ *
+ * ## Idempotency
+ * [publishEvent] returns `false` immediately when the event is not in a publishable
+ * state ([OutboxStatus.PENDING] or [OutboxStatus.FAILED]), so calling it twice on the
+ * same already-published event is safe.
+ */
+@Component
+class OutboxPublisher(
+    private val kafkaTemplate: KafkaTemplate<String, String>,
+) {
+    companion object : KLogging() {
+        const val TOPIC = "order-events"
+        const val MAX_RETRY = 3
+    }
+
+    /**
+     * Polls for publishable outbox events every 2 seconds and publishes each one.
+     *
+     * Runs inside a read-only transaction to load the batch; each event is published
+     * via [publishEvent] which manages its own transaction.
+     */
+    @Scheduled(fixedDelay = 2000)
+    @Transactional(readOnly = true)
+    fun publishPendingEvents() {
+        val pendingIds = OutboxEventTable.selectAll()
+            .where {
+                ((OutboxEventTable.status eq OutboxStatus.PENDING) or
+                    (OutboxEventTable.status eq OutboxStatus.FAILED)) and
+                    (OutboxEventTable.retryCount less MAX_RETRY)
+            }
+            .map { it[OutboxEventTable.id].value }
+
+        log.debug { "publishPendingEvents: found ${pendingIds.size} publishable event(s)" }
+
+        pendingIds.forEach { id ->
+            try {
+                publishEvent(id)
+            } catch (e: Exception) {
+                log.warn(e) { "Unexpected error while publishing outbox event id=$id" }
+            }
+        }
+    }
+
+    /**
+     * Publishes a single outbox event identified by [eventId].
+     *
+     * The Kafka send is performed **before** the database status update; if the send
+     * throws, the surrounding transaction rolls back and the row remains PENDING/FAILED
+     * for the next poll.  A [REQUIRES_NEW] transaction is used so that a retry-counter
+     * increment (on failure) is always persisted independently.
+     *
+     * @return `true` if the event was successfully sent and marked [OutboxStatus.PUBLISHED];
+     *         `false` if the event was already published (idempotent duplicate call).
+     */
+    @Transactional
+    fun publishEvent(eventId: Long): Boolean {
+        val row = OutboxEventTable.selectAll()
+            .where { OutboxEventTable.id eq eventId }
+            .singleOrNull()
+            ?: return false
+
+        val currentStatus = row[OutboxEventTable.status]
+        if (currentStatus != OutboxStatus.PENDING && currentStatus != OutboxStatus.FAILED) {
+            log.debug { "Event id=$eventId is already in state=$currentStatus — skipping" }
+            return false
+        }
+
+        val currentRetry = row[OutboxEventTable.retryCount]
+        if (currentRetry >= MAX_RETRY) {
+            markDeadLetter(eventId)
+            return false
+        }
+
+        val aggregateId = row[OutboxEventTable.aggregateId]
+        val payload = row[OutboxEventTable.payload]
+
+        return try {
+            // Synchronous get() so we know the send succeeded before updating status
+            kafkaTemplate.send(TOPIC, aggregateId, payload).get()
+            markPublished(eventId)
+            log.debug { "Published outbox event id=$eventId to topic=$TOPIC" }
+            true
+        } catch (e: Exception) {
+            log.error(e) { "Failed to publish outbox event id=$eventId" }
+            val newRetry = currentRetry + 1
+            incrementRetry(eventId, newRetry)
+            false
+        }
+    }
+
+    // ── Private status-update helpers (each runs in own REQUIRES_NEW tx) ────
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    fun markPublished(eventId: Long) {
+        OutboxEventTable.update({ OutboxEventTable.id eq eventId }) {
+            it[OutboxEventTable.status] = OutboxStatus.PUBLISHED
+            it[OutboxEventTable.processedAt] = LocalDateTime.now()
+        }
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    fun incrementRetry(eventId: Long, newRetryCount: Int) {
+        val newStatus = if (newRetryCount >= MAX_RETRY) OutboxStatus.DEAD_LETTER else OutboxStatus.FAILED
+        OutboxEventTable.update({ OutboxEventTable.id eq eventId }) {
+            it[OutboxEventTable.retryCount] = newRetryCount
+            it[OutboxEventTable.status] = newStatus
+        }
+        if (newStatus == OutboxStatus.DEAD_LETTER) {
+            log.warn { "Outbox event id=$eventId moved to DEAD_LETTER after $newRetryCount attempts" }
+        }
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    fun markDeadLetter(eventId: Long) {
+        OutboxEventTable.update({ OutboxEventTable.id eq eventId }) {
+            it[OutboxEventTable.status] = OutboxStatus.DEAD_LETTER
+        }
+    }
+}

--- a/messaging/transactional-outbox/src/main/kotlin/io/bluetape4k/workshop/messaging/outbox/outbox/OutboxStatus.kt
+++ b/messaging/transactional-outbox/src/main/kotlin/io/bluetape4k/workshop/messaging/outbox/outbox/OutboxStatus.kt
@@ -1,0 +1,17 @@
+package io.bluetape4k.workshop.messaging.outbox.outbox
+
+/**
+ * Represents the processing status of an [OutboxEvent].
+ *
+ * ## States
+ * - [PENDING]     — event created, not yet published to Kafka
+ * - [PUBLISHED]   — event successfully sent to Kafka
+ * - [FAILED]      — last publish attempt failed; eligible for retry
+ * - [DEAD_LETTER] — exceeded [OutboxPublisher.MAX_RETRY]; no further retries
+ */
+enum class OutboxStatus {
+    PENDING,
+    PUBLISHED,
+    FAILED,
+    DEAD_LETTER,
+}

--- a/messaging/transactional-outbox/src/main/resources/application.yml
+++ b/messaging/transactional-outbox/src/main/resources/application.yml
@@ -1,0 +1,41 @@
+spring:
+  application:
+    name: transactional-outbox
+  datasource:
+    url: jdbc:postgresql://localhost:5432/outbox_db
+    username: outbox_user
+    password: outbox_pass
+    driver-class-name: org.postgresql.Driver
+  exposed:
+    generate-ddl: true
+  kafka:
+    bootstrap-servers: localhost:9092
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
+      acks: all
+      retries: 3
+    consumer:
+      group-id: outbox-consumer
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      auto-offset-reset: earliest
+
+server:
+  port: 8080
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,prometheus
+  endpoint:
+    health:
+      show-details: always
+
+logging:
+  level:
+    io.bluetape4k.workshop: DEBUG
+    org.jetbrains.exposed: INFO
+    org.springframework.kafka: INFO
+    org.springframework: WARN

--- a/messaging/transactional-outbox/src/test/kotlin/io/bluetape4k/workshop/messaging/outbox/AbstractOutboxTest.kt
+++ b/messaging/transactional-outbox/src/test/kotlin/io/bluetape4k/workshop/messaging/outbox/AbstractOutboxTest.kt
@@ -1,0 +1,38 @@
+package io.bluetape4k.workshop.messaging.outbox
+
+import io.bluetape4k.junit5.faker.Fakers
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.testcontainers.database.PostgreSQLServer
+import io.bluetape4k.testcontainers.mq.KafkaServer
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.web.server.LocalServerPort
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.springframework.test.web.reactive.server.WebTestClient
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+abstract class AbstractOutboxTest {
+
+    companion object : KLogging() {
+        val postgres = PostgreSQLServer.Launcher.postgres
+        val kafka = KafkaServer.Launcher.kafka
+
+        @JvmStatic
+        @DynamicPropertySource
+        fun containerProperties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url") { postgres.jdbcUrl!! }
+            registry.add("spring.datasource.username") { postgres.username!! }
+            registry.add("spring.datasource.password") { postgres.password!! }
+            registry.add("spring.kafka.bootstrap-servers") { kafka.bootstrapServers }
+        }
+
+        val faker = Fakers.faker
+    }
+
+    @LocalServerPort
+    protected val port: Int = 0
+
+    protected val webTestClient: WebTestClient by lazy {
+        WebTestClient.bindToServer().baseUrl("http://localhost:$port").build()
+    }
+}

--- a/messaging/transactional-outbox/src/test/kotlin/io/bluetape4k/workshop/messaging/outbox/OutboxTransactionTest.kt
+++ b/messaging/transactional-outbox/src/test/kotlin/io/bluetape4k/workshop/messaging/outbox/OutboxTransactionTest.kt
@@ -1,0 +1,265 @@
+package io.bluetape4k.workshop.messaging.outbox
+
+import com.ninjasquad.springmockk.MockkBean
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeGreaterThan
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import io.bluetape4k.workshop.messaging.outbox.api.OrderRequest
+import io.bluetape4k.workshop.messaging.outbox.api.OrderResponse
+import io.bluetape4k.workshop.messaging.outbox.api.UpdateStatusRequest
+import io.bluetape4k.workshop.messaging.outbox.domain.OrderService
+import io.bluetape4k.workshop.messaging.outbox.domain.OrderStatus
+import io.bluetape4k.workshop.messaging.outbox.domain.OutboxEventTable
+import io.bluetape4k.workshop.messaging.outbox.outbox.OutboxPublisher
+import io.bluetape4k.workshop.messaging.outbox.outbox.OutboxStatus
+import io.mockk.every
+import io.mockk.mockk
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.update
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.MediaType
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.kafka.support.SendResult
+import org.springframework.transaction.support.TransactionTemplate
+import java.util.concurrent.CompletableFuture
+
+/**
+ * Integration tests for the Transactional Outbox pattern.
+ *
+ * Uses `@MockkBean` for `KafkaTemplate` to avoid generic-type-erasure issues
+ * with `@MockkSpyBean` and to control publish success/failure per test.
+ *
+ * ## Test coverage
+ * 1. Place order → both order row and outbox event row created atomically
+ * 2. HTTP POST → order created, HTTP 201 returned
+ * 3. HTTP PUT → order status updated
+ * 4. publishEvent → event marked PUBLISHED
+ * 5. Failed publish → retryCount incremented, status FAILED
+ * 6. Max-retry exceeded → status transitions to DEAD_LETTER
+ * 7. Duplicate publish call → idempotent (returns false, status unchanged)
+ */
+class OutboxTransactionTest : AbstractOutboxTest() {
+    companion object : KLogging()
+
+    @Autowired
+    private lateinit var orderService: OrderService
+
+    @Autowired
+    private lateinit var outboxPublisher: OutboxPublisher
+
+    @Autowired
+    private lateinit var transactionTemplate: TransactionTemplate
+
+    @MockkBean(relaxed = true)
+    private lateinit var kafkaTemplate: KafkaTemplate<String, String>
+
+    @BeforeEach
+    fun stubSuccessfulSend() {
+        // Default: Kafka send succeeds
+        val successFuture: CompletableFuture<SendResult<String, String>> =
+            CompletableFuture.completedFuture(mockk())
+        every { kafkaTemplate.send(any<String>(), any<String>(), any<String>()) } returns successFuture
+    }
+
+    // ── 1. Atomic creation ──────────────────────────────────────────────────
+
+    @Test
+    fun `placeOrder creates order and outbox event in same transaction`() {
+        val order = orderService.placeOrder(
+            customerId = faker.name().username(),
+            product = faker.commerce().productName(),
+            quantity = faker.number().numberBetween(1, 10),
+        )
+
+        order.shouldNotBeNull()
+        order.id.shouldBeGreaterThan(0L)
+        order.status shouldBeEqualTo OrderStatus.PENDING
+
+        val eventCount = transactionTemplate.execute {
+            OutboxEventTable.selectAll()
+                .where { OutboxEventTable.aggregateId eq order.id.toString() }
+                .count()
+        }!!
+        eventCount shouldBeEqualTo 1L
+        log.debug { "placeOrder: orderId=${order.id}, outboxEventCount=$eventCount" }
+    }
+
+    // ── 2. HTTP POST ──────────────────────────────────────────────────────────
+
+    @Test
+    fun `POST api-orders creates order and returns 201`() {
+        val request = OrderRequest(
+            customerId = faker.name().username(),
+            product = faker.commerce().productName(),
+            quantity = 3,
+        )
+
+        webTestClient.post().uri("/api/orders")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(request)
+            .exchange()
+            .expectStatus().isCreated
+            .expectBody(OrderResponse::class.java)
+            .value { it!!.id.shouldBeGreaterThan(0L) }
+    }
+
+    // ── 3. HTTP PUT ───────────────────────────────────────────────────────────
+
+    @Test
+    fun `PUT api-orders-id-status updates order status`() {
+        val order = orderService.placeOrder(
+            customerId = faker.name().username(),
+            product = faker.commerce().productName(),
+            quantity = 2,
+        )
+
+        webTestClient.put().uri("/api/orders/${order.id}/status")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(UpdateStatusRequest(status = OrderStatus.CONFIRMED))
+            .exchange()
+            .expectStatus().isOk
+            .expectBody(OrderResponse::class.java)
+            .value { it!!.status shouldBeEqualTo OrderStatus.CONFIRMED }
+    }
+
+    // ── 4. Publish succeeds ──────────────────────────────────────────────────
+
+    @Test
+    fun `publishEvent publishes to Kafka and marks event PUBLISHED`() {
+        val order = orderService.placeOrder(
+            customerId = faker.name().username(),
+            product = faker.commerce().productName(),
+            quantity = 1,
+        )
+
+        val eventId = transactionTemplate.execute {
+            OutboxEventTable.selectAll()
+                .where { OutboxEventTable.aggregateId eq order.id.toString() }
+                .map { it[OutboxEventTable.id].value }
+                .first()
+        }!!
+
+        val result = outboxPublisher.publishEvent(eventId)
+        result.shouldBeTrue()
+
+        val status = transactionTemplate.execute {
+            OutboxEventTable.selectAll()
+                .where { OutboxEventTable.id eq eventId }
+                .map { it[OutboxEventTable.status] }
+                .first()
+        }!!
+        status shouldBeEqualTo OutboxStatus.PUBLISHED
+    }
+
+    // ── 5. Failed publish → FAILED + retryCount++ ─────────────────────────
+
+    @Test
+    fun `failed publish increments retry count and sets status FAILED`() {
+        val order = orderService.placeOrder(
+            customerId = faker.name().username(),
+            product = faker.commerce().productName(),
+            quantity = 1,
+        )
+
+        val eventId = transactionTemplate.execute {
+            OutboxEventTable.selectAll()
+                .where { OutboxEventTable.aggregateId eq order.id.toString() }
+                .map { it[OutboxEventTable.id].value }
+                .first()
+        }!!
+
+        every {
+            kafkaTemplate.send(any<String>(), any<String>(), any<String>())
+        } throws RuntimeException("Kafka unavailable")
+
+        val result = outboxPublisher.publishEvent(eventId)
+        result.shouldBeFalse()
+
+        val row = transactionTemplate.execute {
+            OutboxEventTable.selectAll()
+                .where { OutboxEventTable.id eq eventId }
+                .map { Pair(it[OutboxEventTable.retryCount], it[OutboxEventTable.status]) }
+                .first()
+        }!!
+        row.first shouldBeEqualTo 1
+        row.second shouldBeEqualTo OutboxStatus.FAILED
+    }
+
+    // ── 6. Max retry → DEAD_LETTER ───────────────────────────────────────────
+
+    @Test
+    fun `event exceeding max retries moves to DEAD_LETTER`() {
+        val order = orderService.placeOrder(
+            customerId = faker.name().username(),
+            product = faker.commerce().productName(),
+            quantity = 1,
+        )
+
+        val eventId = transactionTemplate.execute {
+            OutboxEventTable.selectAll()
+                .where { OutboxEventTable.aggregateId eq order.id.toString() }
+                .map { it[OutboxEventTable.id].value }
+                .first()
+        }!!
+
+        // Pre-set retryCount to MAX_RETRY - 1 so next failure tips it over
+        transactionTemplate.execute {
+            OutboxEventTable.update({ OutboxEventTable.id eq eventId }) {
+                it[OutboxEventTable.retryCount] = OutboxPublisher.MAX_RETRY - 1
+                it[OutboxEventTable.status] = OutboxStatus.FAILED
+            }
+        }
+
+        every {
+            kafkaTemplate.send(any<String>(), any<String>(), any<String>())
+        } throws RuntimeException("Kafka unavailable")
+
+        outboxPublisher.publishEvent(eventId)
+
+        val status = transactionTemplate.execute {
+            OutboxEventTable.selectAll()
+                .where { OutboxEventTable.id eq eventId }
+                .map { it[OutboxEventTable.status] }
+                .first()
+        }!!
+        status shouldBeEqualTo OutboxStatus.DEAD_LETTER
+    }
+
+    // ── 7. Idempotent publish ─────────────────────────────────────────────────
+
+    @Test
+    fun `duplicate publish call is idempotent`() {
+        val order = orderService.placeOrder(
+            customerId = faker.name().username(),
+            product = faker.commerce().productName(),
+            quantity = 1,
+        )
+
+        val eventId = transactionTemplate.execute {
+            OutboxEventTable.selectAll()
+                .where { OutboxEventTable.aggregateId eq order.id.toString() }
+                .map { it[OutboxEventTable.id].value }
+                .first()
+        }!!
+
+        outboxPublisher.publishEvent(eventId).shouldBeTrue()
+
+        // Second call must return false (already PUBLISHED)
+        outboxPublisher.publishEvent(eventId).shouldBeFalse()
+
+        val status = transactionTemplate.execute {
+            OutboxEventTable.selectAll()
+                .where { OutboxEventTable.id eq eventId }
+                .map { it[OutboxEventTable.status] }
+                .first()
+        }!!
+        status shouldBeEqualTo OutboxStatus.PUBLISHED
+    }
+}

--- a/messaging/transactional-outbox/src/test/resources/junit-platform.properties
+++ b/messaging/transactional-outbox/src/test/resources/junit-platform.properties
@@ -1,0 +1,6 @@
+junit.jupiter.extensions.autodetection.enabled=true
+junit.jupiter.testinstance.lifecycle.default=per_class
+
+junit.jupiter.execution.parallel.enabled=false
+junit.jupiter.execution.parallel.mode.default=same_thread
+junit.jupiter.execution.parallel.mode.classes.default=concurrent

--- a/messaging/transactional-outbox/src/test/resources/logback-test.xml
+++ b/messaging/transactional-outbox/src/test/resources/logback-test.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+    <springProperty scope="context" name="APP_NAME" source="spring.application.name"/>
+
+    <property name="CONSOLE_LOG_PATTERN"
+              value="%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %highlight(${LOG_LEVEL_PATTERN:-%5p}) %magenta(${PID:- }) %clr(---){faint} %clr([%25.25t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}"/>
+
+    <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>DEBUG</level>
+        </filter>
+        <encoder>
+            <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+            <charset>utf8</charset>
+        </encoder>
+    </appender>
+
+    <logger name="io.bluetape4k.workshop" level="DEBUG"/>
+    <logger name="org.springframework.kafka" level="DEBUG"/>
+    <logger name="org.jetbrains.exposed" level="INFO"/>
+
+    <root level="INFO">
+        <appender-ref ref="console"/>
+    </root>
+</configuration>


### PR DESCRIPTION
## Summary

Implements the Transactional Outbox pattern workshop as a Spring Boot + Exposed + Kafka module.

## Problem

Naive DB+Kafka integration: if Kafka publish fails after DB commit → event lost. If DB fails after Kafka send → duplicate event.

## Solution

Write domain state + outbox event in **one DB transaction**, then a background scheduler polls and publishes to Kafka.

## Module: `messaging/transactional-outbox`

### Architecture

```
Client → OrderController → OrderService
                           ├── INSERT orders         ┐
                           └── INSERT outbox_events  ┘ one transaction

Scheduler → OutboxPublisher → SELECT PENDING outbox_events
                           → KafkaTemplate.send("order-events")
                           → UPDATE outbox_events SET status=PUBLISHED
```

### Key Components

| Class | Role |
|-------|------|
| `OrderService` | Writes Order + OutboxEvent atomically |
| `OutboxPublisher` | `@Scheduled` poller, retry (MAX=3), DEAD_LETTER |
| `OrderTable` | Exposed table for orders |
| `OutboxEventTable` | Exposed table for outbox events |
| `OrderController` | REST: POST/PUT/GET /api/orders |

### bluetape4k Features Used

| Feature | Module | Benefit |
|---------|--------|---------|
| `KLogging` | bluetape4k-logging | Structured logging |
| `requireNotBlank`, `requirePositiveNumber` | bluetape4k-core | Input validation |
| `PostgreSQLServer.Launcher` | bluetape4k-testcontainers | Zero-config DB |
| `KafkaServer.Launcher` | bluetape4k-testcontainers | Zero-config Kafka |
| `Fakers.faker` | bluetape4k-junit5 | Realistic test data |

## Test Results

```
./gradlew :messaging-transactional-outbox:test
7 tests passing (10.7s)
```

### Tests Cover
1. Atomic creation — Order + OutboxEvent in same transaction
2. HTTP POST/PUT — REST API works
3. publishEvent — Kafka send + status=PUBLISHED
4. Failed publish — retryCount++, status=FAILED
5. Max retry exceeded — status=DEAD_LETTER
6. Duplicate publish — idempotent (false return)

## Lessons

`docs/lessons/2026-05-24-transactional-outbox-pattern.md` — Jackson 3 package, MockkBean relaxed, Exposed where() syntax

Closes #99