### PR TITLE
feat: add spring-boot/cache-benchmark with 7 cache profiles (kotlinx-benchmark)

### DIFF
--- a/docs/lessons/2026-05-24-cache-benchmark-advanced.md
+++ b/docs/lessons/2026-05-24-cache-benchmark-advanced.md
@@ -1,0 +1,92 @@
+# cache-benchmark-advanced — Lessons Learned
+
+**Date**: 2026-05-24  
+**Branch**: feat/issue-95-near-cache-benchmark  
+**Module**: spring-boot/cache-benchmark  
+**Issue**: #95
+
+---
+
+## 요약
+
+7가지 캐시 전략을 kotlinx-benchmark(JMH 기반)으로 비교하는 Spring Boot 워크샵 모듈 구현.
+각 프로파일은 동일한 `ProductCacheService` 인터페이스를 구현하며 기능 동등성을 보장한다.
+
+---
+
+## Root Cause / Decisions
+
+### 1. Redisson 4.x API 변경 — LocalCachedMapOptions 패키지 이동
+
+- **문제**: `org.redisson.api.LocalCachedMapOptions` (3.x) → Redisson 4.x에서 `org.redisson.api.options.LocalCachedMapOptions`로 이동
+- **증상**: `Unresolved reference 'name'` 컴파일 에러 (올바른 import 없을 때)
+- **해결**: import를 `org.redisson.api.options.LocalCachedMapOptions`로 수정, Duration 파라미터 형식도 `TimeUnit` → `java.time.Duration`으로 변경
+- **교훈**: Redisson 버전 업그레이드 시 `api.options` 패키지 확인 필수
+
+### 2. @Async 자기 호출(self-invocation) — 프록시 우회 버그
+
+- **문제**: `WriteBehindService.save()` 내에서 `this.asyncPersist(product)`를 직접 호출하면 Spring 프록시를 우회해 동기 실행됨. `@EnableAsync`가 있어도 해결 안 됨.
+- **결과**: write-behind 패턴의 핵심 이점(낮은 쓰기 지연)이 사라짐
+- **해결**: `WriteBehindFlusher` 별도 `@Component` 추출 → 외부 빈 호출로 프록시 통과
+- **교훈**: Spring `@Async`, `@Transactional`, `@Cacheable`은 같은 클래스 내 자기 호출에서 동작하지 않는다. 항상 별도 빈으로 분리할 것.
+
+### 3. Write-Behind에서 새 엔티티(id=0) 키 오염
+
+- **문제**: 새 `Product(id=0L)`를 캐시에 먼저 저장 → `products:write-behind:0` 키로 캐시됨. DB 비동기 저장 후 실제 id는 discarded. 호출자는 항상 `id=0` 반환.
+- **해결**: `id == 0L` 경우 DB 먼저 저장해 실제 id 획득 후 캐시 저장. `id > 0L` (업데이트)일 때만 write-behind 패턴 적용.
+- **교훈**: 캐시 키로 DB 자동생성 ID를 사용하는 경우, 새 엔티티에는 반드시 DB 저장을 먼저 수행해야 한다.
+
+### 4. JMH + kotlinx.benchmark 이중 @Setup — double invocation
+
+- **문제**: 추상 클래스에 JMH `@Setup(Level.Trial)`, 구체 클래스에 kotlinx.benchmark `@Setup` 동시 존재 → JMH가 계층 전체를 스캔하여 `setup()` 2회 실행 → Spring 컨텍스트 2개 기동
+- **해결**: 추상 클래스의 JMH 어노테이션 제거. 구체 클래스의 kotlinx.benchmark `@Setup`만 유지.
+- **교훈**: kotlinx-benchmark는 내부적으로 JMH를 사용한다. 추상 클래스에 JMH 어노테이션을 직접 쓰면 구체 클래스의 kotlinx.benchmark 어노테이션과 중복된다.
+
+### 5. bluetape4k 로깅 extension 명시적 import 필요
+
+- **문제**: `log.info { "..." }`, `log.warn(e) { "..." }` 사용 시 `Cannot convert () -> String` 에러
+- **원인**: `io.bluetape4k.logging.Slf4jExtensions.kt`의 extension 함수는 자동 import가 아님. `import io.bluetape4k.logging.info`, `import io.bluetape4k.logging.warn` 명시 필요
+- **교훈**: bluetape4k 로깅 extension은 반드시 파일별로 명시적 import. IDE auto-import 설정 확인.
+
+### 6. Gradle version catalog — 동일 prefix 공유 alias 문제
+
+- **문제**: `libs.redisson`이 `LibraryAccessors` 그룹을 반환해 dependency로 변환 불가
+- **원인**: catalog에 `redisson-lib`, `redisson-spring-boot-starter` 등 공통 prefix 공유 시 `libs.redisson`은 leaf가 아닌 group accessor가 됨
+- **해결**: `libs.redisson.lib` 사용
+- **교훈**: version catalog에서 라이브러리 alias가 다른 alias의 prefix인 경우, `-lib` suffix를 붙인 leaf alias를 사용해야 한다.
+
+---
+
+## Verification Evidence
+
+- **컴파일**: `compileKotlin`, `compileTestKotlin`, `compileBenchmarkKotlin` 모두 오류 없이 성공
+- **테스트**: 23개 테스트, 0 실패, 0 에러
+  - NoCacheServiceTest: 3/3
+  - CaffeineServiceTest: 4/4
+  - RedisCacheServiceTest: 3/3
+  - NearCacheServiceTest: 4/4
+  - ReadThroughServiceTest: 4/4
+  - WriteThroughServiceTest: 2/2
+  - WriteBehindServiceTest: 3/3 (Awaitility async flush 검증 포함)
+
+---
+
+## Review Findings Resolved
+
+| Severity | Finding | Resolution |
+|----------|---------|------------|
+| CRITICAL | `@Async` self-invocation bypasses proxy | `WriteBehindFlusher` 별도 컴포넌트 추출 |
+| CRITICAL | `save()` caches at key=0 for new entities | `id==0L` 분기로 DB 먼저 저장 |
+| HIGH | Mixed JMH + kotlinx.benchmark `@Setup` → double invocation | 추상 클래스 JMH 어노테이션 제거 |
+| Missing | `WriteBehindServiceTest` trivial assertion | Awaitility async DB flush 검증 추가 |
+| Missing | `AbstractCacheBenchmarkTest` `@TestInstance` | `@TestInstance(PER_CLASS)` 추가 |
+
+---
+
+## Future Guidance
+
+1. **@Async 사용 시**: 항상 별도 `@Component`에 선언. 같은 클래스에서 호출 금지.
+2. **Write-Behind 캐시 키**: DB 자동생성 ID를 쓰는 경우 신규 엔티티는 DB 먼저 저장 필수.
+3. **kotlinx-benchmark + JMH**: 추상 클래스에 `@Setup`/`@TearDown` 어노테이션 금지. 구체 클래스에만.
+4. **Redisson 4.x**: `api.options.*` 패키지로 이동된 클래스 확인. `Duration` 파라미터 형식 변경.
+5. **bluetape4k logging**: `import io.bluetape4k.logging.info/warn/debug/error` 명시적 import.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -110,6 +110,7 @@ mockk = "1.14.9"  # https://mvnrepository.com/artifact/io.mockk/mockk
 springmockk = "5.0.1"  # https://mvnrepository.com/artifact/com.ninja-squad/springmockk
 awaitility = "4.3.0"  # https://mvnrepository.com/artifact/org.awaitility/awaitility-kotlin
 jmh = "1.37"  # https://mvnrepository.com/artifact/org.openjdk.jmh/jmh-core
+kotlinx-benchmark = "0.4.13"  # https://mvnrepository.com/artifact/org.jetbrains.kotlinx/kotlinx-benchmark-runtime
 testcontainers = "2.0.5"  # https://mvnrepository.com/artifact/org.testcontainers/testcontainers-bom
 jna = "5.18.1"  # https://mvnrepository.com/artifact/net.java.dev.jna/jna
 archunit = "1.4.2"  # https://mvnrepository.com/artifact/com.tngtech.archunit/archunit
@@ -145,6 +146,7 @@ kotlin-jpa = { id = "org.jetbrains.kotlin.plugin.jpa", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
 kotlinx-atomicfu = { id = "org.jetbrains.kotlinx.atomicfu", version.ref = "kotlinx-atomicfu" }
+kotlinx-benchmark = { id = "org.jetbrains.kotlinx.benchmark", version.ref = "kotlinx-benchmark" }
 
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 dependency-management = { id = "io.spring.dependency-management", version.ref = "dependency-management" }
@@ -645,8 +647,9 @@ aws2-aws-crt-client = { module = "software.amazon.awssdk:aws-crt-client" }
 # Kubernetes
 fabric8-kubernetes-client-bom = { module = "io.fabric8:kubernetes-client-bom", version = "7.7.0" }  # https://mvnrepository.com/artifact/io.fabric8/kubernetes-client-bom
 
-# JMH
+# JMH / Benchmark
 jmh-core = { module = "org.openjdk.jmh:jmh-core", version.ref = "jmh" }
+kotlinx-benchmark-runtime = { module = "org.jetbrains.kotlinx:kotlinx-benchmark-runtime", version.ref = "kotlinx-benchmark" }
 
 # Test
 junit-bom = { module = "org.junit:junit-bom", version.ref = "junit-jupiter" }

--- a/spring-boot/cache-benchmark/README.ko.md
+++ b/spring-boot/cache-benchmark/README.ko.md
@@ -1,0 +1,44 @@
+# cache-benchmark
+
+Spring Boot 서비스에서 7가지 캐시 전략을 비교하는 성능 벤치마크입니다. H2 인메모리 DB와 Redis를 사용합니다.
+
+**kotlinx-benchmark** (JMH 기반)을 사용하여 실제 JVM steady-state 처리량을 측정합니다.
+
+## 7가지 캐시 프로파일
+
+| # | 프로파일 | 전략 | 일관성 | 쓰기 지연 | 읽기 지연 |
+|---|---------|------|--------|-----------|-----------|
+| 1 | **No Cache** | DB 직접 접근 | 강함 | 낮음 | 높음 |
+| 2 | **Caffeine** | `@Cacheable` 로컬 | 인스턴스별 | 낮음 | 최저 (ns) |
+| 3 | **Redis Cache** | `@Cacheable` 원격 | 공유 | 낮음 | 낮음 (µs) |
+| 4 | **Near Cache** | Redisson `RLocalCachedMap` | 최종 | 중간 | 혼합 |
+| 5 | **Read-Through** | 수동 Redis RT | 최종 | 낮음 | 낮음 |
+| 6 | **Write-Through** | 동기 Redis + DB | 강함 | 높음 | 낮음 |
+| 7 | **Write-Behind** | 비동기 DB 플러시 | 최종 | 최저 | 낮음 |
+
+## 사용된 Bluetape4k 기능
+
+| 기능 | 모듈 | 사용처 |
+|------|------|--------|
+| `NearCacheOperations` | `bluetape4k-cache-core` | NearCache 인터페이스 설계 참조 |
+| `RedisServer.Launcher` | `bluetape4k-testcontainers` | 싱글턴 Redis Testcontainer (벤치마크/테스트) |
+| `KLoggingChannel` | `bluetape4k-logging` | 모든 서비스 클래스의 코루틴 안전 로거 |
+| `bluetape4k-redisson` | `bluetape4k-redisson` | NearCacheService용 Redisson 클라이언트 |
+| `bluetape4k-junit5` | `bluetape4k-junit5` | 테스트 assertion |
+
+## 벤치마크 실행
+
+```bash
+# 특정 프로파일
+./gradlew :spring-boot-cache-benchmark:noCacheBenchmark
+./gradlew :spring-boot-cache-benchmark:caffeineBenchmark
+
+# 전체 프로파일
+./gradlew :spring-boot-cache-benchmark:allProfilesBenchmark
+```
+
+## 테스트 실행
+
+```bash
+./gradlew :spring-boot-cache-benchmark:test
+```

--- a/spring-boot/cache-benchmark/README.md
+++ b/spring-boot/cache-benchmark/README.md
@@ -1,0 +1,93 @@
+# cache-benchmark
+
+Performance benchmark comparing 7 cache strategies for a Spring Boot service backed by an H2 in-memory database and Redis.
+
+Built with **kotlinx-benchmark** (JMH-based) so benchmarks reflect real JVM steady-state throughput.
+
+## Architecture
+
+```mermaid
+flowchart TD
+    BM[Benchmark / Test] --> SVC[Service Layer]
+    SVC --> |Profile 1| DB[(H2 DB)]
+    SVC --> |Profile 2| CAF[Caffeine\nLocal Cache]
+    SVC --> |Profile 3| RDS[Redis\nDistributed Cache]
+    SVC --> |Profile 4| NC[Redisson Near Cache\nLocal + Redis]
+    SVC --> |Profile 5| RT[Read-Through\nRedis]
+    SVC --> |Profile 6| WT[Write-Through\nRedis + DB]
+    SVC --> |Profile 7| WB[Write-Behind\nRedis → async DB]
+    CAF --> DB
+    RDS --> DB
+    NC --> RDS
+    RT --> DB
+    WT --> DB
+    WB --> |async| DB
+```
+
+## 7 Cache Profiles
+
+| # | Profile | Strategy | Consistency | Write Latency | Read Latency |
+|---|---------|----------|-------------|---------------|--------------|
+| 1 | **No Cache** | Direct DB | Strong | Low | High |
+| 2 | **Caffeine** | `@Cacheable` local | Per-instance | Low | Lowest (ns) |
+| 3 | **Redis Cache** | `@Cacheable` remote | Shared | Low | Low (µs) |
+| 4 | **Near Cache** | Redisson `RLocalCachedMap` | Eventual | Medium | Mixed |
+| 5 | **Read-Through** | Manual Redis RT | Eventual | Low | Low |
+| 6 | **Write-Through** | Sync Redis + DB | Strong | High | Low |
+| 7 | **Write-Behind** | Async DB flush | Eventual | Lowest | Low |
+
+## Used Bluetape4k Features
+
+| Feature | Module | Usage |
+|---------|--------|-------|
+| `NearCacheOperations` | `bluetape4k-cache-core` | Interface design reference for NearCache profile |
+| `RedisServer.Launcher` | `bluetape4k-testcontainers` | Singleton Redis Testcontainer for benchmarks & tests |
+| `KLoggingChannel` | `bluetape4k-logging` | Coroutine-safe logger in all service classes |
+| `bluetape4k-redisson` | `bluetape4k-redisson` | Redisson client wrapper used by NearCacheService |
+| `bluetape4k-junit5` | `bluetape4k-junit5` | Test assertions (`shouldBeEqualTo`, `shouldBeTrue`) |
+
+## Running Benchmarks
+
+Benchmarks are **not** part of the default build (`./gradlew test`). Run them explicitly:
+
+```bash
+# Profile 1 — baseline no-cache
+./gradlew :spring-boot-cache-benchmark:noCacheBenchmark
+
+# Profile 2 — Caffeine
+./gradlew :spring-boot-cache-benchmark:caffeineBenchmark
+
+# Profile 3 — Redis
+./gradlew :spring-boot-cache-benchmark:redisBenchmark
+
+# Profile 4 — Near Cache
+./gradlew :spring-boot-cache-benchmark:nearCacheBenchmark
+
+# Profile 5 — Read-Through
+./gradlew :spring-boot-cache-benchmark:readThroughBenchmark
+
+# Profile 6 — Write-Through
+./gradlew :spring-boot-cache-benchmark:writeThroughBenchmark
+
+# Profile 7 — Write-Behind
+./gradlew :spring-boot-cache-benchmark:writeBehindBenchmark
+
+# All profiles
+./gradlew :spring-boot-cache-benchmark:allProfilesBenchmark
+```
+
+## Running Tests
+
+```bash
+./gradlew :spring-boot-cache-benchmark:test
+```
+
+Tests verify functional equivalence across all 7 profiles: given the same input, all services return the same result. **Redis container is started automatically** via Testcontainers.
+
+## Configuration
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| `spring.data.redis.host` | `localhost` | Redis host |
+| `spring.data.redis.port` | `6379` | Redis port |
+| `spring.datasource.url` | H2 in-memory | Database URL |

--- a/spring-boot/cache-benchmark/build.gradle.kts
+++ b/spring-boot/cache-benchmark/build.gradle.kts
@@ -172,6 +172,7 @@ dependencies {
 
     // Testing
     testImplementation(libs.bluetape4k.junit5)
+    testImplementation(libs.awaitility.kotlin)
     testImplementation(libs.spring.boot.starter.test) {
         exclude(group = "junit", module = "junit")
         exclude(group = "org.junit.vintage", module = "junit-vintage-engine")

--- a/spring-boot/cache-benchmark/build.gradle.kts
+++ b/spring-boot/cache-benchmark/build.gradle.kts
@@ -1,0 +1,185 @@
+plugins {
+    alias(libs.plugins.kotlin.spring)
+    alias(libs.plugins.kotlin.allopen)
+    alias(libs.plugins.kotlinx.benchmark)
+    alias(libs.plugins.spring.boot)
+}
+
+springBoot {
+    mainClass.set("io.bluetape4k.workshop.cache.benchmark.CacheBenchmarkApplicationKt")
+}
+
+allOpen {
+    // kotlinx-benchmark requires @State classes to be open
+    annotation("org.openjdk.jmh.annotations.State")
+    annotation("kotlinx.benchmark.State")
+    // Spring annotations
+    annotation("org.springframework.stereotype.Service")
+    annotation("org.springframework.stereotype.Component")
+    annotation("org.springframework.stereotype.Repository")
+}
+
+// Benchmark source set: src/benchmark/kotlin
+sourceSets {
+    create("benchmark") {
+        kotlin {
+            srcDir("src/benchmark/kotlin")
+        }
+        resources {
+            srcDir("src/benchmark/resources")
+        }
+        compileClasspath += sourceSets["main"].output + configurations["testRuntimeClasspath"]
+        runtimeClasspath += output + compileClasspath
+    }
+}
+
+kotlin {
+    target {
+        compilations.getByName("benchmark").associateWith(compilations.getByName("main"))
+    }
+}
+
+configurations {
+    testImplementation.get().extendsFrom(compileOnly.get(), runtimeOnly.get())
+    named("benchmarkImplementation") {
+        extendsFrom(
+            configurations["implementation"],
+            configurations["compileOnly"],
+            configurations["testImplementation"],
+        )
+    }
+    named("benchmarkRuntimeOnly") {
+        extendsFrom(configurations["runtimeOnly"], configurations["testRuntimeOnly"])
+    }
+}
+
+benchmark {
+    targets {
+        register("benchmark")
+    }
+    configurations {
+        // Disable the default 'main' configuration
+        named("main") {
+            warmups = 0
+            iterations = 0
+        }
+        // Profile 1: no cache baseline
+        register("noCache") {
+            include(".*NoCacheBenchmark.*")
+            warmups = 2
+            iterations = 5
+            iterationTime = 1
+            iterationTimeUnit = "s"
+        }
+        // Profile 2: Caffeine local cache
+        register("caffeine") {
+            include(".*CaffeineBenchmark.*")
+            warmups = 2
+            iterations = 5
+            iterationTime = 1
+            iterationTimeUnit = "s"
+        }
+        // Profile 3: Redis distributed cache
+        register("redis") {
+            include(".*RedisCacheBenchmark.*")
+            warmups = 2
+            iterations = 5
+            iterationTime = 1
+            iterationTimeUnit = "s"
+        }
+        // Profile 4: Redisson Near Cache (local + Redis)
+        register("nearCache") {
+            include(".*NearCacheBenchmark.*")
+            warmups = 2
+            iterations = 5
+            iterationTime = 1
+            iterationTimeUnit = "s"
+        }
+        // Profile 5: Read-through cache
+        register("readThrough") {
+            include(".*ReadThroughBenchmark.*")
+            warmups = 2
+            iterations = 5
+            iterationTime = 1
+            iterationTimeUnit = "s"
+        }
+        // Profile 6: Write-through cache
+        register("writeThrough") {
+            include(".*WriteThroughBenchmark.*")
+            warmups = 2
+            iterations = 5
+            iterationTime = 1
+            iterationTimeUnit = "s"
+        }
+        // Profile 7: Write-behind cache
+        register("writeBehind") {
+            include(".*WriteBehindBenchmark.*")
+            warmups = 2
+            iterations = 5
+            iterationTime = 1
+            iterationTimeUnit = "s"
+        }
+        // All profiles combined
+        register("allProfiles") {
+            include(".*Benchmark.*")
+            warmups = 2
+            iterations = 5
+            iterationTime = 1
+            iterationTimeUnit = "s"
+        }
+    }
+}
+
+dependencies {
+    // Spring Boot Web (minimal — no embedded server needed for benchmark)
+    implementation(libs.spring.boot.autoconfigure.lib)
+    annotationProcessor(libs.spring.boot.autoconfigure.processor)
+    annotationProcessor(libs.spring.boot.configuration.processor)
+
+    // JPA + H2 (in-memory DB for benchmarks)
+    implementation(libs.spring.boot.starter.data.jpa.lib)
+    runtimeOnly(libs.h2.lib)
+
+    // Spring Cache
+    implementation(libs.spring.boot.starter.cache.lib)
+    testImplementation(libs.spring.boot.starter.cache.test)
+
+    // Caffeine (local cache)
+    implementation(libs.caffeine.lib)
+    implementation(libs.caffeine.jcache)
+
+    // Redis (Spring Cache Redis backend)
+    implementation(libs.spring.boot.starter.data.redis.lib)
+    testImplementation(libs.spring.boot.starter.data.redis.test)
+
+    // Redisson (Near Cache)
+    implementation(libs.bluetape4k.redisson)
+    implementation(libs.redisson.lib)
+    implementation(libs.redisson.spring.boot.starter)
+
+    // bluetape4k utilities
+    implementation(libs.bluetape4k.cache.core)
+    implementation(libs.bluetape4k.jackson3)
+    implementation(libs.bluetape4k.coroutines)
+    implementation(libs.bluetape4k.testcontainers)
+
+    // Coroutines
+    implementation(libs.kotlinx.coroutines.core.lib)
+    testImplementation(libs.kotlinx.coroutines.test.lib)
+
+    // Testcontainers (Redis for benchmarks and tests)
+    testImplementation(libs.testcontainers.junit.jupiter)
+
+    // Testing
+    testImplementation(libs.bluetape4k.junit5)
+    testImplementation(libs.spring.boot.starter.test) {
+        exclude(group = "junit", module = "junit")
+        exclude(group = "org.junit.vintage", module = "junit-vintage-engine")
+        exclude(module = "mockito-core")
+    }
+    testImplementation(libs.mockk)
+
+    // kotlinx-benchmark runtime (for benchmark source set)
+    add("benchmarkImplementation", libs.kotlinx.benchmark.runtime)
+    add("benchmarkImplementation", libs.jmh.core)
+}

--- a/spring-boot/cache-benchmark/src/benchmark/kotlin/io/bluetape4k/workshop/cache/benchmark/benchmarks/AbstractCacheBenchmark.kt
+++ b/spring-boot/cache-benchmark/src/benchmark/kotlin/io/bluetape4k/workshop/cache/benchmark/benchmarks/AbstractCacheBenchmark.kt
@@ -1,0 +1,62 @@
+package io.bluetape4k.workshop.cache.benchmark.benchmarks
+
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.logging.info
+import io.bluetape4k.testcontainers.storage.RedisServer
+import io.bluetape4k.workshop.cache.benchmark.CacheBenchmarkApplication
+import io.bluetape4k.workshop.cache.benchmark.config.DataInitConfig
+import org.openjdk.jmh.annotations.Level
+import org.openjdk.jmh.annotations.Setup
+import org.openjdk.jmh.annotations.TearDown
+import org.springframework.boot.builder.SpringApplicationBuilder
+import org.springframework.context.ConfigurableApplicationContext
+
+/**
+ * Base benchmark state providing a shared Spring Boot context and Testcontainers Redis.
+ *
+ * ## Lifecycle
+ * - [setup]: start Redis container + Spring Boot context (once per JMH trial)
+ * - [teardown]: close Spring Boot context (once per JMH trial)
+ *
+ * Redis is started via bluetape4k's [RedisServer.Launcher] singleton — the container
+ * is shared across all benchmarks in the same JVM.
+ */
+abstract class AbstractCacheBenchmark {
+    companion object : KLoggingChannel() {
+        /** Shared Redis container — started once for the entire JVM. */
+        val redis: RedisServer by lazy { RedisServer.Launcher.redis }
+    }
+
+    protected lateinit var context: ConfigurableApplicationContext
+
+    @Setup(Level.Trial)
+    open fun setup() {
+        val redisHost = redis.host
+        val redisPort = redis.port
+
+        context = SpringApplicationBuilder(CacheBenchmarkApplication::class.java)
+            .properties(
+                "spring.datasource.url=jdbc:h2:mem:benchmark-${System.nanoTime()};DB_CLOSE_DELAY=-1",
+                "spring.data.redis.host=$redisHost",
+                "spring.data.redis.port=$redisPort",
+                "REDIS_HOST=$redisHost",
+                "REDIS_PORT=$redisPort",
+                "logging.level.root=WARN",
+                "logging.level.io.bluetape4k.workshop.cache.benchmark=WARN",
+            )
+            .run()
+
+        log.info { "Spring context started. Redis: $redisHost:$redisPort" }
+    }
+
+    @TearDown(Level.Trial)
+    open fun teardown() {
+        if (::context.isInitialized) {
+            context.close()
+            log.info { "Spring context closed" }
+        }
+    }
+
+    /** Returns a valid product ID within the initialized dataset (1..DataInitConfig.PRODUCT_COUNT). */
+    protected fun sampleId(iteration: Int): Long = ((iteration % DataInitConfig.PRODUCT_COUNT) + 1).toLong()
+}

--- a/spring-boot/cache-benchmark/src/benchmark/kotlin/io/bluetape4k/workshop/cache/benchmark/benchmarks/AbstractCacheBenchmark.kt
+++ b/spring-boot/cache-benchmark/src/benchmark/kotlin/io/bluetape4k/workshop/cache/benchmark/benchmarks/AbstractCacheBenchmark.kt
@@ -5,9 +5,6 @@ import io.bluetape4k.logging.info
 import io.bluetape4k.testcontainers.storage.RedisServer
 import io.bluetape4k.workshop.cache.benchmark.CacheBenchmarkApplication
 import io.bluetape4k.workshop.cache.benchmark.config.DataInitConfig
-import org.openjdk.jmh.annotations.Level
-import org.openjdk.jmh.annotations.Setup
-import org.openjdk.jmh.annotations.TearDown
 import org.springframework.boot.builder.SpringApplicationBuilder
 import org.springframework.context.ConfigurableApplicationContext
 
@@ -15,8 +12,13 @@ import org.springframework.context.ConfigurableApplicationContext
  * Base benchmark state providing a shared Spring Boot context and Testcontainers Redis.
  *
  * ## Lifecycle
- * - [setup]: start Redis container + Spring Boot context (once per JMH trial)
- * - [teardown]: close Spring Boot context (once per JMH trial)
+ * Subclasses must call [setup] from their own `@Setup`-annotated override and
+ * [teardown] from their own `@TearDown`-annotated override.
+ *
+ * **No `@Setup`/`@TearDown` annotations here** — annotating both the abstract parent
+ * and each concrete override with the same annotation causes JMH's scanner to invoke
+ * setup twice per trial (once from the raw-JMH annotation in the hierarchy and once
+ * from the kotlinx.benchmark-mapped one), starting two Spring contexts.
  *
  * Redis is started via bluetape4k's [RedisServer.Launcher] singleton — the container
  * is shared across all benchmarks in the same JVM.
@@ -29,7 +31,7 @@ abstract class AbstractCacheBenchmark {
 
     protected lateinit var context: ConfigurableApplicationContext
 
-    @Setup(Level.Trial)
+    /** Call from the concrete subclass's `@Setup`-annotated method. */
     open fun setup() {
         val redisHost = redis.host
         val redisPort = redis.port
@@ -49,7 +51,7 @@ abstract class AbstractCacheBenchmark {
         log.info { "Spring context started. Redis: $redisHost:$redisPort" }
     }
 
-    @TearDown(Level.Trial)
+    /** Call from the concrete subclass's `@TearDown`-annotated method. */
     open fun teardown() {
         if (::context.isInitialized) {
             context.close()

--- a/spring-boot/cache-benchmark/src/benchmark/kotlin/io/bluetape4k/workshop/cache/benchmark/benchmarks/CaffeineBenchmark.kt
+++ b/spring-boot/cache-benchmark/src/benchmark/kotlin/io/bluetape4k/workshop/cache/benchmark/benchmarks/CaffeineBenchmark.kt
@@ -1,0 +1,43 @@
+package io.bluetape4k.workshop.cache.benchmark.benchmarks
+
+import io.bluetape4k.workshop.cache.benchmark.service.CaffeineService
+import kotlinx.benchmark.Benchmark
+import kotlinx.benchmark.BenchmarkMode
+import kotlinx.benchmark.Measurement
+import kotlinx.benchmark.Mode
+import kotlinx.benchmark.OutputTimeUnit
+import kotlinx.benchmark.Param
+import kotlinx.benchmark.Scope
+import kotlinx.benchmark.Setup
+import kotlinx.benchmark.State
+import kotlinx.benchmark.Warmup
+import java.util.concurrent.TimeUnit
+
+/**
+ * Profile 2 — Caffeine local cache.
+ *
+ * Uses Spring's [@Cacheable] with a Caffeine-backed [CacheManager].
+ * Expected: significantly higher throughput than Profile 1 after warm-up.
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Warmup(iterations = 2, time = 1)
+@Measurement(iterations = 5, time = 1)
+class CaffeineBenchmark : AbstractCacheBenchmark() {
+    private lateinit var service: CaffeineService
+
+    @Param("1", "100", "500")
+    var productId: Long = 1L
+
+    @Setup
+    override fun setup() {
+        super.setup()
+        service = context.getBean(CaffeineService::class.java)
+        // Warm up the cache
+        repeat(10) { service.findById(productId) }
+    }
+
+    @Benchmark
+    fun findById() = service.findById(productId)
+}

--- a/spring-boot/cache-benchmark/src/benchmark/kotlin/io/bluetape4k/workshop/cache/benchmark/benchmarks/NearCacheBenchmark.kt
+++ b/spring-boot/cache-benchmark/src/benchmark/kotlin/io/bluetape4k/workshop/cache/benchmark/benchmarks/NearCacheBenchmark.kt
@@ -1,0 +1,46 @@
+package io.bluetape4k.workshop.cache.benchmark.benchmarks
+
+import io.bluetape4k.workshop.cache.benchmark.service.NearCacheService
+import kotlinx.benchmark.Benchmark
+import kotlinx.benchmark.BenchmarkMode
+import kotlinx.benchmark.Measurement
+import kotlinx.benchmark.Mode
+import kotlinx.benchmark.OutputTimeUnit
+import kotlinx.benchmark.Param
+import kotlinx.benchmark.Scope
+import kotlinx.benchmark.Setup
+import kotlinx.benchmark.State
+import kotlinx.benchmark.Warmup
+import java.util.concurrent.TimeUnit
+
+/**
+ * Profile 4 — Redisson Near Cache.
+ *
+ * Uses [NearCacheService] backed by Redisson's [org.redisson.api.RLocalCachedMap]:
+ * - Tier 1: in-JVM Caffeine-backed local map (sub-microsecond reads when hot)
+ * - Tier 2: Redis backing store (cross-instance consistency via invalidation)
+ *
+ * Expected: close to Caffeine throughput for hot data; better than Redis-only for
+ * repeated reads of the same key.
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Warmup(iterations = 2, time = 1)
+@Measurement(iterations = 5, time = 1)
+class NearCacheBenchmark : AbstractCacheBenchmark() {
+    private lateinit var service: NearCacheService
+
+    @Param("1", "100", "500")
+    var productId: Long = 1L
+
+    @Setup
+    override fun setup() {
+        super.setup()
+        service = context.getBean(NearCacheService::class.java)
+        repeat(10) { service.findById(productId) }  // populate local tier
+    }
+
+    @Benchmark
+    fun findById() = service.findById(productId)
+}

--- a/spring-boot/cache-benchmark/src/benchmark/kotlin/io/bluetape4k/workshop/cache/benchmark/benchmarks/NoCacheBenchmark.kt
+++ b/spring-boot/cache-benchmark/src/benchmark/kotlin/io/bluetape4k/workshop/cache/benchmark/benchmarks/NoCacheBenchmark.kt
@@ -1,0 +1,41 @@
+package io.bluetape4k.workshop.cache.benchmark.benchmarks
+
+import io.bluetape4k.workshop.cache.benchmark.service.NoCacheService
+import kotlinx.benchmark.Benchmark
+import kotlinx.benchmark.BenchmarkMode
+import kotlinx.benchmark.Measurement
+import kotlinx.benchmark.Mode
+import kotlinx.benchmark.OutputTimeUnit
+import kotlinx.benchmark.Param
+import kotlinx.benchmark.Scope
+import kotlinx.benchmark.Setup
+import kotlinx.benchmark.State
+import kotlinx.benchmark.Warmup
+import java.util.concurrent.TimeUnit
+
+/**
+ * Profile 1 — Baseline: no cache, direct DB access.
+ *
+ * All reads go through JPA → H2. This is the performance floor all cache
+ * profiles are measured against.
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Warmup(iterations = 2, time = 1)
+@Measurement(iterations = 5, time = 1)
+class NoCacheBenchmark : AbstractCacheBenchmark() {
+    private lateinit var service: NoCacheService
+
+    @Param("1", "100", "500")
+    var productId: Long = 1L
+
+    @Setup
+    override fun setup() {
+        super.setup()
+        service = context.getBean(NoCacheService::class.java)
+    }
+
+    @Benchmark
+    fun findById() = service.findById(productId)
+}

--- a/spring-boot/cache-benchmark/src/benchmark/kotlin/io/bluetape4k/workshop/cache/benchmark/benchmarks/ReadThroughBenchmark.kt
+++ b/spring-boot/cache-benchmark/src/benchmark/kotlin/io/bluetape4k/workshop/cache/benchmark/benchmarks/ReadThroughBenchmark.kt
@@ -1,0 +1,43 @@
+package io.bluetape4k.workshop.cache.benchmark.benchmarks
+
+import io.bluetape4k.workshop.cache.benchmark.service.ReadThroughService
+import kotlinx.benchmark.Benchmark
+import kotlinx.benchmark.BenchmarkMode
+import kotlinx.benchmark.Measurement
+import kotlinx.benchmark.Mode
+import kotlinx.benchmark.OutputTimeUnit
+import kotlinx.benchmark.Param
+import kotlinx.benchmark.Scope
+import kotlinx.benchmark.Setup
+import kotlinx.benchmark.State
+import kotlinx.benchmark.Warmup
+import java.util.concurrent.TimeUnit
+
+/**
+ * Profile 5 — Read-Through Cache.
+ *
+ * Manual Redis read-through: cache-first; on miss loads from DB and
+ * populates the cache. Similar to Profile 3 but the pattern is explicit
+ * and key-prefixed for isolation.
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Warmup(iterations = 2, time = 1)
+@Measurement(iterations = 5, time = 1)
+class ReadThroughBenchmark : AbstractCacheBenchmark() {
+    private lateinit var service: ReadThroughService
+
+    @Param("1", "100", "500")
+    var productId: Long = 1L
+
+    @Setup
+    override fun setup() {
+        super.setup()
+        service = context.getBean(ReadThroughService::class.java)
+        repeat(5) { service.findById(productId) }
+    }
+
+    @Benchmark
+    fun findById() = service.findById(productId)
+}

--- a/spring-boot/cache-benchmark/src/benchmark/kotlin/io/bluetape4k/workshop/cache/benchmark/benchmarks/RedisCacheBenchmark.kt
+++ b/spring-boot/cache-benchmark/src/benchmark/kotlin/io/bluetape4k/workshop/cache/benchmark/benchmarks/RedisCacheBenchmark.kt
@@ -1,0 +1,43 @@
+package io.bluetape4k.workshop.cache.benchmark.benchmarks
+
+import io.bluetape4k.workshop.cache.benchmark.service.RedisCacheService
+import kotlinx.benchmark.Benchmark
+import kotlinx.benchmark.BenchmarkMode
+import kotlinx.benchmark.Measurement
+import kotlinx.benchmark.Mode
+import kotlinx.benchmark.OutputTimeUnit
+import kotlinx.benchmark.Param
+import kotlinx.benchmark.Scope
+import kotlinx.benchmark.Setup
+import kotlinx.benchmark.State
+import kotlinx.benchmark.Warmup
+import java.util.concurrent.TimeUnit
+
+/**
+ * Profile 3 — Redis distributed cache.
+ *
+ * Uses Spring's [@Cacheable] with a Redis-backed [CacheManager].
+ * Expected: lower throughput than Caffeine (network round-trip to Redis) but
+ * higher than no-cache baseline; cache is shared across JVM instances.
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Warmup(iterations = 2, time = 1)
+@Measurement(iterations = 5, time = 1)
+class RedisCacheBenchmark : AbstractCacheBenchmark() {
+    private lateinit var service: RedisCacheService
+
+    @Param("1", "100", "500")
+    var productId: Long = 1L
+
+    @Setup
+    override fun setup() {
+        super.setup()
+        service = context.getBean(RedisCacheService::class.java)
+        repeat(5) { service.findById(productId) }
+    }
+
+    @Benchmark
+    fun findById() = service.findById(productId)
+}

--- a/spring-boot/cache-benchmark/src/benchmark/kotlin/io/bluetape4k/workshop/cache/benchmark/benchmarks/WriteBehindBenchmark.kt
+++ b/spring-boot/cache-benchmark/src/benchmark/kotlin/io/bluetape4k/workshop/cache/benchmark/benchmarks/WriteBehindBenchmark.kt
@@ -1,0 +1,55 @@
+package io.bluetape4k.workshop.cache.benchmark.benchmarks
+
+import io.bluetape4k.workshop.cache.benchmark.domain.Product
+import io.bluetape4k.workshop.cache.benchmark.service.WriteBehindService
+import kotlinx.benchmark.Benchmark
+import kotlinx.benchmark.BenchmarkMode
+import kotlinx.benchmark.Measurement
+import kotlinx.benchmark.Mode
+import kotlinx.benchmark.OutputTimeUnit
+import kotlinx.benchmark.Scope
+import kotlinx.benchmark.Setup
+import kotlinx.benchmark.State
+import kotlinx.benchmark.Warmup
+import java.math.BigDecimal
+import java.util.concurrent.TimeUnit
+
+/**
+ * Profile 7 — Write-Behind Cache.
+ *
+ * Measures write throughput when the cache is updated synchronously but the DB
+ * flush is deferred to a background thread ([@Async]).
+ *
+ * Expected: highest write throughput among profiles 6 & 7 (async DB flush),
+ * at the cost of eventual consistency.
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Warmup(iterations = 2, time = 1)
+@Measurement(iterations = 5, time = 1)
+class WriteBehindBenchmark : AbstractCacheBenchmark() {
+    private lateinit var service: WriteBehindService
+    private var counter = 0
+
+    @Setup
+    override fun setup() {
+        super.setup()
+        service = context.getBean(WriteBehindService::class.java)
+        repeat(5) { service.findById(1L) }
+    }
+
+    @Benchmark
+    fun findById() = service.findById(1L)
+
+    @Benchmark
+    fun saveAndRead(): Product {
+        val product = Product(
+            name = "BenchProduct-${counter++}",
+            category = "Benchmark",
+            price = BigDecimal("9.99"),
+            stock = 10,
+        )
+        return service.save(product)
+    }
+}

--- a/spring-boot/cache-benchmark/src/benchmark/kotlin/io/bluetape4k/workshop/cache/benchmark/benchmarks/WriteThroughBenchmark.kt
+++ b/spring-boot/cache-benchmark/src/benchmark/kotlin/io/bluetape4k/workshop/cache/benchmark/benchmarks/WriteThroughBenchmark.kt
@@ -1,0 +1,55 @@
+package io.bluetape4k.workshop.cache.benchmark.benchmarks
+
+import io.bluetape4k.workshop.cache.benchmark.domain.Product
+import io.bluetape4k.workshop.cache.benchmark.service.WriteThroughService
+import kotlinx.benchmark.Benchmark
+import kotlinx.benchmark.BenchmarkMode
+import kotlinx.benchmark.Measurement
+import kotlinx.benchmark.Mode
+import kotlinx.benchmark.OutputTimeUnit
+import kotlinx.benchmark.Scope
+import kotlinx.benchmark.Setup
+import kotlinx.benchmark.State
+import kotlinx.benchmark.Warmup
+import java.math.BigDecimal
+import java.util.concurrent.TimeUnit
+
+/**
+ * Profile 6 — Write-Through Cache.
+ *
+ * Measures write throughput when both the Redis cache and the DB are updated
+ * synchronously on every [save] call.
+ *
+ * Also measures read throughput (cache-warmed) to compare with write cost.
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Warmup(iterations = 2, time = 1)
+@Measurement(iterations = 5, time = 1)
+class WriteThroughBenchmark : AbstractCacheBenchmark() {
+    private lateinit var service: WriteThroughService
+    private var counter = 0
+
+    @Setup
+    override fun setup() {
+        super.setup()
+        service = context.getBean(WriteThroughService::class.java)
+        // Pre-populate
+        repeat(5) { service.findById(1L) }
+    }
+
+    @Benchmark
+    fun findById() = service.findById(1L)
+
+    @Benchmark
+    fun saveAndRead(): Product {
+        val product = Product(
+            name = "BenchProduct-${counter++}",
+            category = "Benchmark",
+            price = BigDecimal("9.99"),
+            stock = 10,
+        )
+        return service.save(product)
+    }
+}

--- a/spring-boot/cache-benchmark/src/main/kotlin/io/bluetape4k/workshop/cache/benchmark/CacheBenchmarkApplication.kt
+++ b/spring-boot/cache-benchmark/src/main/kotlin/io/bluetape4k/workshop/cache/benchmark/CacheBenchmarkApplication.kt
@@ -1,0 +1,18 @@
+package io.bluetape4k.workshop.cache.benchmark
+
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
+import org.springframework.cache.annotation.EnableCaching
+import org.springframework.scheduling.annotation.EnableAsync
+
+@SpringBootApplication(proxyBeanMethods = false)
+@EnableCaching
+@EnableAsync
+class CacheBenchmarkApplication {
+    companion object: KLoggingChannel()
+}
+
+fun main(vararg args: String) {
+    runApplication<CacheBenchmarkApplication>(*args)
+}

--- a/spring-boot/cache-benchmark/src/main/kotlin/io/bluetape4k/workshop/cache/benchmark/config/CacheConfig.kt
+++ b/spring-boot/cache-benchmark/src/main/kotlin/io/bluetape4k/workshop/cache/benchmark/config/CacheConfig.kt
@@ -1,0 +1,50 @@
+package io.bluetape4k.workshop.cache.benchmark.config
+
+import com.github.benmanes.caffeine.cache.Caffeine
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import org.springframework.cache.CacheManager
+import org.springframework.cache.caffeine.CaffeineCacheManager
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Primary
+import org.springframework.data.redis.cache.RedisCacheConfiguration
+import org.springframework.data.redis.cache.RedisCacheManager
+import org.springframework.data.redis.connection.RedisConnectionFactory
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer
+import org.springframework.data.redis.serializer.RedisSerializationContext
+import java.time.Duration
+import java.util.concurrent.TimeUnit
+
+@Configuration
+class CacheConfig {
+    companion object : KLoggingChannel()
+
+    @Bean
+    @Primary
+    fun caffeineCacheManager(): CacheManager {
+        val manager = CaffeineCacheManager()
+        manager.setCaffeine(
+            Caffeine.newBuilder()
+                .maximumSize(10_000)
+                .expireAfterWrite(60, TimeUnit.SECONDS)
+                .recordStats()
+        )
+        return manager
+    }
+
+    @Bean("redisCacheManager")
+    fun redisCacheManager(
+        redisConnectionFactory: RedisConnectionFactory,
+    ): CacheManager {
+        val config = RedisCacheConfiguration.defaultCacheConfig()
+            .entryTtl(Duration.ofSeconds(60))
+            .serializeValuesWith(
+                RedisSerializationContext.SerializationPair.fromSerializer(
+                    GenericJackson2JsonRedisSerializer()
+                )
+            )
+        return RedisCacheManager.builder(redisConnectionFactory)
+            .cacheDefaults(config)
+            .build()
+    }
+}

--- a/spring-boot/cache-benchmark/src/main/kotlin/io/bluetape4k/workshop/cache/benchmark/config/DataInitConfig.kt
+++ b/spring-boot/cache-benchmark/src/main/kotlin/io/bluetape4k/workshop/cache/benchmark/config/DataInitConfig.kt
@@ -1,0 +1,37 @@
+package io.bluetape4k.workshop.cache.benchmark.config
+
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.logging.info
+import io.bluetape4k.workshop.cache.benchmark.domain.Product
+import io.bluetape4k.workshop.cache.benchmark.domain.ProductRepository
+import org.springframework.boot.ApplicationRunner
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import java.math.BigDecimal
+
+/**
+ * Initializes the in-memory H2 DB with sample products for benchmark runs.
+ */
+@Configuration
+class DataInitConfig {
+    companion object : KLoggingChannel() {
+        const val PRODUCT_COUNT = 1000
+        val CATEGORIES = listOf("Electronics", "Books", "Clothing", "Food", "Sports")
+    }
+
+    @Bean
+    fun dataInitRunner(productRepository: ProductRepository): ApplicationRunner = ApplicationRunner {
+        if (productRepository.count() > 0L) return@ApplicationRunner
+
+        val products = (1..PRODUCT_COUNT).map { i ->
+            Product(
+                name = "Product-$i",
+                category = CATEGORIES[i % CATEGORIES.size],
+                price = BigDecimal("${10 + (i % 100)}.99"),
+                stock = 100 + i,
+            )
+        }
+        productRepository.saveAll(products)
+        log.info { "Initialized $PRODUCT_COUNT products" }
+    }
+}

--- a/spring-boot/cache-benchmark/src/main/kotlin/io/bluetape4k/workshop/cache/benchmark/config/RedisTemplateConfig.kt
+++ b/spring-boot/cache-benchmark/src/main/kotlin/io/bluetape4k/workshop/cache/benchmark/config/RedisTemplateConfig.kt
@@ -1,0 +1,26 @@
+package io.bluetape4k.workshop.cache.benchmark.config
+
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.workshop.cache.benchmark.domain.Product
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.redis.connection.RedisConnectionFactory
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer
+import org.springframework.data.redis.serializer.StringRedisSerializer
+
+@Configuration
+class RedisTemplateConfig {
+    companion object : KLoggingChannel()
+
+    @Bean
+    fun productRedisTemplate(connectionFactory: RedisConnectionFactory): RedisTemplate<String, Product> {
+        return RedisTemplate<String, Product>().apply {
+            setConnectionFactory(connectionFactory)
+            keySerializer = StringRedisSerializer()
+            valueSerializer = Jackson2JsonRedisSerializer(Product::class.java)
+            hashKeySerializer = StringRedisSerializer()
+            hashValueSerializer = Jackson2JsonRedisSerializer(Product::class.java)
+        }
+    }
+}

--- a/spring-boot/cache-benchmark/src/main/kotlin/io/bluetape4k/workshop/cache/benchmark/config/RedissonConfig.kt
+++ b/spring-boot/cache-benchmark/src/main/kotlin/io/bluetape4k/workshop/cache/benchmark/config/RedissonConfig.kt
@@ -1,0 +1,30 @@
+package io.bluetape4k.workshop.cache.benchmark.config
+
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import org.redisson.Redisson
+import org.redisson.api.RedissonClient
+import org.redisson.config.Config
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class RedissonConfig {
+    companion object : KLoggingChannel()
+
+    @Bean(destroyMethod = "shutdown")
+    fun redissonClient(
+        @Value("\${spring.data.redis.host:localhost}") host: String,
+        @Value("\${spring.data.redis.port:6379}") port: Int,
+    ): RedissonClient {
+        val config = Config().apply {
+            useSingleServer()
+                .setAddress("redis://$host:$port")
+                .setConnectionPoolSize(64)
+                .setConnectionMinimumIdleSize(16)
+                .setTimeout(5000)
+                .setRetryAttempts(3)
+        }
+        return Redisson.create(config)
+    }
+}

--- a/spring-boot/cache-benchmark/src/main/kotlin/io/bluetape4k/workshop/cache/benchmark/domain/Product.kt
+++ b/spring-boot/cache-benchmark/src/main/kotlin/io/bluetape4k/workshop/cache/benchmark/domain/Product.kt
@@ -1,0 +1,47 @@
+package io.bluetape4k.workshop.cache.benchmark.domain
+
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Index
+import jakarta.persistence.Table
+import java.io.Serializable
+import java.math.BigDecimal
+
+/**
+ * Product entity used as the benchmark subject for all 7 cache profiles.
+ *
+ * Implements [Serializable] so it can be stored in distributed caches (Redis, Redisson).
+ */
+@Entity
+@Table(
+    name = "products",
+    indexes = [
+        Index(name = "idx_products_category", columnList = "category"),
+        Index(name = "idx_products_name", columnList = "name"),
+    ]
+)
+data class Product(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+
+    @Column(nullable = false, length = 200)
+    val name: String = "",
+
+    @Column(nullable = false, length = 50)
+    val category: String = "",
+
+    @Column(nullable = false, precision = 12, scale = 2)
+    val price: BigDecimal = BigDecimal.ZERO,
+
+    @Column(nullable = false)
+    val stock: Int = 0,
+): Serializable {
+    companion object: KLoggingChannel() {
+        private const val serialVersionUID: Long = 1L
+    }
+}

--- a/spring-boot/cache-benchmark/src/main/kotlin/io/bluetape4k/workshop/cache/benchmark/domain/ProductRepository.kt
+++ b/spring-boot/cache-benchmark/src/main/kotlin/io/bluetape4k/workshop/cache/benchmark/domain/ProductRepository.kt
@@ -1,0 +1,13 @@
+package io.bluetape4k.workshop.cache.benchmark.domain
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+/**
+ * Spring Data JPA repository for [Product] entities.
+ */
+@Repository
+interface ProductRepository: JpaRepository<Product, Long> {
+    fun findByCategory(category: String): List<Product>
+    fun findByNameContaining(name: String): List<Product>
+}

--- a/spring-boot/cache-benchmark/src/main/kotlin/io/bluetape4k/workshop/cache/benchmark/service/CaffeineService.kt
+++ b/spring-boot/cache-benchmark/src/main/kotlin/io/bluetape4k/workshop/cache/benchmark/service/CaffeineService.kt
@@ -1,0 +1,34 @@
+package io.bluetape4k.workshop.cache.benchmark.service
+
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.workshop.cache.benchmark.domain.Product
+import io.bluetape4k.workshop.cache.benchmark.domain.ProductRepository
+import org.springframework.cache.annotation.CacheEvict
+import org.springframework.cache.annotation.CachePut
+import org.springframework.cache.annotation.Cacheable
+import org.springframework.stereotype.Service
+
+/**
+ * Profile 2 — Caffeine Local Cache.
+ *
+ * Uses Spring's `@Cacheable` with a Caffeine-backed [CacheManager].
+ * Cache is local (in-JVM), so reads are extremely fast but not shared across instances.
+ */
+@Service
+class CaffeineService(private val productRepository: ProductRepository) : ProductCacheService {
+    companion object : KLoggingChannel() {
+        const val CACHE_NAME = "products-caffeine"
+    }
+
+    @Cacheable(cacheNames = [CACHE_NAME], key = "#id")
+    override fun findById(id: Long): Product? = productRepository.findById(id).orElse(null)
+
+    @CachePut(cacheNames = [CACHE_NAME], key = "#result.id")
+    override fun save(product: Product): Product = productRepository.save(product)
+
+    @CacheEvict(cacheNames = [CACHE_NAME], key = "#id")
+    override fun evict(id: Long) {}
+
+    @CacheEvict(cacheNames = [CACHE_NAME], allEntries = true)
+    override fun clearAll() {}
+}

--- a/spring-boot/cache-benchmark/src/main/kotlin/io/bluetape4k/workshop/cache/benchmark/service/NearCacheService.kt
+++ b/spring-boot/cache-benchmark/src/main/kotlin/io/bluetape4k/workshop/cache/benchmark/service/NearCacheService.kt
@@ -1,0 +1,66 @@
+package io.bluetape4k.workshop.cache.benchmark.service
+
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.workshop.cache.benchmark.domain.Product
+import io.bluetape4k.workshop.cache.benchmark.domain.ProductRepository
+import org.redisson.api.RLocalCachedMap
+import org.redisson.api.RedissonClient
+import org.redisson.api.options.LocalCachedMapOptions
+import org.springframework.stereotype.Service
+import java.time.Duration
+
+/**
+ * Profile 4 — Redisson Near Cache (RLocalCachedMap).
+ *
+ * Uses Redisson's [RLocalCachedMap] which provides a 2-tier cache:
+ * - Tier 1: Caffeine-backed local (in-JVM) map — ultra-low latency
+ * - Tier 2: Redis backing store — shared across instances
+ *
+ * This is the bluetape4k-recommended pattern for distributed near caching.
+ * See: [io.bluetape4k.cache.nearcache.NearCacheOperations]
+ */
+@Service
+class NearCacheService(
+    private val productRepository: ProductRepository,
+    redissonClient: RedissonClient,
+) : ProductCacheService {
+    companion object : KLoggingChannel() {
+        const val CACHE_NAME = "products-near-cache"
+    }
+
+    private val nearCache: RLocalCachedMap<Long, Product> = run {
+        val options = LocalCachedMapOptions.name<Long, Product>(CACHE_NAME)
+            .cacheSize(10_000)
+            .evictionPolicy(LocalCachedMapOptions.EvictionPolicy.LRU)
+            .maxIdle(Duration.ofSeconds(60))
+            .timeToLive(Duration.ofSeconds(300))
+            .syncStrategy(LocalCachedMapOptions.SyncStrategy.INVALIDATE)
+        redissonClient.getLocalCachedMap(options)
+    }
+
+    override fun findById(id: Long): Product? {
+        // 1. Check local (in-JVM) tier
+        return nearCache.getOrDefault(id, null)
+            ?: run {
+                // 2. Cache miss: load from DB and populate near cache
+                productRepository.findById(id).orElse(null)?.also { product ->
+                    nearCache[id] = product
+                }
+            }
+    }
+
+    override fun save(product: Product): Product {
+        val saved = productRepository.save(product)
+        nearCache[saved.id] = saved          // write-through to near cache
+        return saved
+    }
+
+    override fun evict(id: Long) {
+        nearCache.remove(id)
+    }
+
+    override fun clearAll() {
+        nearCache.clearLocalCache()
+        nearCache.clear()
+    }
+}

--- a/spring-boot/cache-benchmark/src/main/kotlin/io/bluetape4k/workshop/cache/benchmark/service/NoCacheService.kt
+++ b/spring-boot/cache-benchmark/src/main/kotlin/io/bluetape4k/workshop/cache/benchmark/service/NoCacheService.kt
@@ -1,0 +1,29 @@
+package io.bluetape4k.workshop.cache.benchmark.service
+
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.workshop.cache.benchmark.domain.Product
+import io.bluetape4k.workshop.cache.benchmark.domain.ProductRepository
+import org.springframework.stereotype.Service
+
+/**
+ * Profile 1 — No Cache (Baseline).
+ *
+ * Every [findById] call hits the database directly.
+ * This is the baseline for measuring the overhead that caching eliminates.
+ */
+@Service
+class NoCacheService(private val productRepository: ProductRepository) : ProductCacheService {
+    companion object : KLoggingChannel()
+
+    override fun findById(id: Long): Product? = productRepository.findById(id).orElse(null)
+
+    override fun save(product: Product): Product = productRepository.save(product)
+
+    override fun evict(id: Long) {
+        // No cache to evict — no-op
+    }
+
+    override fun clearAll() {
+        // No cache to clear — no-op
+    }
+}

--- a/spring-boot/cache-benchmark/src/main/kotlin/io/bluetape4k/workshop/cache/benchmark/service/ProductCacheService.kt
+++ b/spring-boot/cache-benchmark/src/main/kotlin/io/bluetape4k/workshop/cache/benchmark/service/ProductCacheService.kt
@@ -1,0 +1,23 @@
+package io.bluetape4k.workshop.cache.benchmark.service
+
+import io.bluetape4k.workshop.cache.benchmark.domain.Product
+
+/**
+ * Common interface for all 7 cache profile service implementations.
+ *
+ * All implementations must return the same logical result for the same input,
+ * ensuring functional equivalence across cache strategies.
+ */
+interface ProductCacheService {
+    /** Find a product by ID. Returns null when not found. */
+    fun findById(id: Long): Product?
+
+    /** Save or update a product. Returns the persisted entity. */
+    fun save(product: Product): Product
+
+    /** Remove a product from cache and storage. */
+    fun evict(id: Long)
+
+    /** Clear all cached entries (local and/or remote). */
+    fun clearAll()
+}

--- a/spring-boot/cache-benchmark/src/main/kotlin/io/bluetape4k/workshop/cache/benchmark/service/ReadThroughService.kt
+++ b/spring-boot/cache-benchmark/src/main/kotlin/io/bluetape4k/workshop/cache/benchmark/service/ReadThroughService.kt
@@ -1,0 +1,58 @@
+package io.bluetape4k.workshop.cache.benchmark.service
+
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.workshop.cache.benchmark.domain.Product
+import io.bluetape4k.workshop.cache.benchmark.domain.ProductRepository
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.stereotype.Service
+import java.time.Duration
+
+/**
+ * Profile 5 — Read-Through Cache.
+ *
+ * A manual read-through implementation using Redis:
+ * - On cache hit: return cached value (no DB access)
+ * - On cache miss: load from DB, populate cache, return value
+ *
+ * Difference from Profile 3 (Redis Cache): explicit `getOrLoad` logic is visible here,
+ * making the read-through pattern explicit and measurable.
+ */
+@Service
+class ReadThroughService(
+    private val productRepository: ProductRepository,
+    private val redisTemplate: RedisTemplate<String, Product>,
+) : ProductCacheService {
+    companion object : KLoggingChannel() {
+        const val KEY_PREFIX = "products:read-through:"
+        val TTL: Duration = Duration.ofSeconds(60)
+    }
+
+    private fun cacheKey(id: Long) = "$KEY_PREFIX$id"
+
+    override fun findById(id: Long): Product? {
+        val key = cacheKey(id)
+        // 1. Read from cache
+        val cached = redisTemplate.opsForValue().get(key)
+        if (cached != null) return cached
+
+        // 2. Cache miss: read through to DB
+        return productRepository.findById(id).orElse(null)?.also { product ->
+            redisTemplate.opsForValue().set(key, product, TTL)
+        }
+    }
+
+    override fun save(product: Product): Product {
+        val saved = productRepository.save(product)
+        redisTemplate.opsForValue().set(cacheKey(saved.id), saved, TTL)
+        return saved
+    }
+
+    override fun evict(id: Long) {
+        redisTemplate.delete(cacheKey(id))
+    }
+
+    override fun clearAll() {
+        val keys = redisTemplate.keys("$KEY_PREFIX*")
+        if (!keys.isNullOrEmpty()) redisTemplate.delete(keys)
+    }
+}

--- a/spring-boot/cache-benchmark/src/main/kotlin/io/bluetape4k/workshop/cache/benchmark/service/RedisCacheService.kt
+++ b/spring-boot/cache-benchmark/src/main/kotlin/io/bluetape4k/workshop/cache/benchmark/service/RedisCacheService.kt
@@ -1,0 +1,34 @@
+package io.bluetape4k.workshop.cache.benchmark.service
+
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.workshop.cache.benchmark.domain.Product
+import io.bluetape4k.workshop.cache.benchmark.domain.ProductRepository
+import org.springframework.cache.annotation.CacheEvict
+import org.springframework.cache.annotation.CachePut
+import org.springframework.cache.annotation.Cacheable
+import org.springframework.stereotype.Service
+
+/**
+ * Profile 3 — Redis Distributed Cache.
+ *
+ * Uses Spring's `@Cacheable` with a Redis-backed [CacheManager] (Spring Data Redis).
+ * Cache entries are shared across all JVM instances, TTL = 60 s.
+ */
+@Service
+class RedisCacheService(private val productRepository: ProductRepository) : ProductCacheService {
+    companion object : KLoggingChannel() {
+        const val CACHE_NAME = "products-redis"
+    }
+
+    @Cacheable(cacheNames = [CACHE_NAME], key = "#id", cacheManager = "redisCacheManager")
+    override fun findById(id: Long): Product? = productRepository.findById(id).orElse(null)
+
+    @CachePut(cacheNames = [CACHE_NAME], key = "#result.id", cacheManager = "redisCacheManager")
+    override fun save(product: Product): Product = productRepository.save(product)
+
+    @CacheEvict(cacheNames = [CACHE_NAME], key = "#id", cacheManager = "redisCacheManager")
+    override fun evict(id: Long) {}
+
+    @CacheEvict(cacheNames = [CACHE_NAME], allEntries = true, cacheManager = "redisCacheManager")
+    override fun clearAll() {}
+}

--- a/spring-boot/cache-benchmark/src/main/kotlin/io/bluetape4k/workshop/cache/benchmark/service/WriteBehindFlusher.kt
+++ b/spring-boot/cache-benchmark/src/main/kotlin/io/bluetape4k/workshop/cache/benchmark/service/WriteBehindFlusher.kt
@@ -1,0 +1,34 @@
+package io.bluetape4k.workshop.cache.benchmark.service
+
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.logging.warn
+import io.bluetape4k.workshop.cache.benchmark.domain.Product
+import io.bluetape4k.workshop.cache.benchmark.domain.ProductRepository
+import org.springframework.scheduling.annotation.Async
+import org.springframework.stereotype.Component
+
+/**
+ * Async DB flusher for the write-behind cache profile.
+ *
+ * **Must be a separate @Component** (not a method on [WriteBehindService]) so that
+ * the `@Async` annotation is honoured through Spring's proxy mechanism.
+ * Calling `@Async` methods on `this` bypasses the proxy and executes synchronously.
+ */
+@Component
+class WriteBehindFlusher(private val productRepository: ProductRepository) {
+    companion object : KLoggingChannel()
+
+    /**
+     * Persists [product] to the database asynchronously.
+     *
+     * Failures are logged and swallowed — the cache already holds the latest value.
+     */
+    @Async
+    fun persist(product: Product) {
+        try {
+            productRepository.save(product)
+        } catch (e: Exception) {
+            log.warn(e) { "Write-behind DB flush failed for product id=${product.id}" }
+        }
+    }
+}

--- a/spring-boot/cache-benchmark/src/main/kotlin/io/bluetape4k/workshop/cache/benchmark/service/WriteBehindService.kt
+++ b/spring-boot/cache-benchmark/src/main/kotlin/io/bluetape4k/workshop/cache/benchmark/service/WriteBehindService.kt
@@ -1,0 +1,67 @@
+package io.bluetape4k.workshop.cache.benchmark.service
+
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.logging.warn
+import io.bluetape4k.workshop.cache.benchmark.domain.Product
+import io.bluetape4k.workshop.cache.benchmark.domain.ProductRepository
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.scheduling.annotation.Async
+import org.springframework.stereotype.Service
+import java.time.Duration
+
+/**
+ * Profile 7 — Write-Behind Cache.
+ *
+ * Writes are applied immediately to the Redis cache and asynchronously to the DB.
+ * - Reads: cache-first, fall through to DB on miss
+ * - Writes: fast (cache only, synchronous) + async DB flush via [@Async]
+ *
+ * Trade-off: lower write latency at the cost of eventual consistency.
+ */
+@Service
+class WriteBehindService(
+    private val productRepository: ProductRepository,
+    private val redisTemplate: RedisTemplate<String, Product>,
+) : ProductCacheService {
+    companion object : KLoggingChannel() {
+        const val KEY_PREFIX = "products:write-behind:"
+        val TTL: Duration = Duration.ofSeconds(60)
+    }
+
+    private fun cacheKey(id: Long) = "$KEY_PREFIX$id"
+
+    override fun findById(id: Long): Product? {
+        val key = cacheKey(id)
+        val cached = redisTemplate.opsForValue().get(key)
+        if (cached != null) return cached
+
+        return productRepository.findById(id).orElse(null)?.also { product ->
+            redisTemplate.opsForValue().set(key, product, TTL)
+        }
+    }
+
+    override fun save(product: Product): Product {
+        // Write-behind: update cache immediately, schedule async DB write
+        redisTemplate.opsForValue().set(cacheKey(product.id), product, TTL)
+        asyncPersist(product)
+        return product
+    }
+
+    @Async
+    fun asyncPersist(product: Product) {
+        try {
+            productRepository.save(product)
+        } catch (e: Exception) {
+            log.warn(e) { "Write-behind DB flush failed for product id=${product.id}" }
+        }
+    }
+
+    override fun evict(id: Long) {
+        redisTemplate.delete(cacheKey(id))
+    }
+
+    override fun clearAll() {
+        val keys = redisTemplate.keys("$KEY_PREFIX*")
+        if (!keys.isNullOrEmpty()) redisTemplate.delete(keys)
+    }
+}

--- a/spring-boot/cache-benchmark/src/main/kotlin/io/bluetape4k/workshop/cache/benchmark/service/WriteBehindService.kt
+++ b/spring-boot/cache-benchmark/src/main/kotlin/io/bluetape4k/workshop/cache/benchmark/service/WriteBehindService.kt
@@ -1,11 +1,9 @@
 package io.bluetape4k.workshop.cache.benchmark.service
 
 import io.bluetape4k.logging.coroutines.KLoggingChannel
-import io.bluetape4k.logging.warn
 import io.bluetape4k.workshop.cache.benchmark.domain.Product
 import io.bluetape4k.workshop.cache.benchmark.domain.ProductRepository
 import org.springframework.data.redis.core.RedisTemplate
-import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Service
 import java.time.Duration
 
@@ -14,15 +12,23 @@ import java.time.Duration
  *
  * Writes are applied immediately to the Redis cache and asynchronously to the DB.
  * - Reads: cache-first, fall through to DB on miss
- * - Writes: fast (cache only, synchronous) + async DB flush via [@Async]
+ * - Writes (new entity): DB save first to get the generated ID, then populate cache
+ * - Writes (update): cache updated immediately, DB flush deferred via [WriteBehindFlusher]
  *
- * Trade-off: lower write latency at the cost of eventual consistency.
+ * ## Why a separate flusher?
+ * Spring's `@Async` requires the call to pass through a Spring proxy.
+ * Internal `this`-calls bypass the proxy and execute synchronously.
+ * [WriteBehindFlusher] is a separate `@Component` so the async invocation
+ * goes through the proxy correctly.
+ *
+ * Trade-off: lower write latency for updates at the cost of eventual consistency.
  */
 @Service
 class WriteBehindService(
     private val productRepository: ProductRepository,
     private val redisTemplate: RedisTemplate<String, Product>,
-) : ProductCacheService {
+    private val flusher: WriteBehindFlusher,
+): ProductCacheService {
     companion object : KLoggingChannel() {
         const val KEY_PREFIX = "products:write-behind:"
         val TTL: Duration = Duration.ofSeconds(60)
@@ -41,18 +47,17 @@ class WriteBehindService(
     }
 
     override fun save(product: Product): Product {
-        // Write-behind: update cache immediately, schedule async DB write
-        redisTemplate.opsForValue().set(cacheKey(product.id), product, TTL)
-        asyncPersist(product)
-        return product
-    }
-
-    @Async
-    fun asyncPersist(product: Product) {
-        try {
-            productRepository.save(product)
-        } catch (e: Exception) {
-            log.warn(e) { "Write-behind DB flush failed for product id=${product.id}" }
+        return if (product.id == 0L) {
+            // New entity: must persist to DB first to obtain the generated ID
+            val saved = productRepository.save(product)
+            redisTemplate.opsForValue().set(cacheKey(saved.id), saved, TTL)
+            saved
+        } else {
+            // Existing entity (update): write-behind — update cache immediately,
+            // flush to DB asynchronously via proxy-based @Async flusher
+            redisTemplate.opsForValue().set(cacheKey(product.id), product, TTL)
+            flusher.persist(product)
+            product
         }
     }
 

--- a/spring-boot/cache-benchmark/src/main/kotlin/io/bluetape4k/workshop/cache/benchmark/service/WriteThroughService.kt
+++ b/spring-boot/cache-benchmark/src/main/kotlin/io/bluetape4k/workshop/cache/benchmark/service/WriteThroughService.kt
@@ -1,0 +1,54 @@
+package io.bluetape4k.workshop.cache.benchmark.service
+
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.workshop.cache.benchmark.domain.Product
+import io.bluetape4k.workshop.cache.benchmark.domain.ProductRepository
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.stereotype.Service
+import java.time.Duration
+
+/**
+ * Profile 6 — Write-Through Cache.
+ *
+ * Every write is applied synchronously to **both** Redis cache and the DB.
+ * - Reads: cache-first, fall through to DB on miss
+ * - Writes: synchronous dual-write (cache + DB) — strong consistency, higher write latency
+ */
+@Service
+class WriteThroughService(
+    private val productRepository: ProductRepository,
+    private val redisTemplate: RedisTemplate<String, Product>,
+) : ProductCacheService {
+    companion object : KLoggingChannel() {
+        const val KEY_PREFIX = "products:write-through:"
+        val TTL: Duration = Duration.ofSeconds(60)
+    }
+
+    private fun cacheKey(id: Long) = "$KEY_PREFIX$id"
+
+    override fun findById(id: Long): Product? {
+        val key = cacheKey(id)
+        val cached = redisTemplate.opsForValue().get(key)
+        if (cached != null) return cached
+
+        return productRepository.findById(id).orElse(null)?.also { product ->
+            redisTemplate.opsForValue().set(key, product, TTL)
+        }
+    }
+
+    override fun save(product: Product): Product {
+        // Write-through: update DB first, then update cache atomically
+        val saved = productRepository.save(product)
+        redisTemplate.opsForValue().set(cacheKey(saved.id), saved, TTL)
+        return saved
+    }
+
+    override fun evict(id: Long) {
+        redisTemplate.delete(cacheKey(id))
+    }
+
+    override fun clearAll() {
+        val keys = redisTemplate.keys("$KEY_PREFIX*")
+        if (!keys.isNullOrEmpty()) redisTemplate.delete(keys)
+    }
+}

--- a/spring-boot/cache-benchmark/src/main/resources/application.yml
+++ b/spring-boot/cache-benchmark/src/main/resources/application.yml
@@ -1,0 +1,46 @@
+spring:
+  application:
+    name: cache-benchmark
+
+  # H2 in-memory database for benchmarks
+  datasource:
+    url: jdbc:h2:mem:benchmark;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: false
+    properties:
+      hibernate:
+        format_sql: false
+        dialect: org.hibernate.dialect.H2Dialect
+
+  # Redis (overridden by benchmark setup via system properties)
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+      timeout: 5000ms
+
+  # Spring Cache: primary = Caffeine
+  cache:
+    type: caffeine
+    caffeine:
+      spec: maximumSize=10000,expireAfterWrite=60s
+
+  # Async for write-behind
+  task:
+    execution:
+      pool:
+        core-size: 4
+        max-size: 16
+        queue-capacity: 500
+
+logging:
+  level:
+    io.bluetape4k.workshop.cache.benchmark: DEBUG
+    org.springframework.cache: DEBUG
+    org.hibernate.SQL: WARN

--- a/spring-boot/cache-benchmark/src/main/resources/logback-spring.xml
+++ b/spring-boot/cache-benchmark/src/main/resources/logback-spring.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+
+    <property name="CONSOLE_LOG_PATTERN"
+              value="%clr(%d{HH:mm:ss.SSS}){faint} %highlight(%-5p) %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n"/>
+
+    <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>DEBUG</level>
+        </filter>
+        <encoder>
+            <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+            <charset>utf8</charset>
+        </encoder>
+    </appender>
+
+    <logger name="io.bluetape4k.workshop.cache.benchmark" level="DEBUG"/>
+    <logger name="org.redisson" level="WARN"/>
+    <logger name="io.lettuce" level="WARN"/>
+
+    <root level="INFO">
+        <appender-ref ref="console"/>
+    </root>
+</configuration>

--- a/spring-boot/cache-benchmark/src/test/kotlin/io/bluetape4k/workshop/cache/benchmark/AbstractCacheBenchmarkTest.kt
+++ b/spring-boot/cache-benchmark/src/test/kotlin/io/bluetape4k/workshop/cache/benchmark/AbstractCacheBenchmarkTest.kt
@@ -1,0 +1,23 @@
+package io.bluetape4k.workshop.cache.benchmark
+
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.testcontainers.storage.RedisServer
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+abstract class AbstractCacheBenchmarkTest {
+    companion object : KLoggingChannel() {
+        val redis: RedisServer by lazy { RedisServer.Launcher.redis }
+
+        @JvmStatic
+        @DynamicPropertySource
+        fun redisProperties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.data.redis.host") { redis.host }
+            registry.add("spring.data.redis.port") { redis.port.toString() }
+            registry.add("REDIS_HOST") { redis.host }
+            registry.add("REDIS_PORT") { redis.port.toString() }
+        }
+    }
+}

--- a/spring-boot/cache-benchmark/src/test/kotlin/io/bluetape4k/workshop/cache/benchmark/AbstractCacheBenchmarkTest.kt
+++ b/spring-boot/cache-benchmark/src/test/kotlin/io/bluetape4k/workshop/cache/benchmark/AbstractCacheBenchmarkTest.kt
@@ -2,11 +2,13 @@ package io.bluetape4k.workshop.cache.benchmark
 
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.testcontainers.storage.RedisServer
+import org.junit.jupiter.api.TestInstance
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.DynamicPropertyRegistry
 import org.springframework.test.context.DynamicPropertySource
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 abstract class AbstractCacheBenchmarkTest {
     companion object : KLoggingChannel() {
         val redis: RedisServer by lazy { RedisServer.Launcher.redis }

--- a/spring-boot/cache-benchmark/src/test/kotlin/io/bluetape4k/workshop/cache/benchmark/service/CaffeineServiceTest.kt
+++ b/spring-boot/cache-benchmark/src/test/kotlin/io/bluetape4k/workshop/cache/benchmark/service/CaffeineServiceTest.kt
@@ -1,0 +1,48 @@
+package io.bluetape4k.workshop.cache.benchmark.service
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.workshop.cache.benchmark.AbstractCacheBenchmarkTest
+import io.bluetape4k.workshop.cache.benchmark.domain.Product
+import io.bluetape4k.workshop.cache.benchmark.domain.ProductRepository
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import java.math.BigDecimal
+
+class CaffeineServiceTest(
+    @Autowired private val service: CaffeineService,
+    @Autowired private val productRepository: ProductRepository,
+) : AbstractCacheBenchmarkTest() {
+
+    @Test
+    fun `findById returns product and caches it`() {
+        val existing = productRepository.findAll().first()
+        val first = service.findById(existing.id)
+        val second = service.findById(existing.id)   // should come from cache
+        first shouldBeEqualTo existing
+        second shouldBeEqualTo first
+    }
+
+    @Test
+    fun `findById returns null for unknown id`() {
+        service.findById(999_999L).shouldBeNull()
+    }
+
+    @Test
+    fun `save updates cache`() {
+        val product = Product(name = "CafTest", category = "Test", price = BigDecimal("2.99"), stock = 3)
+        val saved = service.save(product)
+        (saved.id > 0L).shouldBeTrue()
+        service.findById(saved.id) shouldBeEqualTo saved
+    }
+
+    @Test
+    fun `evict removes entry from cache`() {
+        val existing = productRepository.findAll().first()
+        service.findById(existing.id)   // populate cache
+        service.evict(existing.id)
+        // After evict, next call goes to DB — should still return the record
+        service.findById(existing.id) shouldBeEqualTo existing
+    }
+}

--- a/spring-boot/cache-benchmark/src/test/kotlin/io/bluetape4k/workshop/cache/benchmark/service/NearCacheServiceTest.kt
+++ b/spring-boot/cache-benchmark/src/test/kotlin/io/bluetape4k/workshop/cache/benchmark/service/NearCacheServiceTest.kt
@@ -1,0 +1,47 @@
+package io.bluetape4k.workshop.cache.benchmark.service
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.workshop.cache.benchmark.AbstractCacheBenchmarkTest
+import io.bluetape4k.workshop.cache.benchmark.domain.Product
+import io.bluetape4k.workshop.cache.benchmark.domain.ProductRepository
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import java.math.BigDecimal
+
+class NearCacheServiceTest(
+    @Autowired private val service: NearCacheService,
+    @Autowired private val productRepository: ProductRepository,
+) : AbstractCacheBenchmarkTest() {
+
+    @Test
+    fun `findById populates local and remote cache tiers`() {
+        val existing = productRepository.findAll().first()
+        val first = service.findById(existing.id)   // DB miss → populate both tiers
+        val second = service.findById(existing.id)  // local-tier hit
+        first shouldBeEqualTo existing
+        second shouldBeEqualTo first
+    }
+
+    @Test
+    fun `findById returns null for unknown id`() {
+        service.findById(999_999L).shouldBeNull()
+    }
+
+    @Test
+    fun `save writes through to near cache`() {
+        val product = Product(name = "NearTest", category = "Test", price = BigDecimal("4.99"), stock = 2)
+        val saved = service.save(product)
+        (saved.id > 0L).shouldBeTrue()
+        service.findById(saved.id) shouldBeEqualTo saved
+    }
+
+    @Test
+    fun `evict removes entry from both cache tiers`() {
+        val existing = productRepository.findAll().first()
+        service.findById(existing.id)
+        service.evict(existing.id)
+        service.findById(existing.id) shouldBeEqualTo existing  // re-loads from DB
+    }
+}

--- a/spring-boot/cache-benchmark/src/test/kotlin/io/bluetape4k/workshop/cache/benchmark/service/NoCacheServiceTest.kt
+++ b/spring-boot/cache-benchmark/src/test/kotlin/io/bluetape4k/workshop/cache/benchmark/service/NoCacheServiceTest.kt
@@ -1,0 +1,37 @@
+package io.bluetape4k.workshop.cache.benchmark.service
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.workshop.cache.benchmark.AbstractCacheBenchmarkTest
+import io.bluetape4k.workshop.cache.benchmark.domain.Product
+import io.bluetape4k.workshop.cache.benchmark.domain.ProductRepository
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import java.math.BigDecimal
+
+class NoCacheServiceTest(
+    @Autowired private val service: NoCacheService,
+    @Autowired private val productRepository: ProductRepository,
+) : AbstractCacheBenchmarkTest() {
+
+    @Test
+    fun `findById returns product from DB`() {
+        val existing = productRepository.findAll().first()
+        val found = service.findById(existing.id)
+        found shouldBeEqualTo existing
+    }
+
+    @Test
+    fun `findById returns null for unknown id`() {
+        service.findById(999_999L).shouldBeNull()
+    }
+
+    @Test
+    fun `save persists product`() {
+        val product = Product(name = "Test", category = "Test", price = BigDecimal("1.99"), stock = 5)
+        val saved = service.save(product)
+        (saved.id > 0L).shouldBeTrue()
+        service.findById(saved.id) shouldBeEqualTo saved
+    }
+}

--- a/spring-boot/cache-benchmark/src/test/kotlin/io/bluetape4k/workshop/cache/benchmark/service/ReadThroughServiceTest.kt
+++ b/spring-boot/cache-benchmark/src/test/kotlin/io/bluetape4k/workshop/cache/benchmark/service/ReadThroughServiceTest.kt
@@ -1,0 +1,46 @@
+package io.bluetape4k.workshop.cache.benchmark.service
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.workshop.cache.benchmark.AbstractCacheBenchmarkTest
+import io.bluetape4k.workshop.cache.benchmark.domain.Product
+import io.bluetape4k.workshop.cache.benchmark.domain.ProductRepository
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import java.math.BigDecimal
+
+class ReadThroughServiceTest(
+    @Autowired private val service: ReadThroughService,
+    @Autowired private val productRepository: ProductRepository,
+) : AbstractCacheBenchmarkTest() {
+
+    @Test
+    fun `findById reads through to DB on first access`() {
+        val existing = productRepository.findAll().first()
+        val result = service.findById(existing.id)
+        result shouldBeEqualTo existing
+    }
+
+    @Test
+    fun `findById returns cached value on second access`() {
+        val existing = productRepository.findAll().first()
+        val first = service.findById(existing.id)
+        val second = service.findById(existing.id)
+        first shouldBeEqualTo existing
+        second shouldBeEqualTo first
+    }
+
+    @Test
+    fun `findById returns null for unknown id`() {
+        service.findById(999_999L).shouldBeNull()
+    }
+
+    @Test
+    fun `save populates cache`() {
+        val product = Product(name = "RTTest", category = "Test", price = BigDecimal("5.99"), stock = 4)
+        val saved = service.save(product)
+        (saved.id > 0L).shouldBeTrue()
+        service.findById(saved.id) shouldBeEqualTo saved
+    }
+}

--- a/spring-boot/cache-benchmark/src/test/kotlin/io/bluetape4k/workshop/cache/benchmark/service/RedisCacheServiceTest.kt
+++ b/spring-boot/cache-benchmark/src/test/kotlin/io/bluetape4k/workshop/cache/benchmark/service/RedisCacheServiceTest.kt
@@ -1,0 +1,39 @@
+package io.bluetape4k.workshop.cache.benchmark.service
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.workshop.cache.benchmark.AbstractCacheBenchmarkTest
+import io.bluetape4k.workshop.cache.benchmark.domain.Product
+import io.bluetape4k.workshop.cache.benchmark.domain.ProductRepository
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import java.math.BigDecimal
+
+class RedisCacheServiceTest(
+    @Autowired private val service: RedisCacheService,
+    @Autowired private val productRepository: ProductRepository,
+) : AbstractCacheBenchmarkTest() {
+
+    @Test
+    fun `findById stores and retrieves from Redis cache`() {
+        val existing = productRepository.findAll().first()
+        val first = service.findById(existing.id)
+        val second = service.findById(existing.id)
+        first shouldBeEqualTo existing
+        second shouldBeEqualTo first
+    }
+
+    @Test
+    fun `findById returns null for unknown id`() {
+        service.findById(999_999L).shouldBeNull()
+    }
+
+    @Test
+    fun `save updates Redis cache`() {
+        val product = Product(name = "RedisTest", category = "Test", price = BigDecimal("3.99"), stock = 7)
+        val saved = service.save(product)
+        (saved.id > 0L).shouldBeTrue()
+        service.findById(saved.id) shouldBeEqualTo saved
+    }
+}

--- a/spring-boot/cache-benchmark/src/test/kotlin/io/bluetape4k/workshop/cache/benchmark/service/WriteBehindServiceTest.kt
+++ b/spring-boot/cache-benchmark/src/test/kotlin/io/bluetape4k/workshop/cache/benchmark/service/WriteBehindServiceTest.kt
@@ -1,0 +1,42 @@
+package io.bluetape4k.workshop.cache.benchmark.service
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.workshop.cache.benchmark.AbstractCacheBenchmarkTest
+import io.bluetape4k.workshop.cache.benchmark.domain.Product
+import io.bluetape4k.workshop.cache.benchmark.domain.ProductRepository
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import java.math.BigDecimal
+
+class WriteBehindServiceTest(
+    @Autowired private val service: WriteBehindService,
+    @Autowired private val productRepository: ProductRepository,
+) : AbstractCacheBenchmarkTest() {
+
+    @Test
+    fun `save writes to cache immediately`() {
+        val product = Product(name = "WBTest", category = "Test", price = BigDecimal("7.99"), stock = 6)
+        val saved = service.save(product)
+
+        // Cache should have the value immediately
+        service.findById(saved.id) shouldBeEqualTo saved
+    }
+
+    @Test
+    fun `findById returns cached product`() {
+        val existing = productRepository.findAll().first()
+        service.findById(existing.id)
+        service.findById(existing.id) shouldBeEqualTo existing
+    }
+
+    @Test
+    fun `async flush eventually persists to DB`() {
+        val product = Product(name = "WBAsyncTest", category = "Test", price = BigDecimal("8.99"), stock = 9)
+        val saved = service.save(product)
+        (saved.id >= 0L).shouldBeTrue()
+
+        // For new products (id=0), the async flush needs a fresh save; skip DB check for new records.
+        // DB check only meaningful for update path (id > 0).
+    }
+}

--- a/spring-boot/cache-benchmark/src/test/kotlin/io/bluetape4k/workshop/cache/benchmark/service/WriteBehindServiceTest.kt
+++ b/spring-boot/cache-benchmark/src/test/kotlin/io/bluetape4k/workshop/cache/benchmark/service/WriteBehindServiceTest.kt
@@ -5,38 +5,52 @@ import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.workshop.cache.benchmark.AbstractCacheBenchmarkTest
 import io.bluetape4k.workshop.cache.benchmark.domain.Product
 import io.bluetape4k.workshop.cache.benchmark.domain.ProductRepository
+import org.awaitility.kotlin.atMost
+import org.awaitility.kotlin.await
+import org.awaitility.kotlin.until
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import java.math.BigDecimal
+import java.time.Duration
 
 class WriteBehindServiceTest(
     @Autowired private val service: WriteBehindService,
     @Autowired private val productRepository: ProductRepository,
-) : AbstractCacheBenchmarkTest() {
+): AbstractCacheBenchmarkTest() {
 
     @Test
-    fun `save writes to cache immediately`() {
-        val product = Product(name = "WBTest", category = "Test", price = BigDecimal("7.99"), stock = 6)
+    fun `save new entity persists to DB and populates cache`() {
+        val product = Product(name = "WBNew", category = "Test", price = BigDecimal("7.99"), stock = 6)
         val saved = service.save(product)
 
-        // Cache should have the value immediately
+        // New entity: ID must be DB-assigned (> 0)
+        (saved.id > 0L).shouldBeTrue()
+        // Cache should hold the value immediately
         service.findById(saved.id) shouldBeEqualTo saved
+        // DB must already have the record (synchronous save for new entities)
+        productRepository.findById(saved.id).orElse(null) shouldBeEqualTo saved
     }
 
     @Test
-    fun `findById returns cached product`() {
+    fun `save update writes cache immediately and flushes DB asynchronously`() {
         val existing = productRepository.findAll().first()
-        service.findById(existing.id)
-        service.findById(existing.id) shouldBeEqualTo existing
+        val updated = existing.copy(name = "WBUpdated-${System.nanoTime()}")
+
+        service.save(updated)
+
+        // Cache must be updated immediately (synchronous write)
+        service.findById(existing.id) shouldBeEqualTo updated
+
+        // DB flush is async — poll up to 5 s for the write-behind flush to complete
+        await atMost Duration.ofSeconds(5) until {
+            productRepository.findById(existing.id).orElse(null)?.name == updated.name
+        }
     }
 
     @Test
-    fun `async flush eventually persists to DB`() {
-        val product = Product(name = "WBAsyncTest", category = "Test", price = BigDecimal("8.99"), stock = 9)
-        val saved = service.save(product)
-        (saved.id >= 0L).shouldBeTrue()
-
-        // For new products (id=0), the async flush needs a fresh save; skip DB check for new records.
-        // DB check only meaningful for update path (id > 0).
+    fun `findById returns cached product on second access`() {
+        val existing = productRepository.findAll().first()
+        service.findById(existing.id)                     // prime cache
+        service.findById(existing.id) shouldBeEqualTo existing
     }
 }

--- a/spring-boot/cache-benchmark/src/test/kotlin/io/bluetape4k/workshop/cache/benchmark/service/WriteThroughServiceTest.kt
+++ b/spring-boot/cache-benchmark/src/test/kotlin/io/bluetape4k/workshop/cache/benchmark/service/WriteThroughServiceTest.kt
@@ -1,0 +1,36 @@
+package io.bluetape4k.workshop.cache.benchmark.service
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.workshop.cache.benchmark.AbstractCacheBenchmarkTest
+import io.bluetape4k.workshop.cache.benchmark.domain.Product
+import io.bluetape4k.workshop.cache.benchmark.domain.ProductRepository
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import java.math.BigDecimal
+
+class WriteThroughServiceTest(
+    @Autowired private val service: WriteThroughService,
+    @Autowired private val productRepository: ProductRepository,
+) : AbstractCacheBenchmarkTest() {
+
+    @Test
+    fun `save writes to both cache and DB synchronously`() {
+        val product = Product(name = "WTTest", category = "Test", price = BigDecimal("6.99"), stock = 8)
+        val saved = service.save(product)
+        (saved.id > 0L).shouldBeTrue()
+
+        // Cache hit
+        service.findById(saved.id) shouldBeEqualTo saved
+
+        // DB persisted
+        productRepository.findById(saved.id).orElse(null) shouldBeEqualTo saved
+    }
+
+    @Test
+    fun `findById returns cached product`() {
+        val existing = productRepository.findAll().first()
+        service.findById(existing.id) // prime cache
+        service.findById(existing.id) shouldBeEqualTo existing
+    }
+}

--- a/spring-boot/cache-benchmark/src/test/resources/junit-platform.properties
+++ b/spring-boot/cache-benchmark/src/test/resources/junit-platform.properties
@@ -1,0 +1,6 @@
+junit.jupiter.extensions.autodetection.enabled=true
+junit.jupiter.testinstance.lifecycle.default=per_class
+
+junit.jupiter.execution.parallel.enabled=false
+junit.jupiter.execution.parallel.mode.default=same_thread
+junit.jupiter.execution.parallel.mode.classes.default=concurrent

--- a/spring-boot/cache-benchmark/src/test/resources/logback-test.xml
+++ b/spring-boot/cache-benchmark/src/test/resources/logback-test.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+
+    <property name="CONSOLE_LOG_PATTERN"
+              value="%clr(%d{HH:mm:ss.SSS}){faint} %highlight(%-5p) %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n"/>
+
+    <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>DEBUG</level>
+        </filter>
+        <encoder>
+            <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+            <charset>utf8</charset>
+        </encoder>
+    </appender>
+
+    <logger name="io.bluetape4k.workshop.cache.benchmark" level="DEBUG"/>
+    <logger name="org.redisson" level="WARN"/>
+    <logger name="io.lettuce" level="WARN"/>
+    <logger name="org.testcontainers" level="INFO"/>
+
+    <root level="INFO">
+        <appender-ref ref="console"/>
+    </root>
+</configuration>


### PR DESCRIPTION
## Summary

Implements issue #95 — **Performance Benchmark Advanced**.

Adds `spring-boot/cache-benchmark` module comparing 7 cache strategies using **kotlinx-benchmark** (JMH-based) against an H2 in-memory DB and Redis (Testcontainers).

## 7 Cache Profiles

| # | Profile | Strategy | Consistency | Write Latency |
|---|---------|----------|-------------|---------------|
| 1 | **No Cache** | Direct JPA/H2 | Strong | Low |
| 2 | **Caffeine** | `@Cacheable` local | Per-instance | Low |
| 3 | **Redis Cache** | `@Cacheable` remote | Shared | Low |
| 4 | **Near Cache** | Redisson `RLocalCachedMap` (2-tier) | Eventual | Medium |
| 5 | **Read-Through** | Manual Redis read-through | Eventual | Low |
| 6 | **Write-Through** | Sync dual-write (Redis + DB) | Strong | High |
| 7 | **Write-Behind** | Async DB flush via `@Async` | Eventual | Lowest |

## Used Bluetape4k Features

| Feature | Module | Usage |
|---------|--------|-------|
| `NearCacheOperations` | `bluetape4k-cache-core` | Interface design reference |
| `RedisServer.Launcher` | `bluetape4k-testcontainers` | Singleton Redis container |
| `KLoggingChannel` | `bluetape4k-logging` | Coroutine-safe logger |
| `bluetape4k-redisson` | `bluetape4k-redisson` | NearCacheService Redisson client |
| `bluetape4k-junit5` | `bluetape4k-junit5` | Test assertions |

## Running Benchmarks

Benchmarks are **not** in the default CI test run (profile-gated):

```bash
# Single profile
./gradlew :spring-boot-cache-benchmark:noCacheBenchmark
./gradlew :spring-boot-cache-benchmark:caffeineBenchmark
./gradlew :spring-boot-cache-benchmark:nearCacheBenchmark

# All 7 profiles
./gradlew :spring-boot-cache-benchmark:allProfilesBenchmark
```

## Test Results

```
:spring-boot-cache-benchmark:test
  NoCacheServiceTest      3/3  ✅
  CaffeineServiceTest     4/4  ✅
  RedisCacheServiceTest   3/3  ✅
  NearCacheServiceTest    4/4  ✅
  ReadThroughServiceTest  4/4  ✅
  WriteThroughServiceTest 2/2  ✅
  WriteBehindServiceTest  3/3  ✅ (Awaitility async flush assertion)
  
  Total: 23 tests, 0 failures, 0 errors
```

## Code Review Findings Resolved (P0/P1 = 0)

| Severity | Finding | Fix |
|----------|---------|-----|
| CRITICAL | `@Async` self-invocation bypasses proxy | Extracted `WriteBehindFlusher` component |
| CRITICAL | `save()` cached id=0 for new entities | DB-first save for new entities; write-behind for updates only |
| HIGH | Mixed JMH + kotlinx.benchmark `@Setup` → double invocation | Removed JMH annotations from abstract class |

## Lessons Documented

`docs/lessons/2026-05-24-cache-benchmark-advanced.md`

Key lessons: Redisson 4.x API migration, `@Async` proxy pitfall, write-behind ID semantics, kotlinx-benchmark + JMH interaction, bluetape4k explicit logging imports.

Closes #95