### PR TITLE
feat: add multi-tenant data isolation workshop

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -83,10 +83,12 @@ Redis, Kafka, Observability 스택, 가상 스레드, Vert.x, 클라우드 네�
 | Advanced | [`spring-boot-chaos-monkey`](spring-boot/chaos-monkey/) | `logging` | In-memory | Spring Boot용 Chaos Monkey — 지연/예외 주입 |
 | Basic | [`spring-boot-problem`](spring-boot/problem/) | `logging` | In-memory | RFC 9457 Problem Details 에러 응답 |
 | Advanced | [`spring-boot-application-event-demo`](spring-boot/application-event-demo/) | `coroutines` | In-memory | 코루틴 리스너를 활용한 Spring 애플리케이션 이벤트 |
+| Advanced | [`spring-boot-multi-tenant-data-isolation`](spring-boot/multi-tenant-data-isolation/) | `exposed-jdbc`, `spring-boot4-core`, `micrometer` | H2 | 테넌트별 repository, cache key, lock key, rate-limit, metrics 격리 |
 
 ```bash
 ./gradlew :spring-boot-cache-redis:test
 ./gradlew :spring-boot-resilience4j-coroutines:test
+./gradlew :spring-boot-multi-tenant-data-isolation:test
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -83,10 +83,12 @@ Each domain lists **Basic** (self-contained, minimal infra) and **Advanced** (mu
 | Advanced | [`spring-boot-chaos-monkey`](spring-boot/chaos-monkey/) | `logging` | In-memory | Chaos Monkey for Spring Boot — latency/exception injection |
 | Basic | [`spring-boot-problem`](spring-boot/problem/) | `logging` | In-memory | RFC 9457 Problem Details error responses |
 | Advanced | [`spring-boot-application-event-demo`](spring-boot/application-event-demo/) | `coroutines` | In-memory | Spring application events with coroutine listeners |
+| Advanced | [`spring-boot-multi-tenant-data-isolation`](spring-boot/multi-tenant-data-isolation/) | `exposed-jdbc`, `spring-boot4-core`, `micrometer` | H2 | Tenant-scoped repository, cache key, lock key, rate-limit, and metrics isolation |
 
 ```bash
 ./gradlew :spring-boot-cache-redis:test
 ./gradlew :spring-boot-resilience4j-coroutines:test
+./gradlew :spring-boot-multi-tenant-data-isolation:test
 ```
 
 ---

--- a/docs/lessons/2026-05-24-issue-104-multi-tenant-data-isolation.md
+++ b/docs/lessons/2026-05-24-issue-104-multi-tenant-data-isolation.md
@@ -1,0 +1,23 @@
+# Issue #104 Multi-Tenant Data Isolation
+
+## Context
+
+GitHub issue #104 requested an advanced workshop example proving tenant isolation across data access, cache keys, locks, rate limits, and metrics.
+
+## Decision
+
+Add `spring-boot/multi-tenant-data-isolation` as a deterministic Spring Boot + H2 example. Use Bluetape4k Exposed JDBC `LongJdbcRepository` for the safe repository path, and keep lock/rate-limit examples in memory so the lesson focuses on tenant-key design rather than external infrastructure.
+
+## Outcome
+
+The module includes safe and unsafe repository/cache paths, tenant-prefixed key helpers, per-key locks, tenant-keyed rate limiting, tenant-tagged Micrometer counters, and English/Korean README files.
+
+## Verification
+
+- `./gradlew :spring-boot-multi-tenant-data-isolation:test` passed.
+- `./gradlew projects` includes `:spring-boot-multi-tenant-data-isolation`.
+- `git diff --check` passed.
+
+## Future Guidance
+
+When adding Spring Boot workshop modules under `spring-boot/`, the Gradle project name includes the base directory prefix, for example `:spring-boot-<module>`.

--- a/docs/superpowers/plans/2026-05-24-issue-104-multi-tenant-data-isolation-plan.md
+++ b/docs/superpowers/plans/2026-05-24-issue-104-multi-tenant-data-isolation-plan.md
@@ -1,0 +1,50 @@
+# Issue #104 - Multi-Tenant Data Isolation Implementation Plan
+
+**Date**: 2026-05-24
+**Issue**: https://github.com/bluetape4k/bluetape4k-workshop/issues/104
+**Spec**: `docs/superpowers/specs/2026-05-24-issue-104-multi-tenant-data-isolation-design.md`
+**Status**: Draft
+
+## Tasks
+
+- [x] Add `spring-boot/multi-tenant-data-isolation/build.gradle.kts`.
+- [x] Add Spring Boot application entrypoint and H2/Exposed configuration.
+- [x] Add `TenantId` and `InvoiceRecord` domain types with `Serializable` and `serialVersionUID`.
+- [x] Add `InvoiceTable` and schema initializer.
+- [x] Add `TenantInvoiceRepository : LongJdbcRepository<InvoiceRecord>`.
+- [x] Add `UnsafeInvoiceRepository` baseline implementation.
+- [x] Add `TenantKeyFactory`, tenant-keyed cache, per-key `ReentrantLock` lock registry, fixed-window in-memory rate limiter, and Micrometer counter service.
+- [x] Add tests proving baseline leakage and tenant-safe behavior.
+- [x] Add `src/test/resources/junit-platform.properties`.
+- [x] Add `src/test/resources/logback-test.xml`.
+- [x] Add `README.md` and `README.ko.md`.
+- [x] Verify `./gradlew :spring-boot-multi-tenant-data-isolation:test`.
+- [x] Verify `git diff --check`.
+- [x] Audit English KDoc for new public APIs and README/README.ko.md lockstep.
+- [x] Add concise lesson under `docs/lessons/`.
+- [x] Run code review/advisor gates on the final diff.
+
+## Implementation Notes
+
+- Module path under `spring-boot/` creates project name `:spring-boot-multi-tenant-data-isolation` because `settings.gradle.kts` includes `spring-boot` with `withProjectName=false` and `withBaseDir=true`.
+- Public API KDoc must be English.
+- New tests use JUnit 5 plus `bluetape4k-assertions`; no AssertJ/JUnit assertion APIs.
+- Data classes implement `Serializable` and define `serialVersionUID`.
+- Tenant key helpers are intentionally explicit so README can contrast raw keys and tenant-prefixed keys.
+- README claims must reference actual classes and dependencies only.
+- Dependencies are pinned to existing aliases: `exposed-jdbc`, `bluetape4k-spring-boot4-core`, `bluetape4k-micrometer`, `micrometer-core`, `h2-v2`, Spring Boot JDBC/test starters, `bluetape4k-junit5`, and `bluetape4k-assertions`.
+- Rate-limit and lock examples use in-memory state keyed by `TenantKeyFactory`; no new Bucket4j or distributed-lock dependency is introduced.
+
+## Verification
+
+```bash
+./gradlew :spring-boot-multi-tenant-data-isolation:test
+git diff --check
+```
+
+## Review Notes
+
+- Claude advisor gate 1: `.omx/artifacts/claude-issue-104-design-20260524152918.md`
+- P0/P1 findings from gate 1: fixed in this draft.
+- Claude design rerun: `.omx/artifacts/claude-issue-104-design-rerun-20260524153255.md`, PASS, P0=0, P1=0.
+- Claude code review: `.omx/artifacts/claude-issue-104-code-review-final-20260524154933.md`, PASS, P0=0, P1=0.

--- a/docs/superpowers/specs/2026-05-24-issue-104-multi-tenant-data-isolation-design.md
+++ b/docs/superpowers/specs/2026-05-24-issue-104-multi-tenant-data-isolation-design.md
@@ -1,0 +1,74 @@
+# Issue #104 - Multi-Tenant Data Isolation Workshop Design
+
+**Date**: 2026-05-24
+**Issue**: https://github.com/bluetape4k/bluetape4k-workshop/issues/104
+**Parent Epic**: #76
+**Backlog tracker**: #92
+**Status**: Draft
+
+## Goal
+
+Add an advanced workshop example that proves tenant-scoped data isolation across repository queries, cache keys, lock keys, rate-limit buckets, and metrics tags.
+
+## Scope
+
+- New Spring Boot workshop module: `spring-boot/multi-tenant-data-isolation`.
+- Tenant-aware Exposed JDBC repository over an H2 database.
+- Baseline repository/cache paths that intentionally omit tenant scope and demonstrate leakage risk in tests.
+- Tenant-prefixed cache keys, lock keys, and rate-limit bucket keys.
+- Tenant-tagged Micrometer counters.
+- README with Bluetape4k-first explanation and feature table.
+
+## Non-Goals
+
+- Production authentication or authorization.
+- Real Redis-backed distributed locks.
+- Full HTTP API security integration.
+- Changing shared dependency governance.
+
+## Design
+
+The module keeps the example small and deterministic:
+
+1. `TenantId` represents a normalized tenant identifier.
+2. `InvoiceTable` stores `tenant_id` on every row.
+3. `TenantInvoiceRepository` implements the bluetape4k Exposed `LongJdbcRepository` pattern and adds tenant-scoped methods.
+4. `UnsafeInvoiceRepository` uses the same table without tenant predicates to provide a failing baseline scenario.
+5. `TenantKeyFactory` builds cache, lock, and rate-limit keys with the tenant prefix.
+6. `TenantInvoiceService` composes repository, cache, lock, rate-limit, and metrics behavior.
+7. Workshop record/data classes implement `Serializable` and define `serialVersionUID`.
+8. Lock behavior uses per-key in-memory locks, and rate-limit behavior uses fixed-window in-memory buckets keyed by `TenantKeyFactory`; real distributed lock semantics and Bucket4j adapters are explicitly out of scope for this module.
+
+## Used Bluetape4k Features
+
+| Feature | Module/artifact | Code reference | Benefit |
+|---|---|---|---|
+| Exposed repository helper | `io.github.bluetape4k.exposed:bluetape4k-exposed-jdbc` | `TenantInvoiceRepository : LongJdbcRepository` | Reuses bluetape4k repository defaults and keeps Exposed row mapping explicit. |
+| Spring Boot support | `io.github.bluetape4k:bluetape4k-spring-boot4-core` | module dependencies | Keeps the example aligned with Bluetape4k Spring Boot 4 workshop modules. |
+| Logging | `io.github.bluetape4k:bluetape4k-logging` | service/repository companion loggers | Uses existing logging conventions. |
+| Metrics bridge | `io.github.bluetape4k:bluetape4k-micrometer` | tenant-tagged `MeterRegistry` counters | Shows tenant-aware observability without custom metrics wrappers. |
+| Test runtime | `io.github.bluetape4k:bluetape4k-junit5` | module test dependencies | Keeps the new module aligned with shared test lifecycle rules. |
+| Test assertions | `io.github.bluetape4k:bluetape4k-assertions` | isolation tests | Keeps tests consistent with the ecosystem. |
+
+## Acceptance Criteria
+
+- Baseline leakage test shows cross-tenant data can leak when tenant scope is omitted.
+- Tenant-scoped repository reads and writes cannot cross tenant boundaries.
+- Cache hits are isolated per tenant.
+- Lock/rate-limit key examples include tenant prefixes and use in-memory state keyed by those prefixes.
+- Metrics include a tenant tag.
+- README includes a `Used Bluetape4k features` table and before/after explanation.
+- Targeted Gradle test for the new module passes.
+
+## Risks
+
+- Real distributed lock semantics are out of scope; use per-key `ReentrantLock` instances to demonstrate tenant-safe keying.
+- Bucket4j is out of scope for this module; use an in-memory fixed-window limiter so the example does not add rate-limit dependencies only for key naming.
+- H2 auto-increment behavior must be verified with Exposed 1.3 APIs.
+
+## Review Notes
+
+- Claude advisor gate 1: `.omx/artifacts/claude-issue-104-design-20260524152918.md`
+- P0/P1 findings from gate 1: fixed in this draft.
+- Claude advisor gate 2: `.omx/artifacts/claude-issue-104-design-rerun-20260524153255.md`
+- Gate 2 verdict: PASS, P0=0, P1=0.

--- a/spring-boot/multi-tenant-data-isolation/README.ko.md
+++ b/spring-boot/multi-tenant-data-isolation/README.ko.md
@@ -1,0 +1,92 @@
+# 멀티 테넌트 데이터 격리
+
+[English](README.md) | [한국어](README.ko.md)
+
+테넌트별 데이터 접근, 캐시 키, 락 키, rate-limit 버킷, 메트릭 태그를 안전하게 분리하는 고급 Spring Boot 워크숍입니다.
+
+## 개요
+
+Repository 쿼리, 캐시 키, 락 키, rate-limit 버킷이 공용 리소스 ID만 사용하면 테넌트 간 데이터가 새어 나갈 수 있습니다. 이 모듈은 H2, 인메모리 lock, fixed-window rate-limit bucket으로 실행 환경을 가볍게 유지하고, 테스트로 격리 경계를 증명합니다.
+
+## 아키텍처
+
+```mermaid
+flowchart LR
+    Client["Tenant caller"] --> Service["TenantInvoiceService"]
+    Service --> Repo["TenantInvoiceRepository"]
+    Service --> Unsafe["UnsafeInvoiceRepository baseline"]
+    Service --> Cache["TenantInvoiceCache"]
+    Service --> Lock["TenantLockRegistry"]
+    Service --> Rate["TenantRateLimiter"]
+    Service --> Metrics["TenantMetrics"]
+    Repo --> H2[("H2 + Exposed")]
+    Unsafe --> H2
+```
+
+## 주요 구성
+
+| 클래스 | 역할 |
+|---|---|
+| `TenantId` | 모든 격리 경계에 사용하는 정규화된 테넌트 값 |
+| `InvoiceTable` | 필수 `tenant_id` 컬럼을 가진 공유 테이블 |
+| `TenantInvoiceRepository` | tenant predicate를 강제하는 안전한 `LongJdbcRepository` 구현 |
+| `UnsafeInvoiceRepository` | tenant predicate를 빠뜨린 baseline 경로 |
+| `TenantKeyFactory` | 테넌트 prefix가 붙은 캐시, 락, rate-limit 키 생성 |
+| `TenantInvoiceService` | repository, cache, lock, rate-limit, metrics 경로 조합 |
+
+## 사용된 Bluetape4k 기능
+
+| 기능 | 모듈/아티팩트 | 코드 위치 | 이점 |
+|---|---|---|---|
+| Exposed JDBC repository helper | `bluetape4k-exposed-jdbc` | `TenantInvoiceRepository : LongJdbcRepository` | Bluetape4k repository 기본 동작을 재사용하면서 tenant predicate를 명시 |
+| Spring Boot support | `bluetape4k-spring-boot4-core` | `build.gradle.kts` | Spring Boot 4 워크숍 모듈과 일관성 유지 |
+| Logging | `bluetape4k-logging` | `KLogging` companion | 공통 Bluetape4k 로깅 관례 사용 |
+| Metrics bridge | `bluetape4k-micrometer` | `TenantMetrics` | 테넌트 태그가 붙은 Micrometer counter를 Bluetape4k 의존성 집합 안에서 사용 |
+| JUnit support and assertions | `bluetape4k-junit5`, `bluetape4k-assertions` | `TenantIsolationTest` | 저장소 표준 테스트 lifecycle과 matcher 사용 |
+
+## Before / After
+
+### Repository
+
+```kotlin
+// Before: ID만 조회하면 다른 테넌트 row가 노출될 수 있습니다.
+InvoiceTable.selectAll()
+    .where { InvoiceTable.id eq invoiceId }
+    .firstOrNull()
+
+// After: tenant와 ID가 모두 맞아야 합니다.
+InvoiceTable.selectAll()
+    .where {
+        (InvoiceTable.tenantId eq tenantId.value) and (InvoiceTable.id eq invoiceId)
+    }
+    .firstOrNull()
+```
+
+### 캐시, 락, Rate Limit 키
+
+```kotlin
+// Before
+invoice:42
+
+// After
+tenant:tenant-alpha:invoice:42
+tenant:tenant-alpha:lock:invoice:42
+tenant:tenant-alpha:rate-limit:reader
+```
+
+## 실행
+
+```bash
+./gradlew :spring-boot-multi-tenant-data-isolation:test
+```
+
+## 테스트가 증명하는 것
+
+- ID만 사용하는 baseline repository/cache 경로는 테넌트 데이터를 누출합니다.
+- 테넌트가 다른 invoice ID 조회는 `null`을 반환합니다.
+- 테넌트가 다른 write는 invoice 상태를 변경하지 못합니다.
+- 캐시 키, 락 키, rate-limit 키, 메트릭이 tenant scope를 포함합니다.
+
+## Gap Notes
+
+이 모듈은 인메모리 상태로 lock/rate-limit 격리를 보여줍니다. 실제 Redis/Redisson 락과 Bucket4j backend는 의도적으로 제외해서 tenant key 설계에 집중합니다.

--- a/spring-boot/multi-tenant-data-isolation/README.md
+++ b/spring-boot/multi-tenant-data-isolation/README.md
@@ -1,0 +1,92 @@
+# Multi-Tenant Data Isolation
+
+[English](README.md) | [한국어](README.ko.md)
+
+Advanced Spring Boot workshop for tenant-safe data access, cache keys, lock keys, rate-limit buckets, and metrics tags.
+
+## Overview
+
+Tenant isolation fails when a repository query, cache key, lock key, or rate-limit bucket uses only a shared resource ID. This module keeps the infrastructure lightweight with H2, in-memory locks, and fixed-window rate-limit buckets, then proves the isolation boundary with executable tests.
+
+## Architecture
+
+```mermaid
+flowchart LR
+    Client["Tenant caller"] --> Service["TenantInvoiceService"]
+    Service --> Repo["TenantInvoiceRepository"]
+    Service --> Unsafe["UnsafeInvoiceRepository baseline"]
+    Service --> Cache["TenantInvoiceCache"]
+    Service --> Lock["TenantLockRegistry"]
+    Service --> Rate["TenantRateLimiter"]
+    Service --> Metrics["TenantMetrics"]
+    Repo --> H2[("H2 + Exposed")]
+    Unsafe --> H2
+```
+
+## Main Components
+
+| Class | Role |
+|---|---|
+| `TenantId` | Normalized tenant value used by all isolation boundaries |
+| `InvoiceTable` | Shared table with mandatory `tenant_id` column |
+| `TenantInvoiceRepository` | Safe `LongJdbcRepository` implementation with tenant predicates |
+| `UnsafeInvoiceRepository` | Baseline path that omits tenant predicates |
+| `TenantKeyFactory` | Tenant-prefixed cache, lock, and rate-limit keys |
+| `TenantInvoiceService` | Composes repository, cache, lock, rate-limit, and metrics behavior |
+
+## Used Bluetape4k Features
+
+| Feature | Module/artifact | Code reference | Benefit |
+|---|---|---|---|
+| Exposed JDBC repository helper | `bluetape4k-exposed-jdbc` | `TenantInvoiceRepository : LongJdbcRepository` | Reuses Bluetape4k repository defaults while keeping tenant predicates explicit |
+| Spring Boot support | `bluetape4k-spring-boot4-core` | `build.gradle.kts` | Aligns with Spring Boot 4 workshop modules |
+| Logging | `bluetape4k-logging` | `KLogging` companions | Uses the common Bluetape4k logging convention |
+| Metrics bridge | `bluetape4k-micrometer` | `TenantMetrics` | Keeps tenant-tagged Micrometer counters in the Bluetape4k dependency set |
+| JUnit support and assertions | `bluetape4k-junit5`, `bluetape4k-assertions` | `TenantIsolationTest` | Uses repository-standard test lifecycle and matchers |
+
+## Before / After
+
+### Repository
+
+```kotlin
+// Before: ID-only lookup can leak rows across tenants.
+InvoiceTable.selectAll()
+    .where { InvoiceTable.id eq invoiceId }
+    .firstOrNull()
+
+// After: tenant and ID must both match.
+InvoiceTable.selectAll()
+    .where {
+        (InvoiceTable.tenantId eq tenantId.value) and (InvoiceTable.id eq invoiceId)
+    }
+    .firstOrNull()
+```
+
+### Cache, Lock, and Rate Limit Keys
+
+```kotlin
+// Before
+invoice:42
+
+// After
+tenant:tenant-alpha:invoice:42
+tenant:tenant-alpha:lock:invoice:42
+tenant:tenant-alpha:rate-limit:reader
+```
+
+## Run
+
+```bash
+./gradlew :spring-boot-multi-tenant-data-isolation:test
+```
+
+## What the Tests Prove
+
+- Baseline ID-only repository and cache paths leak tenant data.
+- Tenant-scoped reads return `null` for another tenant's invoice ID.
+- Tenant-scoped writes do not update another tenant's invoice.
+- Cache keys, lock keys, rate-limit keys, and metrics use tenant scope.
+
+## Gap Notes
+
+This module demonstrates lock and rate-limit isolation with in-memory state. Real Redis/Redisson locks and Bucket4j backends are deliberately out of scope so the workshop focuses on tenant key design.

--- a/spring-boot/multi-tenant-data-isolation/build.gradle.kts
+++ b/spring-boot/multi-tenant-data-isolation/build.gradle.kts
@@ -1,0 +1,54 @@
+plugins {
+    alias(libs.plugins.kotlin.spring)
+    alias(libs.plugins.spring.boot)
+}
+springBoot {
+    mainClass.set("io.bluetape4k.workshop.multitenant.MultiTenantDataIsolationApplicationKt")
+}
+
+configurations {
+    testImplementation.get().extendsFrom(compileOnly.get(), runtimeOnly.get())
+}
+
+dependencies {
+    testImplementation(project(":shared"))
+    testImplementation(libs.bluetape4k.junit5)
+    testImplementation(libs.bluetape4k.assertions)
+    testImplementation(libs.mockk)
+    testImplementation(libs.springmockk)
+
+    // Bluetape4k
+    implementation(libs.bluetape4k.core)
+    implementation(libs.bluetape4k.logging)
+    implementation(libs.bluetape4k.spring.boot4.core)
+    implementation(libs.bluetape4k.micrometer)
+
+    // Exposed
+    implementation(libs.exposed.core)
+    implementation(libs.exposed.jdbc)
+    implementation(libs.jetbrains.exposed.spring.boot4.starter)
+    implementation(libs.jetbrains.exposed.spring7.transaction)
+
+    // DB
+    implementation(libs.hikaricp)
+    runtimeOnly(libs.h2.v2)
+
+    // Spring Boot
+    implementation(libs.spring.boot.autoconfigure.lib)
+    annotationProcessor(libs.spring.boot.autoconfigure.processor)
+    annotationProcessor(libs.spring.boot.configuration.processor)
+    developmentOnly(libs.spring.boot.devtools)
+    implementation(libs.spring.boot.starter.actuator)
+    implementation(libs.spring.boot.starter.jdbc.lib)
+    implementation(libs.spring.boot.starter.validation)
+    implementation(libs.spring.boot.starter.webmvc.lib)
+    testImplementation(libs.spring.boot.starter.webmvc.test)
+    testImplementation(libs.spring.boot.starter.test) {
+        exclude(group = "junit", module = "junit")
+        exclude(group = "org.junit.vintage", module = "junit-vintage-engine")
+        exclude(module = "mockito-core")
+    }
+
+    // Observability
+    implementation(libs.micrometer.core)
+}

--- a/spring-boot/multi-tenant-data-isolation/src/main/kotlin/io/bluetape4k/workshop/multitenant/MultiTenantDataIsolationApplication.kt
+++ b/spring-boot/multi-tenant-data-isolation/src/main/kotlin/io/bluetape4k/workshop/multitenant/MultiTenantDataIsolationApplication.kt
@@ -1,0 +1,14 @@
+package io.bluetape4k.workshop.multitenant
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
+
+/**
+ * Spring Boot entrypoint for the multi-tenant data isolation workshop.
+ */
+@SpringBootApplication
+class MultiTenantDataIsolationApplication
+
+fun main(args: Array<String>) {
+    runApplication<MultiTenantDataIsolationApplication>(*args)
+}

--- a/spring-boot/multi-tenant-data-isolation/src/main/kotlin/io/bluetape4k/workshop/multitenant/config/ExposedSchemaInitializer.kt
+++ b/spring-boot/multi-tenant-data-isolation/src/main/kotlin/io/bluetape4k/workshop/multitenant/config/ExposedSchemaInitializer.kt
@@ -1,0 +1,25 @@
+package io.bluetape4k.workshop.multitenant.config
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.info
+import io.bluetape4k.workshop.multitenant.domain.InvoiceTable
+import org.jetbrains.exposed.v1.jdbc.SchemaUtils
+import org.springframework.boot.ApplicationArguments
+import org.springframework.boot.ApplicationRunner
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * Creates workshop tables when the application starts.
+ */
+@Component
+class ExposedSchemaInitializer : ApplicationRunner {
+
+    companion object : KLogging()
+
+    @Transactional
+    override fun run(args: ApplicationArguments) {
+        log.info { "Creating tenant isolation workshop schema." }
+        SchemaUtils.createMissingTablesAndColumns(InvoiceTable)
+    }
+}

--- a/spring-boot/multi-tenant-data-isolation/src/main/kotlin/io/bluetape4k/workshop/multitenant/domain/InvoiceRecord.kt
+++ b/spring-boot/multi-tenant-data-isolation/src/main/kotlin/io/bluetape4k/workshop/multitenant/domain/InvoiceRecord.kt
@@ -1,0 +1,29 @@
+package io.bluetape4k.workshop.multitenant.domain
+
+import java.io.Serializable
+import java.math.BigDecimal
+
+/**
+ * Invoice record persisted by the tenant-scoped Exposed repository.
+ */
+data class InvoiceRecord(
+    val id: Long = 0L,
+    val tenantId: TenantId,
+    val customerName: String,
+    val amount: BigDecimal,
+    val status: InvoiceStatus = InvoiceStatus.OPEN,
+) : Serializable {
+
+    companion object {
+        private const val serialVersionUID: Long = 104L
+    }
+}
+
+/**
+ * Minimal invoice lifecycle for isolation tests.
+ */
+enum class InvoiceStatus {
+    OPEN,
+    PAID,
+    VOID,
+}

--- a/spring-boot/multi-tenant-data-isolation/src/main/kotlin/io/bluetape4k/workshop/multitenant/domain/InvoiceTable.kt
+++ b/spring-boot/multi-tenant-data-isolation/src/main/kotlin/io/bluetape4k/workshop/multitenant/domain/InvoiceTable.kt
@@ -1,0 +1,26 @@
+package io.bluetape4k.workshop.multitenant.domain
+
+import org.jetbrains.exposed.v1.core.ResultRow
+import org.jetbrains.exposed.v1.core.dao.id.LongIdTable
+
+/**
+ * Shared invoice table. Tenant isolation is enforced by repository predicates.
+ */
+object InvoiceTable : LongIdTable("tenant_invoices") {
+    val tenantId = varchar("tenant_id", 64)
+    val customerName = varchar("customer_name", 120)
+    val amount = decimal("amount", 19, 2)
+    val status = enumerationByName("status", 20, InvoiceStatus::class).default(InvoiceStatus.OPEN)
+}
+
+/**
+ * Maps an Exposed row to an [InvoiceRecord].
+ */
+fun ResultRow.toInvoiceRecord(): InvoiceRecord =
+    InvoiceRecord(
+        id = this[InvoiceTable.id].value,
+        tenantId = TenantId(this[InvoiceTable.tenantId]),
+        customerName = this[InvoiceTable.customerName],
+        amount = this[InvoiceTable.amount],
+        status = this[InvoiceTable.status],
+    )

--- a/spring-boot/multi-tenant-data-isolation/src/main/kotlin/io/bluetape4k/workshop/multitenant/domain/TenantId.kt
+++ b/spring-boot/multi-tenant-data-isolation/src/main/kotlin/io/bluetape4k/workshop/multitenant/domain/TenantId.kt
@@ -1,0 +1,31 @@
+package io.bluetape4k.workshop.multitenant.domain
+
+import java.io.Serializable
+
+/**
+ * Normalized tenant identifier used in every isolation boundary.
+ */
+@JvmInline
+value class TenantId(val value: String) : Serializable {
+
+    init {
+        require(value.isNotBlank()) { "tenantId must not be blank" }
+        require(value.matches(Regex("[a-z0-9][a-z0-9-]{1,62}"))) {
+            "tenantId must use lowercase letters, digits, or hyphens"
+        }
+    }
+
+    /**
+     * Returns the stable prefix used for tenant-scoped keys.
+     */
+    fun keyPrefix(): String = "tenant:$value"
+
+    override fun toString(): String = value
+
+    companion object {
+        private const val serialVersionUID: Long = 104L
+
+        val ALPHA: TenantId = TenantId("tenant-alpha")
+        val BETA: TenantId = TenantId("tenant-beta")
+    }
+}

--- a/spring-boot/multi-tenant-data-isolation/src/main/kotlin/io/bluetape4k/workshop/multitenant/repository/TenantInvoiceRepository.kt
+++ b/spring-boot/multi-tenant-data-isolation/src/main/kotlin/io/bluetape4k/workshop/multitenant/repository/TenantInvoiceRepository.kt
@@ -1,0 +1,89 @@
+package io.bluetape4k.workshop.multitenant.repository
+
+import io.bluetape4k.exposed.jdbc.repository.LongJdbcRepository
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.workshop.multitenant.domain.InvoiceRecord
+import io.bluetape4k.workshop.multitenant.domain.InvoiceStatus
+import io.bluetape4k.workshop.multitenant.domain.InvoiceTable
+import io.bluetape4k.workshop.multitenant.domain.TenantId
+import io.bluetape4k.workshop.multitenant.domain.toInvoiceRecord
+import org.jetbrains.exposed.v1.core.ResultRow
+import org.jetbrains.exposed.v1.core.SortOrder
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.deleteAll
+import org.jetbrains.exposed.v1.jdbc.insertAndGetId
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.update
+import org.springframework.stereotype.Repository
+
+/**
+ * Tenant-safe invoice repository backed by Bluetape4k's Exposed JDBC repository helper.
+ *
+ * Callers execute repository operations inside a Spring-managed transaction.
+ */
+@Repository
+class TenantInvoiceRepository : LongJdbcRepository<InvoiceRecord> {
+
+    companion object : KLogging()
+
+    override val table = InvoiceTable
+
+    override fun extractId(entity: InvoiceRecord): Long = entity.id
+
+    override fun ResultRow.toEntity(): InvoiceRecord = toInvoiceRecord()
+
+    /**
+     * Inserts an invoice and returns the persisted record.
+     */
+    fun saveInvoice(invoice: InvoiceRecord): InvoiceRecord {
+        val id = InvoiceTable.insertAndGetId {
+            it[tenantId] = invoice.tenantId.value
+            it[customerName] = invoice.customerName
+            it[amount] = invoice.amount
+            it[status] = invoice.status
+        }.value
+        return requireNotNull(findByTenantAndId(invoice.tenantId, id)) {
+            "Inserted invoice $id was not found for tenant ${invoice.tenantId}"
+        }
+    }
+
+    /**
+     * Finds an invoice only when both tenant and ID match.
+     */
+    fun findByTenantAndId(tenantId: TenantId, invoiceId: Long): InvoiceRecord? =
+        InvoiceTable
+            .selectAll()
+            .where {
+                (InvoiceTable.tenantId eq tenantId.value) and (InvoiceTable.id eq invoiceId)
+            }
+            .firstOrNull()
+            ?.toInvoiceRecord()
+
+    /**
+     * Lists invoices for a single tenant only.
+     */
+    fun findAllByTenant(tenantId: TenantId): List<InvoiceRecord> =
+        InvoiceTable
+            .selectAll()
+            .where { InvoiceTable.tenantId eq tenantId.value }
+            .orderBy(InvoiceTable.id, SortOrder.ASC)
+            .map { it.toInvoiceRecord() }
+
+    /**
+     * Updates invoice status only when the tenant predicate also matches.
+     */
+    fun updateStatus(tenantId: TenantId, invoiceId: Long, status: InvoiceStatus): Boolean =
+        InvoiceTable.update({
+            (InvoiceTable.tenantId eq tenantId.value) and (InvoiceTable.id eq invoiceId)
+        }) {
+            it[InvoiceTable.status] = status
+        } == 1
+
+    /**
+     * Removes all workshop data.
+     */
+    fun deleteAllInvoices() {
+        InvoiceTable.deleteAll()
+    }
+}

--- a/spring-boot/multi-tenant-data-isolation/src/main/kotlin/io/bluetape4k/workshop/multitenant/repository/UnsafeInvoiceRepository.kt
+++ b/spring-boot/multi-tenant-data-isolation/src/main/kotlin/io/bluetape4k/workshop/multitenant/repository/UnsafeInvoiceRepository.kt
@@ -1,0 +1,27 @@
+package io.bluetape4k.workshop.multitenant.repository
+
+import io.bluetape4k.workshop.multitenant.domain.InvoiceRecord
+import io.bluetape4k.workshop.multitenant.domain.InvoiceTable
+import io.bluetape4k.workshop.multitenant.domain.toInvoiceRecord
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.springframework.stereotype.Repository
+
+/**
+ * Baseline repository that intentionally omits tenant predicates.
+ *
+ * This class exists only to make leakage risk executable in tests.
+ */
+@Repository
+class UnsafeInvoiceRepository {
+
+    /**
+     * Finds by invoice ID alone, allowing a caller from another tenant to read the row.
+     */
+    fun findByIdWithoutTenant(invoiceId: Long): InvoiceRecord? =
+        InvoiceTable
+            .selectAll()
+            .where { InvoiceTable.id eq invoiceId }
+            .firstOrNull()
+            ?.toInvoiceRecord()
+}

--- a/spring-boot/multi-tenant-data-isolation/src/main/kotlin/io/bluetape4k/workshop/multitenant/service/TenantInvoiceCache.kt
+++ b/spring-boot/multi-tenant-data-isolation/src/main/kotlin/io/bluetape4k/workshop/multitenant/service/TenantInvoiceCache.kt
@@ -1,0 +1,61 @@
+package io.bluetape4k.workshop.multitenant.service
+
+import io.bluetape4k.workshop.multitenant.domain.InvoiceRecord
+import io.bluetape4k.workshop.multitenant.domain.TenantId
+import org.springframework.stereotype.Component
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * In-memory cache that demonstrates the difference between tenant-safe and unsafe keys.
+ */
+@Component
+class TenantInvoiceCache(
+    private val keyFactory: TenantKeyFactory,
+) {
+
+    private val cache = ConcurrentHashMap<String, InvoiceRecord>()
+
+    /**
+     * Reads with a tenant-prefixed key.
+     */
+    fun getOrLoad(
+        tenantId: TenantId,
+        invoiceId: Long,
+        loader: () -> InvoiceRecord?,
+    ): InvoiceRecord? {
+        val key = keyFactory.invoiceCacheKey(tenantId, invoiceId)
+        cache[key]?.let { return it }
+        return loader()?.also { cache[key] = it }
+    }
+
+    /**
+     * Reads with an unsafe key that omits tenant scope.
+     */
+    fun getOrLoadUnsafe(
+        invoiceId: Long,
+        loader: () -> InvoiceRecord?,
+    ): InvoiceRecord? {
+        val key = keyFactory.unsafeInvoiceCacheKey(invoiceId)
+        cache[key]?.let { return it }
+        return loader()?.also { cache[key] = it }
+    }
+
+    /**
+     * Returns current cache keys for workshop assertions.
+     */
+    fun keys(): Set<String> = cache.keys.toSet()
+
+    /**
+     * Evicts a tenant-scoped invoice cache entry.
+     */
+    fun evict(tenantId: TenantId, invoiceId: Long) {
+        cache.remove(keyFactory.invoiceCacheKey(tenantId, invoiceId))
+    }
+
+    /**
+     * Clears all cache entries.
+     */
+    fun clear() {
+        cache.clear()
+    }
+}

--- a/spring-boot/multi-tenant-data-isolation/src/main/kotlin/io/bluetape4k/workshop/multitenant/service/TenantInvoiceService.kt
+++ b/spring-boot/multi-tenant-data-isolation/src/main/kotlin/io/bluetape4k/workshop/multitenant/service/TenantInvoiceService.kt
@@ -1,0 +1,98 @@
+package io.bluetape4k.workshop.multitenant.service
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.workshop.multitenant.domain.InvoiceRecord
+import io.bluetape4k.workshop.multitenant.domain.InvoiceStatus
+import io.bluetape4k.workshop.multitenant.domain.TenantId
+import io.bluetape4k.workshop.multitenant.repository.TenantInvoiceRepository
+import io.bluetape4k.workshop.multitenant.repository.UnsafeInvoiceRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * Application service that composes tenant-scoped data, cache, lock, rate-limit, and metric paths.
+ */
+@Service
+class TenantInvoiceService(
+    private val tenantRepository: TenantInvoiceRepository,
+    private val unsafeRepository: UnsafeInvoiceRepository,
+    private val invoiceCache: TenantInvoiceCache,
+    private val lockRegistry: TenantLockRegistry,
+    private val rateLimiter: TenantRateLimiter,
+    private val metrics: TenantMetrics,
+) {
+
+    companion object : KLogging()
+
+    /**
+     * Creates a tenant-scoped invoice.
+     */
+    @Transactional
+    fun createInvoice(invoice: InvoiceRecord): InvoiceRecord =
+        tenantRepository.saveInvoice(invoice).also {
+            metrics.recordInvoiceWrite(it.tenantId)
+        }
+
+    /**
+     * Reads an invoice through the tenant-safe repository and cache.
+     */
+    @Transactional(readOnly = true)
+    fun findInvoice(tenantId: TenantId, invoiceId: Long): InvoiceRecord? =
+        invoiceCache.getOrLoad(tenantId, invoiceId) {
+            tenantRepository.findByTenantAndId(tenantId, invoiceId)
+        }?.also {
+            metrics.recordInvoiceRead(tenantId)
+        }
+
+    /**
+     * Updates an invoice only when the tenant predicate matches.
+     */
+    @Transactional
+    fun markPaid(tenantId: TenantId, invoiceId: Long): Boolean =
+        tenantRepository.updateStatus(tenantId, invoiceId, InvoiceStatus.PAID).also { updated ->
+            if (updated) {
+                invoiceCache.evict(tenantId, invoiceId)
+            }
+        }
+
+    /**
+     * Baseline read path that intentionally omits tenant scope.
+     */
+    @Transactional(readOnly = true)
+    fun unsafeFindInvoiceForBaseline(requestingTenantId: TenantId, invoiceId: Long): InvoiceRecord? =
+        invoiceCache.getOrLoadUnsafe(invoiceId) {
+            unsafeRepository.findByIdWithoutTenant(invoiceId)
+        }?.also {
+            metrics.recordInvoiceRead(requestingTenantId)
+        }
+
+    /**
+     * Executes a tenant-keyed invoice lock scenario.
+     */
+    fun <T> withInvoiceLock(tenantId: TenantId, invoiceId: Long, block: (String) -> T): T =
+        lockRegistry.withInvoiceLock(tenantId, invoiceId, block)
+
+    /**
+     * Consumes one request from a tenant-keyed rate-limit bucket.
+     */
+    fun tryRateLimit(tenantId: TenantId, principal: String, limit: Int = 2): RateLimitDecision =
+        rateLimiter.tryConsume(tenantId, principal, limit)
+
+    /**
+     * Clears volatile state for tests and repeatable workshop runs.
+     */
+    fun resetVolatileState() {
+        invoiceCache.clear()
+        lockRegistry.clear()
+        rateLimiter.clear()
+    }
+
+    /**
+     * Clears persistent and volatile workshop state.
+     */
+    @Transactional
+    fun resetWorkshopState() {
+        tenantRepository.deleteAllInvoices()
+        resetVolatileState()
+    }
+}

--- a/spring-boot/multi-tenant-data-isolation/src/main/kotlin/io/bluetape4k/workshop/multitenant/service/TenantKeyFactory.kt
+++ b/spring-boot/multi-tenant-data-isolation/src/main/kotlin/io/bluetape4k/workshop/multitenant/service/TenantKeyFactory.kt
@@ -1,0 +1,34 @@
+package io.bluetape4k.workshop.multitenant.service
+
+import io.bluetape4k.workshop.multitenant.domain.TenantId
+import org.springframework.stereotype.Component
+
+/**
+ * Builds tenant-prefixed keys for every non-database isolation boundary.
+ */
+@Component
+class TenantKeyFactory {
+
+    /**
+     * Cache key that includes tenant scope.
+     */
+    fun invoiceCacheKey(tenantId: TenantId, invoiceId: Long): String =
+        "${tenantId.keyPrefix()}:invoice:$invoiceId"
+
+    /**
+     * Baseline cache key that intentionally omits tenant scope.
+     */
+    fun unsafeInvoiceCacheKey(invoiceId: Long): String = "invoice:$invoiceId"
+
+    /**
+     * Lock key that includes tenant scope.
+     */
+    fun invoiceLockKey(tenantId: TenantId, invoiceId: Long): String =
+        "${tenantId.keyPrefix()}:lock:invoice:$invoiceId"
+
+    /**
+     * Rate-limit key that includes tenant scope and the caller principal.
+     */
+    fun rateLimitKey(tenantId: TenantId, principal: String): String =
+        "${tenantId.keyPrefix()}:rate-limit:$principal"
+}

--- a/spring-boot/multi-tenant-data-isolation/src/main/kotlin/io/bluetape4k/workshop/multitenant/service/TenantLockRegistry.kt
+++ b/spring-boot/multi-tenant-data-isolation/src/main/kotlin/io/bluetape4k/workshop/multitenant/service/TenantLockRegistry.kt
@@ -1,0 +1,39 @@
+package io.bluetape4k.workshop.multitenant.service
+
+import io.bluetape4k.workshop.multitenant.domain.TenantId
+import org.springframework.stereotype.Component
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
+
+/**
+ * Tenant-keyed lock registry for deterministic workshop tests.
+ */
+@Component
+class TenantLockRegistry(
+    private val keyFactory: TenantKeyFactory,
+) {
+
+    private val locks = ConcurrentHashMap<String, ReentrantLock>()
+
+    /**
+     * Executes [block] while holding a lock whose key includes tenant scope.
+     */
+    fun <T> withInvoiceLock(tenantId: TenantId, invoiceId: Long, block: (String) -> T): T {
+        val key = keyFactory.invoiceLockKey(tenantId, invoiceId)
+        val lock = locks.computeIfAbsent(key) { ReentrantLock() }
+        return lock.withLock { block(key) }
+    }
+
+    /**
+     * Returns the lock keys created during the workshop scenario.
+     */
+    fun keys(): Set<String> = locks.keys.toSet()
+
+    /**
+     * Clears all lock entries.
+     */
+    fun clear() {
+        locks.clear()
+    }
+}

--- a/spring-boot/multi-tenant-data-isolation/src/main/kotlin/io/bluetape4k/workshop/multitenant/service/TenantMetrics.kt
+++ b/spring-boot/multi-tenant-data-isolation/src/main/kotlin/io/bluetape4k/workshop/multitenant/service/TenantMetrics.kt
@@ -1,0 +1,39 @@
+package io.bluetape4k.workshop.multitenant.service
+
+import io.bluetape4k.workshop.multitenant.domain.TenantId
+import io.micrometer.core.instrument.MeterRegistry
+import org.springframework.stereotype.Component
+
+/**
+ * Records tenant-tagged counters for the workshop service.
+ */
+@Component
+class TenantMetrics(
+    private val meterRegistry: MeterRegistry,
+) {
+
+    /**
+     * Records an invoice read for [tenantId].
+     */
+    fun recordInvoiceRead(tenantId: TenantId) {
+        meterRegistry.counter(INVOICE_READS, "tenant", tenantId.value).increment()
+    }
+
+    /**
+     * Records an invoice write for [tenantId].
+     */
+    fun recordInvoiceWrite(tenantId: TenantId) {
+        meterRegistry.counter(INVOICE_WRITES, "tenant", tenantId.value).increment()
+    }
+
+    /**
+     * Returns the current read count for [tenantId].
+     */
+    fun invoiceReads(tenantId: TenantId): Double =
+        meterRegistry.counter(INVOICE_READS, "tenant", tenantId.value).count()
+
+    companion object {
+        const val INVOICE_READS: String = "tenant.invoice.reads"
+        const val INVOICE_WRITES: String = "tenant.invoice.writes"
+    }
+}

--- a/spring-boot/multi-tenant-data-isolation/src/main/kotlin/io/bluetape4k/workshop/multitenant/service/TenantRateLimiter.kt
+++ b/spring-boot/multi-tenant-data-isolation/src/main/kotlin/io/bluetape4k/workshop/multitenant/service/TenantRateLimiter.kt
@@ -1,0 +1,86 @@
+package io.bluetape4k.workshop.multitenant.service
+
+import io.bluetape4k.workshop.multitenant.domain.TenantId
+import org.springframework.stereotype.Component
+import java.io.Serializable
+import java.time.Duration
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Fixed-window tenant-keyed rate limiter for workshop isolation tests.
+ */
+@Component
+class TenantRateLimiter(
+    private val keyFactory: TenantKeyFactory,
+) {
+
+    private val buckets = ConcurrentHashMap<String, RateLimitBucket>()
+
+    /**
+     * Consumes one request from the tenant/principal bucket.
+     */
+    fun tryConsume(
+        tenantId: TenantId,
+        principal: String,
+        limit: Int = DEFAULT_LIMIT,
+        window: Duration = DEFAULT_WINDOW,
+    ): RateLimitDecision {
+        require(limit > 0) { "limit must be positive" }
+        require(!window.isZero && !window.isNegative) { "window must be positive" }
+
+        val key = keyFactory.rateLimitKey(tenantId, principal)
+        val windowMillis = window.toMillis()
+        val windowStart = (System.currentTimeMillis() / windowMillis) * windowMillis
+        val bucket = buckets.compute(key) { _, current ->
+            if (current?.windowStartEpochMillis == windowStart) {
+                current.copy(used = current.used + 1)
+            } else {
+                RateLimitBucket(windowStartEpochMillis = windowStart, used = 1)
+            }
+        } ?: RateLimitBucket(windowStartEpochMillis = windowStart, used = 1)
+
+        return RateLimitDecision(
+            key = key,
+            allowed = bucket.used <= limit,
+            remaining = (limit - bucket.used).coerceAtLeast(0),
+            resetAtEpochMillis = bucket.windowStartEpochMillis + windowMillis,
+        )
+    }
+
+    /**
+     * Clears all limiter buckets.
+     */
+    fun clear() {
+        buckets.clear()
+    }
+
+    companion object {
+        private const val DEFAULT_LIMIT: Int = 2
+        private val DEFAULT_WINDOW: Duration = Duration.ofMinutes(1)
+    }
+}
+
+/**
+ * Result of a tenant-keyed rate-limit check.
+ */
+data class RateLimitDecision(
+    val key: String,
+    val allowed: Boolean,
+    val remaining: Int,
+    val resetAtEpochMillis: Long,
+) : Serializable {
+
+    companion object {
+        private const val serialVersionUID: Long = 104L
+    }
+}
+
+private data class RateLimitBucket(
+    val windowStartEpochMillis: Long,
+    val used: Int,
+) : Serializable {
+
+    companion object {
+        private const val serialVersionUID: Long = 104L
+    }
+}

--- a/spring-boot/multi-tenant-data-isolation/src/main/resources/application.yml
+++ b/spring-boot/multi-tenant-data-isolation/src/main/resources/application.yml
@@ -1,0 +1,18 @@
+spring:
+  application:
+    name: multi-tenant-data-isolation
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:tenant-isolation;MODE=PostgreSQL;DATABASE_TO_UPPER=false;DB_CLOSE_DELAY=-1
+    username: sa
+    password:
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,metrics
+
+logging:
+  level:
+    io.bluetape4k.workshop.multitenant: DEBUG

--- a/spring-boot/multi-tenant-data-isolation/src/test/kotlin/io/bluetape4k/workshop/multitenant/TenantIsolationTest.kt
+++ b/spring-boot/multi-tenant-data-isolation/src/test/kotlin/io/bluetape4k/workshop/multitenant/TenantIsolationTest.kt
@@ -1,0 +1,123 @@
+package io.bluetape4k.workshop.multitenant
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeGreaterThan
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.workshop.multitenant.domain.InvoiceRecord
+import io.bluetape4k.workshop.multitenant.domain.InvoiceStatus
+import io.bluetape4k.workshop.multitenant.domain.TenantId
+import io.bluetape4k.workshop.multitenant.service.TenantInvoiceCache
+import io.bluetape4k.workshop.multitenant.service.TenantInvoiceService
+import io.bluetape4k.workshop.multitenant.service.TenantKeyFactory
+import io.bluetape4k.workshop.multitenant.service.TenantLockRegistry
+import io.bluetape4k.workshop.multitenant.service.TenantMetrics
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import java.math.BigDecimal
+
+@SpringBootTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class TenantIsolationTest {
+
+    @Autowired
+    private lateinit var service: TenantInvoiceService
+
+    @Autowired
+    private lateinit var cache: TenantInvoiceCache
+
+    @Autowired
+    private lateinit var keyFactory: TenantKeyFactory
+
+    @Autowired
+    private lateinit var lockRegistry: TenantLockRegistry
+
+    @Autowired
+    private lateinit var metrics: TenantMetrics
+
+    @BeforeEach
+    fun reset() {
+        service.resetWorkshopState()
+    }
+
+    @Test
+    fun `baseline repository and cache leak when tenant scope is omitted`() {
+        val alphaInvoice = service.createInvoice(invoice(TenantId.ALPHA, "Alpha Hospital"))
+
+        val leaked = service.unsafeFindInvoiceForBaseline(TenantId.BETA, alphaInvoice.id)
+
+        leaked?.tenantId shouldBeEqualTo TenantId.ALPHA
+        cache.keys().any { it == keyFactory.unsafeInvoiceCacheKey(alphaInvoice.id) }.shouldBeTrue()
+    }
+
+    @Test
+    fun `tenant scoped repository blocks cross tenant reads and writes`() {
+        val alphaInvoice = service.createInvoice(invoice(TenantId.ALPHA, "Alpha Hospital"))
+        service.createInvoice(invoice(TenantId.BETA, "Beta Clinic"))
+
+        service.findInvoice(TenantId.ALPHA, alphaInvoice.id)?.status shouldBeEqualTo InvoiceStatus.OPEN
+        service.findInvoice(TenantId.BETA, alphaInvoice.id).shouldBeNull()
+        service.markPaid(TenantId.BETA, alphaInvoice.id).shouldBeFalse()
+        service.markPaid(TenantId.ALPHA, alphaInvoice.id).shouldBeTrue()
+
+        val alphaAfterWrite = service.findInvoice(TenantId.ALPHA, alphaInvoice.id)
+        alphaAfterWrite?.status shouldBeEqualTo InvoiceStatus.PAID
+    }
+
+    @Test
+    fun `tenant scoped cache keeps same invoice id isolated by tenant key`() {
+        val alphaInvoice = service.createInvoice(invoice(TenantId.ALPHA, "Alpha Hospital"))
+
+        service.findInvoice(TenantId.ALPHA, alphaInvoice.id)?.id shouldBeEqualTo alphaInvoice.id
+        service.findInvoice(TenantId.BETA, alphaInvoice.id).shouldBeNull()
+
+        cache.keys().any {
+            it == keyFactory.invoiceCacheKey(TenantId.ALPHA, alphaInvoice.id)
+        }.shouldBeTrue()
+        cache.keys().any {
+            it == keyFactory.invoiceCacheKey(TenantId.BETA, alphaInvoice.id)
+        }.shouldBeFalse()
+    }
+
+    @Test
+    fun `tenant scoped lock and rate limit keys are isolated`() {
+        val alphaInvoice = service.createInvoice(invoice(TenantId.ALPHA, "Alpha Hospital"))
+
+        val alphaLockKey = service.withInvoiceLock(TenantId.ALPHA, alphaInvoice.id) { it }
+        val betaLockKey = service.withInvoiceLock(TenantId.BETA, alphaInvoice.id) { it }
+
+        alphaLockKey shouldBeEqualTo keyFactory.invoiceLockKey(TenantId.ALPHA, alphaInvoice.id)
+        betaLockKey shouldBeEqualTo keyFactory.invoiceLockKey(TenantId.BETA, alphaInvoice.id)
+        lockRegistry.keys().size shouldBeEqualTo 2
+
+        val alphaFirst = service.tryRateLimit(TenantId.ALPHA, "reader", limit = 1)
+        val alphaSecond = service.tryRateLimit(TenantId.ALPHA, "reader", limit = 1)
+        val betaFirst = service.tryRateLimit(TenantId.BETA, "reader", limit = 1)
+
+        alphaFirst.allowed.shouldBeTrue()
+        alphaSecond.allowed.shouldBeFalse()
+        betaFirst.allowed.shouldBeTrue()
+        alphaFirst.key shouldBeEqualTo keyFactory.rateLimitKey(TenantId.ALPHA, "reader")
+        betaFirst.key shouldBeEqualTo keyFactory.rateLimitKey(TenantId.BETA, "reader")
+    }
+
+    @Test
+    fun `tenant metrics include tenant tag`() {
+        val alphaInvoice = service.createInvoice(invoice(TenantId.ALPHA, "Alpha Hospital"))
+
+        service.findInvoice(TenantId.ALPHA, alphaInvoice.id)
+
+        metrics.invoiceReads(TenantId.ALPHA) shouldBeGreaterThan 0.0
+    }
+
+    private fun invoice(tenantId: TenantId, customerName: String): InvoiceRecord =
+        InvoiceRecord(
+            tenantId = tenantId,
+            customerName = customerName,
+            amount = BigDecimal("125.50"),
+        )
+}

--- a/spring-boot/multi-tenant-data-isolation/src/test/resources/junit-platform.properties
+++ b/spring-boot/multi-tenant-data-isolation/src/test/resources/junit-platform.properties
@@ -1,0 +1,6 @@
+junit.jupiter.extensions.autodetection.enabled=true
+junit.jupiter.testinstance.lifecycle.default=per_class
+
+junit.jupiter.execution.parallel.enabled=false
+junit.jupiter.execution.parallel.mode.default=same_thread
+junit.jupiter.execution.parallel.mode.classes.default=concurrent

--- a/spring-boot/multi-tenant-data-isolation/src/test/resources/logback-test.xml
+++ b/spring-boot/multi-tenant-data-isolation/src/test/resources/logback-test.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+    <!-- @formatter:off -->
+    <springProperty scope="context" name="APP_NAME" source="spring.application.name"/>
+
+    <property name="CONSOLE_LOG_PATTERN"
+              value="%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %highlight(${LOG_LEVEL_PATTERN:-%5p}) %magenta(${PID:- }) %clr(---){faint} %clr([%25.25t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}"/>
+
+    <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>INFO</level>
+        </filter>
+        <encoder>
+            <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+            <charset>utf8</charset>
+        </encoder>
+    </appender>
+    <!-- formatter:on -->
+
+    <logger name="io.bluetape4k.workshop.multitenant" level="DEBUG"/>
+
+    <root level="INFO">
+        <appender-ref ref="console"/>
+    </root>
+</configuration>


### PR DESCRIPTION
Closes #104

## Background

Issue #104 asks for an advanced multi-tenant data isolation workshop. The example must make tenant scope visible across data access, cache keys, rate limits, locks, metrics, and tests, while actively using Bluetape4k libraries.

## Work Done

- Added `spring-boot/multi-tenant-data-isolation`.
- Implemented safe tenant-scoped Exposed JDBC repository with `LongJdbcRepository`.
- Added unsafe baseline repository/cache paths so leakage risk is executable.
- Added tenant-prefixed cache, lock, fixed-window rate-limit, and Micrometer metric examples.
- Added tests proving cross-tenant read/write/cache isolation and key/tag isolation.
- Added `README.md`, `README.ko.md`, root README entries, spec, plan, and lesson.

## DoD

- [x] Baseline leakage test included.
- [x] Tenant-scoped repository and cache keys implemented.
- [x] Tenant-aware lock and rate-limit examples included.
- [x] Tests prove cross-tenant reads/writes/cache hits are blocked.
- [x] `Used Bluetape4k features` table included in README.
- [x] Before/after explanation included.
- [x] `./gradlew :spring-boot-multi-tenant-data-isolation:test` passed.
- [x] `./gradlew projects` includes `:spring-boot-multi-tenant-data-isolation`.
- [x] `git diff --check` passed.
- [x] Claude design gate: `.omx/artifacts/claude-issue-104-design-rerun-20260524153255.md`, P0=0, P1=0.
- [x] Claude code review gate: `.omx/artifacts/claude-issue-104-code-review-final-20260524154933.md`, P0=0, P1=0.

## Commit

- `603ecc98 feat: demonstrate tenant isolation boundaries`

