### PR TITLE
feat: add ktor-rest-coroutines workshop module (#14)

### DIFF
--- a/docs/lessons/2026-05-25-ktor-rest-coroutines.md
+++ b/docs/lessons/2026-05-25-ktor-rest-coroutines.md
@@ -1,0 +1,129 @@
+# Lessons: ktor-rest-coroutines workshop module
+
+**Date**: 2026-05-25
+**Branch**: feat/ktor-rest-coroutines
+**Issue**: #14 — Ktor 기반 Kotlin-first workshop 예제 추가
+
+---
+
+## Root Cause / Background
+
+이 모듈은 신규 구현이므로 버그 수정이 아닌, 구현 과정에서 발견된 블로커 패턴들을 기록한다.
+
+---
+
+## Key Decisions and Outcomes
+
+### 1. `sse("/books/stream")` — explicit path mandatory
+
+**결정**: `sse { }` 대신 반드시 `sse("/books/stream") { }` 형태로 경로 명시.
+
+**이유**: Ktor 3에서 bare `sse { }` 는 application root에 마운트되어 `/books/stream`이 아닌 `/`에 응답한다.
+
+**규칙**: SSE 라우트는 항상 명시적 경로를 지정하고, `route("/books")` 블록 바깥의 top-level `routing { }` 에 등록한다 (안에 넣으면 `/books/books/stream` 이중 prefix 생성).
+
+### 2. `KLoggingChannel` 패키지 경로
+
+**결정**: `io.bluetape4k.logging.coroutines.KLoggingChannel` (coroutines 하위 패키지).
+
+**실수**: `io.bluetape4k.logging.KLoggingChannel`으로 잘못 작성 → Unresolved reference 에러.
+
+**규칙**: bluetape4k logging 임포트는 항상 실제 소스 위치를 확인 후 사용할 것:
+- `KLogging` → `io.bluetape4k.logging.KLogging`
+- `KLoggingChannel` → `io.bluetape4k.logging.coroutines.KLoggingChannel`
+
+### 3. bluetape4k Logger 확장 함수는 별도 임포트 필요
+
+**결정**: `log.debug { }`, `log.warn(e) { }` 등 람다 형식 로그는 `io.bluetape4k.logging.*` 확장 함수이므로 명시적 import 필요.
+
+**실수**: `KLogging` 임포트만으로는 `log.warn(e) { }` 형식이 컴파일되지 않음 — SLF4J `Logger`의 Java 메서드와 타입 불일치 오류.
+
+**규칙**:
+```kotlin
+import io.bluetape4k.logging.debug
+import io.bluetape4k.logging.warn
+import io.bluetape4k.logging.info
+```
+
+### 4. `testApplication { }` 내 `coroutineContext` 충돌
+
+**결정**: `CoroutineScope(Dispatchers.Default + SupervisorJob())` 사용.
+
+**이유**: Ktor 3 `ApplicationTestBuilder`에 `coroutineContext` 프로퍼티가 `String` 타입으로 선언되어 있어, Kotlin coroutines의 `kotlin.coroutines.coroutineContext` 와 이름 충돌 발생.
+
+**규칙**: `testApplication { }` 블록 내에서 SSE 구독 scope 생성 시:
+```kotlin
+// BAD — coroutineContext is String in ApplicationTestBuilder
+val scope = CoroutineScope(coroutineContext + SupervisorJob())
+
+// GOOD — use Dispatchers.Default explicitly
+val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+```
+
+### 5. Kluent vs bluetape4k-assertions
+
+**결정**: Kluent (`org.amshove.kluent.*`)는 이 workspace의 `build.gradle.kts` 카탈로그에 없음 → `io.bluetape4k.assertions.*` 사용.
+
+**규칙**: workshop 모듈 테스트에서 assertion import는 반드시 `io.bluetape4k.assertions.*`를 사용.
+
+### 6. Jackson 3 NDJSON + kotlinx-serialization 공존
+
+**결정**: ContentNegotiation은 `kotlinx-serialization-json`, NDJSON export만 `tools.jackson.*` (Jackson 3).
+
+**검증**: `rg "com.fasterxml.jackson" ktor/rest-coroutines/src` → 0 matches 확인 필수.
+
+### 7. `withTimeoutOrNull(5_000)` around `sharedFlow.emit()`
+
+**결정**: SSE 구독자가 느릴 때 HTTP handler가 블로킹되지 않도록 emit에 타임아웃 추가.
+
+**패턴**:
+```kotlin
+val emitted = withTimeoutOrNull(EMIT_TIMEOUT_MS) { sharedFlow.emit(book) } != null
+if (!emitted) {
+    log.warn { "SSE emit timed out; event dropped" }
+}
+```
+Book은 emit 전에 저장되므로 타임아웃 시에도 저장은 보장됨.
+
+### 8. StatusPages catch-all에 `"type":"Internal"` 필수
+
+**결정**: `exception<Throwable>` 핸들러는 반드시 `"type" to "Internal"` 포함.
+
+**이유**: 클라이언트가 에러 타입을 구분할 수 있어야 하고, 500 응답에서 stack trace가 노출되지 않아야 함.
+
+---
+
+## Review Misses (Step 2-R / 3-R 에서 발견된 것들)
+
+- Round 2 N1: SSE explicit path (`sse("/books/stream")` vs `sse {}`)
+- Round 2 N2: catch-all Throwable handler에 `"type"` 필드 누락
+- Round 2 UX-1: `AppJson` visibility — `private` → `internal`
+- Round 4 R4-H1: `backgroundScope.launch {}` 미접근 → `CoroutineScope(coroutineContext + SupervisorJob())` → 실제로는 `Dispatchers.Default + SupervisorJob()` 필요
+
+---
+
+## Future Guidance
+
+- Ktor 3 모듈 신규 생성 시 이 모듈의 `build.gradle.kts`, `ApplicationModule.kt`, `BookRoutes.kt`를 템플릿으로 참고.
+- SSE + SharedFlow 패턴은 `InMemoryBookRepository` + `BookRoutes.kt` 조합 참고.
+- NDJSON export는 `Jackson3Support.kt` + `respondBytesWriter` 패턴 참고.
+- bluetape4k logging 사용 시 패키지 경로와 확장 함수 임포트 항상 확인.
+
+---
+
+## Verification Evidence
+
+```
+모듈: :ktor-rest-coroutines
+소스 컴파일: BUILD SUCCESSFUL
+테스트 컴파일: BUILD SUCCESSFUL
+
+InMemoryBookRepositoryTest : 10 tests, 0 failures
+BookRoutesTest             : 12 tests, 0 failures
+BookStreamTest             :  2 tests, 0 failures
+HealthRoutesTest           :  1 tests, 0 failures
+BookServiceTest            : 16 tests, 0 failures
+총                          : 41 tests, 0 failures
+
+./gradlew :ktor-rest-coroutines:build  → BUILD SUCCESSFUL
+```

--- a/docs/superpowers/plans/2026-05-25-ktor-rest-coroutines-plan.md
+++ b/docs/superpowers/plans/2026-05-25-ktor-rest-coroutines-plan.md
@@ -67,6 +67,11 @@
   ```kotlin
   plugins {
       alias(libs.plugins.kotlin.serialization)
+      application   // required for ./gradlew :ktor-rest-coroutines:run
+  }
+
+  application {
+      mainClass.set("io.bluetape4k.workshop.ktor.MainKt")
   }
 
   configurations {
@@ -85,13 +90,15 @@
       implementation(libs.ktor.serialization.kotlinx.json)
       implementation(libs.kotlinx.serialization.json)
 
-      implementation(Libs.bluetape4k_core)
-      implementation(Libs.bluetape4k_logging)
-      implementation(Libs.bluetape4k_coroutines)
-      implementation(Libs.bluetape4k_jackson3)
+      // Use libs.* catalog aliases (NOT Libs.*) — no Libs.kt exists in this workspace
+      implementation(libs.bluetape4k.core)
+      implementation(libs.bluetape4k.logging)
+      implementation(libs.bluetape4k.coroutines)
+      implementation(libs.bluetape4k.jackson3)
+      implementation(libs.jackson3.module.kotlin)   // required for Jackson 3 Kotlin data class serialization
 
-      testImplementation(Libs.bluetape4k_junit5)
-      testImplementation(Libs.bluetape4k_assertions)
+      testImplementation(libs.bluetape4k.junit5)
+      testImplementation(libs.bluetape4k.assertions)
       testImplementation(libs.kotlinx.coroutines.test.lib)
       testImplementation(libs.ktor.server.test.host)
       testImplementation(libs.ktor.client.core)
@@ -99,7 +106,8 @@
   }
   ```
 - **MUST NOT include**: `ktor-serialization-jackson`, any `com.fasterxml.jackson.*`, `springBoot { }` block.
-- **verify**: `./gradlew :ktor-rest-coroutines:dependencies` resolves Ktor 3.4.3 BOM.
+- **⚠ NOTE**: This workspace uses `libs.*` catalog aliases, NOT `Libs.*`. There is no `Libs.kt` / `buildSrc` object in this project.
+- **verify**: `./gradlew :ktor-rest-coroutines:dependencies --configuration runtimeClasspath | grep "com.fasterxml.jackson"` → zero matches expected.
 
 ---
 
@@ -211,14 +219,15 @@
 - **CRITICAL requirements**:
   1. `internal val AppJson = Json { ignoreUnknownKeys = true; prettyPrint = false }` — **`internal`**, NOT `private`. `BookRoutes.kt` imports via `import io.bluetape4k.workshop.ktor.AppJson`.
   2. Function signature: `fun Application.module(repository: BookRepository = InMemoryBookRepository(), jackson3: Jackson3Support = Jackson3Support())`.
-  3. StatusPages handler order (specific first, `Throwable` last):
+  3. **`CallLogging` import**: Ktor 3.x path is `import io.ktor.server.plugins.calllogging.*` (lowercase, single 'g'). Not `callLogging.*`, not the Ktor 2 variant.
+  4. StatusPages handler order (specific first, `Throwable` last):
      - `exception<DomainError.NotFound>` → 404 + `{"error":"...","type":"NotFound"}`
      - `exception<DomainError.Conflict>` → 409 + `{"error":"...","type":"Conflict"}`
      - `exception<IllegalArgumentException>` → 400 + `{"error":"...","type":"BadRequest"}`
      - `exception<BadRequestException>` → 400 + `{"error":"...","type":"BadRequest"}`
      - **`exception<Throwable>` catch-all** → 500 + `{"error":"Internal server error","type":"Internal"}` (MUST include `"type":"Internal"` — Round 2 N2 fix)
-  4. `ContentNegotiation { json(AppJson) }` — same `AppJson` instance.
-  5. Plugin install order: `CallLogging` → `ContentNegotiation` → `SSE` → `StatusPages`.
+  5. `ContentNegotiation { json(AppJson) }` — same `AppJson` instance.
+  6. Plugin install order: `CallLogging` → `ContentNegotiation` → `SSE` → `StatusPages`.
 
 ---
 
@@ -234,10 +243,11 @@
 - **file**: `ktor/rest-coroutines/src/main/kotlin/io/bluetape4k/workshop/ktor/routes/BookRoutes.kt`
 - **CRITICAL requirements**:
   1. **`sse("/books/stream") { ... }` with explicit path** — NEVER bare `sse { }` (Round 2 N1 fix).
-  2. `import io.bluetape4k.workshop.ktor.AppJson` — shared instance for SSE encoding.
-  3. `CancellationException` MUST be rethrown before `catch (e: Exception)` in the SSE collect block.
-  4. `GET /books/export` uses `call.respondBytesWriter(contentType = ContentType("application", "x-ndjson")) { jackson3.writeNdjson(this, books) }`.
-  5. Logger via `private object BookRoutesLog : KLoggingChannel()` (extension functions cannot have companion objects).
+  2. **`sse("/books/stream")` must be at the top-level `routing { }` scope, NOT nested inside `route("/books") { }`**. Nesting inside `route("/books")` would produce the double-prefix `/books/books/stream`.
+  3. `import io.bluetape4k.workshop.ktor.AppJson` — shared instance for SSE encoding.
+  4. `CancellationException` MUST be rethrown before `catch (e: Exception)` in the SSE collect block.
+  5. `GET /books/export` uses `call.respondBytesWriter(contentType = ContentType("application", "x-ndjson")) { jackson3.writeNdjson(this, books) }`.
+  6. Logger via `private object BookRoutesLog : KLoggingChannel()` (extension functions cannot have companion objects).
 - Route structure:
   ```kotlin
   route("/books") {
@@ -283,8 +293,23 @@
 ### T15 — Test resources
 - **complexity**: low
 - **files**:
-  - `ktor/rest-coroutines/src/test/resources/junit-platform.properties` — copy from workshop templates.
-  - `ktor/rest-coroutines/src/test/resources/logback-test.xml` — copy from workshop templates; adapt if Spring Boot classpath unavailable.
+  - `ktor/rest-coroutines/src/test/resources/junit-platform.properties` — copy from workshop templates (`templates/test/resources/junit-platform.properties`).
+  - `ktor/rest-coroutines/src/test/resources/logback-test.xml` — this module has NO Spring Boot on the classpath; the Spring-Boot-referencing template will fail. Use standalone minimal content:
+    ```xml
+    <?xml version="1.0" encoding="UTF-8"?>
+    <configuration scan="true">
+      <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+          <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+      </appender>
+      <root level="INFO">
+        <appender-ref ref="CONSOLE" />
+      </root>
+      <logger name="io.bluetape4k.workshop" level="DEBUG" />
+      <logger name="io.ktor" level="INFO" />
+    </configuration>
+    ```
 
 ---
 
@@ -293,7 +318,7 @@
 ### T16 — `AbstractKtorTest.kt`
 - **complexity**: medium
 - **file**: `ktor/rest-coroutines/src/test/kotlin/io/bluetape4k/workshop/ktor/AbstractKtorTest.kt`
-- `abstract class AbstractKtorTest { companion object : KLoggingChannel() }`
+- `@TestInstance(TestInstance.Lifecycle.PER_CLASS) abstract class AbstractKtorTest { companion object : KLoggingChannel() }` — workspace CLAUDE.md mandates `PER_CLASS` on test base classes.
 - Shared Book fixture builders.
 
 ### T17 — `routes/HealthRoutesTest.kt`
@@ -303,17 +328,21 @@
 
 ### T18 — `routes/BookRoutesTest.kt`
 - **complexity**: high
-- **8 test cases**:
-  - `GET /books` → 200 + list
+- **12 test cases**:
+  - `GET /books` (empty repository) → 200 + `[]`
+  - `GET /books` (pre-seeded) → 200 + list
   - `GET /books/{id}` (exists) → 200 + book
   - `GET /books/{id}` (missing) → 404 + `{"type":"NotFound"}`
   - `POST /books` (valid) → 201 + book
   - `POST /books` (duplicate) → 409 + `{"type":"Conflict"}`
   - `POST /books` (blank title) → 400 + `{"type":"BadRequest"}`
-  - `POST /books` (year out of range) → 400
-  - `GET /books/export` → 200 + `application/x-ndjson` + one JSON object per line
-- Each test is `@Test fun foo() = testApplication { val repository = InMemoryBookRepository(); application { module(repository = repository) }; ... }`.
-- Pre-seed with `kotlinx.coroutines.runBlocking { repository.save(...) }`.
+  - `POST /books` (blank id) → 400 + `{"type":"BadRequest"}`
+  - `POST /books` (year out of range) → 400 + `{"type":"BadRequest"}`
+  - `GET /books/export` → 200 + `Content-Type: application/x-ndjson`; parse body line-by-line; assert each line deserializes to `Book`; assert line count matches seeded count
+  - `GET /health` (full module with SSE installed) → 200 + `OK` (verifies SSE route does not shadow `/health`)
+  - Catch-all 500: inject `FakeRepository` that throws `RuntimeException` on `findAll()`; assert 500 + body contains `"type":"Internal"` and does NOT contain stack trace text
+- Each test: `@Test fun foo() = testApplication { val repository = InMemoryBookRepository(); application { module(repository = repository) }; ... }` — NOT wrapped in `runSuspendTest`.
+- Pre-seed: call `repository.save(...)` directly — **`testApplication` block is `suspend`, so `save()` is callable without `runBlocking {}`**.
 
 ### T19 — `routes/BookStreamTest.kt`
 - **complexity**: high
@@ -360,10 +389,24 @@
 - Pattern: `@Test fun foo() = runSuspendTest { ... }` — pure suspend unit tests, NOT inside `testApplication`.
 - Cover: save+findById, duplicate conflict, stream emission.
 - `assertFailsWith<DomainError.Conflict> { ... }` for exception checks.
+- **Stream emission pattern** (inside `runSuspendTest { }` which IS a `TestScope`, so `this.launch {}` is available):
+  ```kotlin
+  val repo = InMemoryBookRepository()
+  val received = Channel<Book>(Channel.BUFFERED)
+  val job = launch { repo.stream().collect { received.send(it) } }
+  delay(50)
+  val book = Book("b-1", "T", "A", 2020)
+  repo.save(book)
+  withTimeoutOrNull(2_000) { received.receive() } shouldBeEqualTo book
+  job.cancel(); received.close()
+  ```
+  Note: `launch {}` is available inside `runSuspendTest` because `runSuspendTest` provides a `TestScope` receiver.
 
-### T20b — `service/BookServiceTest.kt` (optional)
+### T20b — `service/BookServiceTest.kt` (required — validation matrix)
 - **complexity**: medium
-- Validation matrix via `runSuspendTest` + `FakeBookRepository`.
+- Validation matrix via `runSuspendTest` + inline `FakeBookRepository` stub.
+- Must cover all four fields: id (blank, too long), title (blank, too long), author (blank, too long), year (< 1, > 3000).
+- Ensures 80%+ coverage on `BookService.create()` path independent of HTTP layer.
 
 ---
 
@@ -384,8 +427,9 @@
 ### T23 — Settings + catalog smoke check
 - **complexity**: low
 - `./gradlew projects | grep ktor-rest-coroutines`
-- `rg "com.fasterxml.jackson" ktor/rest-coroutines/src` → zero matches
+- `rg "com.fasterxml.jackson" ktor/rest-coroutines/src` → zero matches (source check)
 - `rg "io.ktor.serialization.jackson" ktor/rest-coroutines/src` → zero matches
+- `./gradlew :ktor-rest-coroutines:dependencies --configuration runtimeClasspath | grep "com.fasterxml.jackson"` → zero matches (classpath transitive check)
 
 ### T24 — Build, test, detekt
 - **complexity**: low
@@ -397,6 +441,15 @@
   ./gradlew detekt
   ```
 - All exit 0; test reports > 0 tests with 0 failures.
+
+### T25 — CI/nightly smoke registration + spec path correction
+- **complexity**: low
+- **Workflow Hazards Catalog (Module Addition)** — mandatory for every new Gradle module.
+- `rg ":ktor-rest-coroutines:test" .github/workflows/ scripts/` — confirm current absence.
+- Add `:ktor-rest-coroutines:test \` to `all-smoke` case in `scripts/smoke-validate.sh` (pure in-memory, no Testcontainers — qualifies for Mon-Sat smoke).
+- Bump `expected=` count by 1 in `stale-check` case of `scripts/smoke-validate.sh`.
+- Check `nightly-tests.yml`; add `:ktor-rest-coroutines:test` to the task list if missing.
+- **Spec path fix**: spec §13.4–§13.6 references `:ktor:rest-coroutines:*` — incorrect. The flat project name produced by `includeModules("ktor", false, true)` is `:ktor-rest-coroutines`. Update all spec verification commands to `:ktor-rest-coroutines:*`.
 
 ---
 
@@ -424,11 +477,12 @@
 | T18 | BookRoutesTest.kt (8 cases) | **high** |
 | T19 | BookStreamTest.kt (SSE + CoroutineScope pattern) | **high** |
 | T20 | InMemoryBookRepositoryTest.kt | medium |
-| T20b | BookServiceTest.kt (optional) | medium |
+| T20b | BookServiceTest.kt (required — validation matrix) | medium |
 | T21 | README.md | medium |
 | T22 | README.ko.md | low |
-| T23 | Smoke checks | low |
+| T23 | Smoke checks (source + classpath) | low |
 | T24 | Build/test/detekt | low |
+| T25 | CI/nightly smoke registration + spec path fix | low |
 
 **High complexity tasks**: T7, T9, T11, T18, T19 — implement these with maximum care; refer to spec critical notes.
 

--- a/docs/superpowers/plans/2026-05-25-ktor-rest-coroutines-plan.md
+++ b/docs/superpowers/plans/2026-05-25-ktor-rest-coroutines-plan.md
@@ -1,0 +1,455 @@
+# Implementation Plan: ktor-rest-coroutines Workshop Module
+
+- **Date**: 2026-05-25
+- **Branch**: feat/ktor-rest-coroutines
+- **Spec**: `docs/superpowers/specs/2026-05-25-ktor-rest-coroutines-design.md`
+- **Module path**: `ktor/rest-coroutines`
+- **Gradle project**: `:ktor-rest-coroutines`
+- **Base package**: `io.bluetape4k.workshop.ktor`
+
+---
+
+## Phase Overview
+
+| Phase | Scope | Tasks |
+|---|---|---|
+| 1 | Build scaffolding (settings, version catalog, module build) | T1–T3 |
+| 2 | Domain types (Book, DomainError) | T4–T5 |
+| 3 | Repository layer (interface + in-memory with SharedFlow) | T6–T7 |
+| 4 | Service layer (BookService + validation constants) | T8 |
+| 5 | Application wiring (ApplicationModule + AppJson + StatusPages) | T9 |
+| 6 | Routes (HealthRoutes, BookRoutes, SSE, NDJSON) | T10–T12 |
+| 7 | Entry point (Main.kt) and production logging | T13–T14 |
+| 8 | Test resources (junit-platform.properties, logback-test.xml) | T15 |
+| 9 | Tests (AbstractKtorTest, Health, Books, Stream, Repository) | T16–T20 |
+| 10 | Documentation (README en/ko) | T21–T22 |
+| 11 | Final verification (settings + catalog + build/test) | T23–T24 |
+
+---
+
+## Phase 1 — Build Scaffolding
+
+### T1 — Add Ktor coordinates to `gradle/libs.versions.toml`
+- **complexity**: low
+- **file**: `gradle/libs.versions.toml`
+- **changes**:
+  - Confirm `ktor = "3.4.3"` under `[versions]` (already added in Step 2 prep — verify only).
+  - Add under `[libraries]`:
+    ```toml
+    ktor-bom                        = { module = "io.ktor:ktor-bom", version.ref = "ktor" }
+    ktor-server-core                = { module = "io.ktor:ktor-server-core" }
+    ktor-server-netty               = { module = "io.ktor:ktor-server-netty" }
+    ktor-server-content-negotiation = { module = "io.ktor:ktor-server-content-negotiation" }
+    ktor-server-call-logging        = { module = "io.ktor:ktor-server-call-logging" }
+    ktor-server-status-pages        = { module = "io.ktor:ktor-server-status-pages" }
+    ktor-server-sse                 = { module = "io.ktor:ktor-server-sse" }
+    ktor-server-test-host           = { module = "io.ktor:ktor-server-test-host" }
+    ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json" }
+    ktor-client-core                = { module = "io.ktor:ktor-client-core" }
+    ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation" }
+    ```
+  - `kotlinx-serialization-json` alias and `kotlin-serialization` plugin alias already exist — reuse, do not redeclare.
+- **note**: Versions resolve via `ktor-bom`; no version.ref needed for individual libraries.
+
+### T2 — Register module in `settings.gradle.kts`
+- **complexity**: low
+- **file**: `settings.gradle.kts`
+- **change**: Add at the correct alphabetical position:
+  ```kotlin
+  includeModules("ktor", false, true)
+  ```
+- **verify**: `./gradlew projects | grep ktor-rest-coroutines`
+
+### T3 — Module `build.gradle.kts`
+- **complexity**: medium
+- **file**: `ktor/rest-coroutines/build.gradle.kts`
+- **content**:
+  ```kotlin
+  plugins {
+      alias(libs.plugins.kotlin.serialization)
+  }
+
+  configurations {
+      testImplementation.get().extendsFrom(compileOnly.get(), runtimeOnly.get())
+  }
+
+  dependencies {
+      implementation(platform(libs.ktor.bom))
+
+      implementation(libs.ktor.server.core)
+      implementation(libs.ktor.server.netty)
+      implementation(libs.ktor.server.content.negotiation)
+      implementation(libs.ktor.server.call.logging)
+      implementation(libs.ktor.server.status.pages)
+      implementation(libs.ktor.server.sse)
+      implementation(libs.ktor.serialization.kotlinx.json)
+      implementation(libs.kotlinx.serialization.json)
+
+      implementation(Libs.bluetape4k_core)
+      implementation(Libs.bluetape4k_logging)
+      implementation(Libs.bluetape4k_coroutines)
+      implementation(Libs.bluetape4k_jackson3)
+
+      testImplementation(Libs.bluetape4k_junit5)
+      testImplementation(Libs.bluetape4k_assertions)
+      testImplementation(libs.kotlinx.coroutines.test.lib)
+      testImplementation(libs.ktor.server.test.host)
+      testImplementation(libs.ktor.client.core)
+      testImplementation(libs.ktor.client.content.negotiation)
+  }
+  ```
+- **MUST NOT include**: `ktor-serialization-jackson`, any `com.fasterxml.jackson.*`, `springBoot { }` block.
+- **verify**: `./gradlew :ktor-rest-coroutines:dependencies` resolves Ktor 3.4.3 BOM.
+
+---
+
+## Phase 2 — Domain Layer
+
+### T4 — `domain/Book.kt`
+- **complexity**: low
+- **file**: `ktor/rest-coroutines/src/main/kotlin/io/bluetape4k/workshop/ktor/domain/Book.kt`
+- **content**:
+  ```kotlin
+  package io.bluetape4k.workshop.ktor.domain
+
+  import kotlinx.serialization.Serializable
+
+  /**
+   * Represents a book in the catalog.
+   *
+   * ## Behavior / Contract
+   * - `@Serializable` (kotlinx) enables JSON serialization via ContentNegotiation and SSE encoding.
+   * - Implements `java.io.Serializable` (workspace convention) independently of kotlinx serialization.
+   * - Pure value object; no DB annotations.
+   */
+  @Serializable
+  data class Book(
+      val id: String,
+      val title: String,
+      val author: String,
+      val year: Int,
+  ) : java.io.Serializable {
+      companion object {
+          private const val serialVersionUID: Long = 1L
+      }
+  }
+  ```
+
+### T5 — `domain/DomainError.kt`
+- **complexity**: low
+- **file**: `ktor/rest-coroutines/src/main/kotlin/io/bluetape4k/workshop/ktor/domain/DomainError.kt`
+- **content**:
+  ```kotlin
+  package io.bluetape4k.workshop.ktor.domain
+
+  /**
+   * Domain-specific exception hierarchy.
+   * StatusPages in ApplicationModule maps each subclass to an HTTP status code:
+   * - [NotFound] → 404
+   * - [Conflict] → 409
+   */
+  sealed class DomainError(message: String) : RuntimeException(message) {
+      /** Thrown when a book with the given id does not exist. Maps to HTTP 404. */
+      class NotFound(id: String) : DomainError("Book not found: id=$id")
+      /** Thrown when a book with the same id already exists. Maps to HTTP 409. */
+      class Conflict(message: String) : DomainError(message)
+  }
+  ```
+
+---
+
+## Phase 3 — Repository Layer
+
+### T6 — `repository/BookRepository.kt`
+- **complexity**: medium
+- **file**: `ktor/rest-coroutines/src/main/kotlin/io/bluetape4k/workshop/ktor/repository/BookRepository.kt`
+- **content**: Exactly the interface from spec §5.5 with KDoc. Critical points:
+  - `stream()` KDoc: **"hot [MutableSharedFlow]"** (NOT "cold") — live-only delivery, no replay.
+  - `save()` KDoc: emits to stream after persistence; throws `DomainError.Conflict` on duplicate.
+
+### T7 — `repository/InMemoryBookRepository.kt`
+- **complexity**: high
+- **file**: `ktor/rest-coroutines/src/main/kotlin/io/bluetape4k/workshop/ktor/repository/InMemoryBookRepository.kt`
+- **key implementation requirements**:
+  - `MutableSharedFlow<Book>(extraBufferCapacity = 64, onBufferOverflow = BufferOverflow.SUSPEND)`
+  - `save()` must use `withTimeoutOrNull(5_000)` around `sharedFlow.emit(book)`:
+    ```kotlin
+    val emitted = withTimeoutOrNull(5_000L) { sharedFlow.emit(book) } != null
+    if (!emitted) {
+        log.warn { "SSE emit timed out for book ${book.id}; book saved, event dropped" }
+    }
+    ```
+  - Book is written to `ConcurrentHashMap` BEFORE the emit attempt; durability is independent of SSE.
+  - `stream()` returns `sharedFlow.asSharedFlow()`.
+  - `companion object : KLoggingChannel()`.
+  - No `@Synchronized`, no blocking I/O.
+
+---
+
+## Phase 4 — Service Layer
+
+### T8 — `service/BookService.kt`
+- **complexity**: medium
+- **file**: `ktor/rest-coroutines/src/main/kotlin/io/bluetape4k/workshop/ktor/service/BookService.kt`
+- **validation constants** (in companion):
+  ```kotlin
+  const val MAX_ID_LENGTH = 128
+  const val MAX_TITLE_LENGTH = 500
+  const val MAX_AUTHOR_LENGTH = 200
+  val YEAR_RANGE = 1..3000
+  ```
+- `create(book: Book)` validates BEFORE calling `repository.save(book)`. Use bluetape4k `requireNotBlank` extensions.
+- `stream()` is non-suspend: `fun stream(): Flow<Book> = repository.stream()`.
+
+---
+
+## Phase 5 — Application Wiring
+
+### T9 — `ApplicationModule.kt`
+- **complexity**: high
+- **file**: `ktor/rest-coroutines/src/main/kotlin/io/bluetape4k/workshop/ktor/ApplicationModule.kt`
+- **CRITICAL requirements**:
+  1. `internal val AppJson = Json { ignoreUnknownKeys = true; prettyPrint = false }` — **`internal`**, NOT `private`. `BookRoutes.kt` imports via `import io.bluetape4k.workshop.ktor.AppJson`.
+  2. Function signature: `fun Application.module(repository: BookRepository = InMemoryBookRepository(), jackson3: Jackson3Support = Jackson3Support())`.
+  3. StatusPages handler order (specific first, `Throwable` last):
+     - `exception<DomainError.NotFound>` → 404 + `{"error":"...","type":"NotFound"}`
+     - `exception<DomainError.Conflict>` → 409 + `{"error":"...","type":"Conflict"}`
+     - `exception<IllegalArgumentException>` → 400 + `{"error":"...","type":"BadRequest"}`
+     - `exception<BadRequestException>` → 400 + `{"error":"...","type":"BadRequest"}`
+     - **`exception<Throwable>` catch-all** → 500 + `{"error":"Internal server error","type":"Internal"}` (MUST include `"type":"Internal"` — Round 2 N2 fix)
+  4. `ContentNegotiation { json(AppJson) }` — same `AppJson` instance.
+  5. Plugin install order: `CallLogging` → `ContentNegotiation` → `SSE` → `StatusPages`.
+
+---
+
+## Phase 6 — Routes
+
+### T10 — `routes/HealthRoutes.kt`
+- **complexity**: low
+- **file**: `ktor/rest-coroutines/src/main/kotlin/io/bluetape4k/workshop/ktor/routes/HealthRoutes.kt`
+- `fun Route.healthRoutes() { get("/health") { call.respondText("OK") } }`
+
+### T11 — `routes/BookRoutes.kt`
+- **complexity**: high
+- **file**: `ktor/rest-coroutines/src/main/kotlin/io/bluetape4k/workshop/ktor/routes/BookRoutes.kt`
+- **CRITICAL requirements**:
+  1. **`sse("/books/stream") { ... }` with explicit path** — NEVER bare `sse { }` (Round 2 N1 fix).
+  2. `import io.bluetape4k.workshop.ktor.AppJson` — shared instance for SSE encoding.
+  3. `CancellationException` MUST be rethrown before `catch (e: Exception)` in the SSE collect block.
+  4. `GET /books/export` uses `call.respondBytesWriter(contentType = ContentType("application", "x-ndjson")) { jackson3.writeNdjson(this, books) }`.
+  5. Logger via `private object BookRoutesLog : KLoggingChannel()` (extension functions cannot have companion objects).
+- Route structure:
+  ```kotlin
+  route("/books") {
+      get { call.respond(service.list()) }
+      get("/{id}") { ... }
+      post { ... respond(HttpStatusCode.Created, created) ... }
+      get("/export") { ... }
+  }
+  sse("/books/stream") {
+      service.stream().collect { book ->
+          try {
+              send(ServerSentEvent(data = AppJson.encodeToString(book)))
+          } catch (e: CancellationException) { throw e }
+          catch (e: Exception) { log.warn(e) { "SSE send failed for book ${book.id}" } }
+      }
+  }
+  ```
+
+### T12 — `json/Jackson3Support.kt`
+- **complexity**: medium
+- **file**: `ktor/rest-coroutines/src/main/kotlin/io/bluetape4k/workshop/ktor/json/Jackson3Support.kt`
+- **CRITICAL**: `ByteWriteChannel.writeStringUtf8` is already non-blocking suspend. **NO `withContext(Dispatchers.IO)`** wrapper.
+- All imports must be `tools.jackson.*` (Jackson 3) only.
+
+---
+
+## Phase 7 — Entry Point and Logging
+
+### T13 — `Main.kt`
+- **complexity**: low
+- **file**: `ktor/rest-coroutines/src/main/kotlin/io/bluetape4k/workshop/ktor/Main.kt`
+- `fun main() { embeddedServer(Netty, port = 8080, host = "0.0.0.0") { module() }.start(wait = true) }`
+
+### T14 — `src/main/resources/logback.xml`
+- **complexity**: low
+- Minimal: Console appender, root INFO, `io.bluetape4k.workshop` at DEBUG, `io.ktor` at INFO.
+- NOT Spring Boot style (no `defaults.xml` include).
+
+---
+
+## Phase 8 — Test Resources
+
+### T15 — Test resources
+- **complexity**: low
+- **files**:
+  - `ktor/rest-coroutines/src/test/resources/junit-platform.properties` — copy from workshop templates.
+  - `ktor/rest-coroutines/src/test/resources/logback-test.xml` — copy from workshop templates; adapt if Spring Boot classpath unavailable.
+
+---
+
+## Phase 9 — Tests
+
+### T16 — `AbstractKtorTest.kt`
+- **complexity**: medium
+- **file**: `ktor/rest-coroutines/src/test/kotlin/io/bluetape4k/workshop/ktor/AbstractKtorTest.kt`
+- `abstract class AbstractKtorTest { companion object : KLoggingChannel() }`
+- Shared Book fixture builders.
+
+### T17 — `routes/HealthRoutesTest.kt`
+- **complexity**: low
+- Pattern: `@Test fun foo() = testApplication { application { module() }; ... }` — NOT `runSuspendTest`.
+- Assertions: bluetape4k-assertions only.
+
+### T18 — `routes/BookRoutesTest.kt`
+- **complexity**: high
+- **8 test cases**:
+  - `GET /books` → 200 + list
+  - `GET /books/{id}` (exists) → 200 + book
+  - `GET /books/{id}` (missing) → 404 + `{"type":"NotFound"}`
+  - `POST /books` (valid) → 201 + book
+  - `POST /books` (duplicate) → 409 + `{"type":"Conflict"}`
+  - `POST /books` (blank title) → 400 + `{"type":"BadRequest"}`
+  - `POST /books` (year out of range) → 400
+  - `GET /books/export` → 200 + `application/x-ndjson` + one JSON object per line
+- Each test is `@Test fun foo() = testApplication { val repository = InMemoryBookRepository(); application { module(repository = repository) }; ... }`.
+- Pre-seed with `kotlinx.coroutines.runBlocking { repository.save(...) }`.
+
+### T19 — `routes/BookStreamTest.kt`
+- **complexity**: high
+- **MANDATORY pattern** (Round 4 R4-H1 — CRITICAL implementation constraint):
+  ```kotlin
+  @Test
+  fun `SSE stream emits event after POST`() = testApplication {
+      val preseeded = InMemoryBookRepository()
+      application { module(repository = preseeded) }
+
+      val sseClient = createClient { install(SSE) }
+      val events = Channel<String>(Channel.BUFFERED)
+
+      // testApplication receiver = ApplicationTestBuilder (not CoroutineScope/TestScope).
+      // Neither bare launch{} nor backgroundScope.launch{} compiles here.
+      val subscriptionScope = CoroutineScope(coroutineContext + SupervisorJob())
+      val subscription = subscriptionScope.launch {
+          sseClient.sse("/books/stream") {
+              incoming.collect { event -> event.data?.let { events.send(it) } }
+          }
+      }
+
+      delay(100)  // allow subscription to register on hot SharedFlow
+
+      val response = client.post("/books") {
+          contentType(ContentType.Application.Json)
+          setBody("""{"id":"test-1","title":"T","author":"A","year":2024}""")
+      }
+      response.status shouldBeEqualTo HttpStatusCode.Created
+
+      val received = withTimeoutOrNull(5_000) { events.receive() }
+      received.shouldNotBeNull()
+      received shouldContain "test-1"
+
+      subscription.cancel()
+      subscriptionScope.cancel()
+      events.close()
+  }
+  ```
+- **NOT wrapped in `runSuspendTest`**.
+
+### T20 — `repository/InMemoryBookRepositoryTest.kt`
+- **complexity**: medium
+- Pattern: `@Test fun foo() = runSuspendTest { ... }` — pure suspend unit tests, NOT inside `testApplication`.
+- Cover: save+findById, duplicate conflict, stream emission.
+- `assertFailsWith<DomainError.Conflict> { ... }` for exception checks.
+
+### T20b — `service/BookServiceTest.kt` (optional)
+- **complexity**: medium
+- Validation matrix via `runSuspendTest` + `FakeBookRepository`.
+
+---
+
+## Phase 10 — Documentation
+
+### T21 — `README.md`
+- **complexity**: medium
+- **sections**: Architecture, features, curl examples for all 6 endpoints, config, deps, Jackson 3 stance, run instructions, production gaps (link to spec §12), follow-up `bluetape4k-ktor` gap.
+
+### T22 — `README.ko.md`
+- **complexity**: low
+- Korean translation of T21.
+
+---
+
+## Phase 11 — Verification
+
+### T23 — Settings + catalog smoke check
+- **complexity**: low
+- `./gradlew projects | grep ktor-rest-coroutines`
+- `rg "com.fasterxml.jackson" ktor/rest-coroutines/src` → zero matches
+- `rg "io.ktor.serialization.jackson" ktor/rest-coroutines/src` → zero matches
+
+### T24 — Build, test, detekt
+- **complexity**: low
+- All of spec §13.6:
+  ```bash
+  ./gradlew :ktor-rest-coroutines:compileKotlin
+  ./gradlew :ktor-rest-coroutines:test
+  ./gradlew :ktor-rest-coroutines:build
+  ./gradlew detekt
+  ```
+- All exit 0; test reports > 0 tests with 0 failures.
+
+---
+
+## Task Summary
+
+| ID | Task | Complexity |
+|---|---|---|
+| T1 | libs.versions.toml — Ktor entries | low |
+| T2 | settings.gradle.kts — includeModules | low |
+| T3 | build.gradle.kts | medium |
+| T4 | domain/Book.kt | low |
+| T5 | domain/DomainError.kt | low |
+| T6 | repository/BookRepository.kt (interface) | medium |
+| T7 | repository/InMemoryBookRepository.kt (SharedFlow + 5s emit timeout) | **high** |
+| T8 | service/BookService.kt | medium |
+| T9 | ApplicationModule.kt (internal AppJson, StatusPages) | **high** |
+| T10 | routes/HealthRoutes.kt | low |
+| T11 | routes/BookRoutes.kt (sse path, CancellationException) | **high** |
+| T12 | json/Jackson3Support.kt | medium |
+| T13 | Main.kt | low |
+| T14 | logback.xml | low |
+| T15 | test resources | low |
+| T16 | AbstractKtorTest.kt | medium |
+| T17 | HealthRoutesTest.kt | low |
+| T18 | BookRoutesTest.kt (8 cases) | **high** |
+| T19 | BookStreamTest.kt (SSE + CoroutineScope pattern) | **high** |
+| T20 | InMemoryBookRepositoryTest.kt | medium |
+| T20b | BookServiceTest.kt (optional) | medium |
+| T21 | README.md | medium |
+| T22 | README.ko.md | low |
+| T23 | Smoke checks | low |
+| T24 | Build/test/detekt | low |
+
+**High complexity tasks**: T7, T9, T11, T18, T19 — implement these with maximum care; refer to spec critical notes.
+
+---
+
+## Critical Implementation Reminders
+
+Before coding each high-complexity file, re-read these constraints:
+
+1. **`sse("/books/stream")` — NEVER `sse { }`** (Round 2 N1).
+2. **`internal val AppJson`** in ApplicationModule (Round 2 UX-1); `BookRoutes.kt` imports it.
+3. **`withTimeoutOrNull(5_000)` around `sharedFlow.emit(book)`** in InMemoryBookRepository.save() (Round 2 S1+OPS-2).
+4. **`CoroutineScope(coroutineContext + SupervisorJob()).launch {}`** in BookStreamTest (Round 4 R4-H1); not `backgroundScope.launch {}`, not bare `launch {}`.
+5. **Catch-all `exception<Throwable>` must include `"type" to "Internal"`** (Round 2 N2).
+6. **Route/integration tests: `= testApplication { }` directly — NOT wrapped in `runSuspendTest`** (AD-8).
+7. **Pure tests: `= runSuspendTest { }` — NOT inside `testApplication`** (AD-8).
+8. **No `com.fasterxml.jackson.*` imports anywhere** (spec AC §13.2).
+9. **`CancellationException` rethrown** before broad catch in SSE collect block (spec §5.9).
+10. **No `withContext(Dispatchers.IO)` around `ByteWriteChannel.writeStringUtf8`** (spec §5.10).
+11. **No `runBlocking` in `src/main`; no `@Synchronized`** (workspace policy).
+12. **`Book` implements `@Serializable` AND `java.io.Serializable` with `serialVersionUID`** (AD-9).
+13. **`BufferOverflow.SUSPEND`** on MutableSharedFlow (NOT `DROP_OLDEST`).
+14. **Assertions: bluetape4k-assertions only** — no `assertEquals`, no `assertThrows`.
+15. **`KLoggingChannel` for every logger** — extension functions use a file-private holder object.

--- a/docs/superpowers/specs/2026-05-25-ktor-rest-coroutines-design.md
+++ b/docs/superpowers/specs/2026-05-25-ktor-rest-coroutines-design.md
@@ -1,0 +1,786 @@
+# Ktor REST Coroutines Workshop Module — Design Spec
+
+- **Date:** 2026-05-25
+- **Module path:** `bluetape4k-workshop/ktor/rest-coroutines`
+- **Status:** Approved — Ready for Implementation Plan (Step 2-R CONVERGENCE ✅)
+- **Author:** bluetape4k-workshop contributors
+- **Audience:** Engineers implementing the workshop module + Bluetape4k library maintainers (gap input)
+
+---
+
+## 1. Summary / Goal
+
+Add a greenfield workshop module that demonstrates a **Ktor 3.4.3 REST server** built with Kotlin coroutines, using Bluetape4k libraries as the default toolkit. The module is a small **Book Catalog** service with an in-memory repository, JSON content negotiation via `kotlinx-serialization`, an SSE streaming endpoint, and an NDJSON export endpoint backed by **bluetape4k-jackson3**.
+
+Concrete goals:
+
+- Show the canonical Ktor + coroutines REST shape in this workspace.
+- Use Bluetape4k APIs in the main happy path: `KLoggingChannel`, `runSuspendTest`, `bluetape4k-assertions`, `bluetape4k-jackson3`.
+- Validate that Bluetape4k Jackson 3 and Ktor `kotlinx-serialization` can co-exist in one module without collision.
+- Surface a concrete capability gap: there is **no `bluetape4k-ktor`** integration library today.
+
+Non-goals:
+
+- No database / Exposed / R2DBC integration. Repository is in-memory.
+- No security (auth, CORS hardening) — workshop scope only.
+- No Koin / Spring DI — explicit constructor wiring.
+- No Jackson 2 anywhere. The module is Jackson-3-only on top of `kotlinx-serialization` for HTTP payloads.
+
+---
+
+## 2. Design Risks
+
+| # | Risk | Likelihood | Impact | Mitigation |
+|---|------|------------|--------|------------|
+| R1 | **Jackson version split**: `io.ktor:ktor-serialization-jackson` is Jackson 2 (`com.fasterxml.jackson.*`), but `bluetape4k-jackson3` is Jackson 3 (`tools.jackson.*`). Mixing them on the classpath risks confusion and accidental double-binding of `ObjectMapper`. | High | Medium | **Do not depend on `ktor-serialization-jackson`.** Use `kotlinx-serialization-json` for ContentNegotiation. Use `bluetape4k-jackson3` only in the dedicated `/books/export` NDJSON path, behind a thin `Jackson3Support` helper. |
+| R2 | **SSE on Netty engine**: Ktor SSE plugin is engine-aware; misuse (e.g., synchronous blocking inside `send {}`) breaks streaming and starves Netty event loops. | Medium | High | Restrict SSE producers to `suspend` calls; emit through a `Flow<Book>` and `collect { send(...) }`. Document this in the route file. Add a smoke test that consumes the stream via `ktor-client`. |
+| R3 | **No `bluetape4k-ktor` module exists**: each workshop module reinvents wiring. Drift between modules is likely (logging, error mapping, JSON config). | High | Medium | Keep the workshop module's wiring minimal and idiomatic so it can later become the seed for a `bluetape4k-ktor` library. Record the gap in §9 and link from the workshop README. |
+| R4 | **Kotlin serialization vs `data class` Serializable contract**: bluetape4k convention requires `data class` to implement `java.io.Serializable` with `serialVersionUID`. `@Serializable` from kotlinx is unrelated and must not be confused. | Medium | Low | Domain `Book` implements both `@Serializable` (kotlinx) and `java.io.Serializable` with explicit `serialVersionUID`. Documented in `domain/Book.kt`. |
+| R5 | **Status mapping leakage**: throwing domain exceptions from routes without `StatusPages` produces 500s and leaks stack traces. | Medium | Medium | Install `StatusPages` in `ApplicationModule` and map `DomainError.NotFound` -> 404, `DomainError.Conflict` -> 409, `IllegalArgumentException` -> 400. |
+| R6 | **Test flakiness from `embeddedServer`**: spinning up Netty on a random port in unit tests adds I/O and timing risk. | Low | Medium | Use `testApplication { }` from `ktor-server-test-host` (in-memory) for all tests. No real Netty server in tests. |
+
+---
+
+## 3. Approach Comparison — JSON Serialization Strategy
+
+Three credible options were considered for HTTP body serialization in Ktor.
+
+### Option A — `kotlinx-serialization-json` (CHOSEN)
+
+- **Pros:** Native to Kotlin. Compile-time-checked schema via `@Serializable`. No reflection. Already in this workspace's `libs.versions.toml`. Cleanly avoids the Jackson 2 vs Jackson 3 split. Multiplatform-friendly. Plays well with Ktor 3.4.3 `ContentNegotiation`.
+- **Cons:** Annotation processor / KSP plugin must be applied. Requires per-module `kotlin.serialization` plugin. Slightly different conventions from Jackson (e.g., default values, polymorphism).
+- **Fit:** Best for a workshop showing modern Kotlin + Ktor. Avoids R1 entirely.
+
+### Option B — Hand-rolled `ContentConverter` over `bluetape4k-jackson3`
+
+- **Pros:** Re-uses Bluetape4k's preferred `ObjectMapper`. Single JSON engine across the codebase. Demonstrates the extensibility of Ktor's content negotiation.
+- **Cons:** Non-trivial: must implement `ContentConverter.serializeNullable` / `deserialize` against Ktor 3's API, handle charsets, streaming, and `TypeInfo`. Easy to get edge cases wrong. Adds maintenance debt that should actually live in a future `bluetape4k-ktor` library.
+- **Fit:** Right idea, wrong layer. Belongs in `bluetape4k-ktor`, not a workshop module.
+
+### Option C — `ktor-serialization-jackson` (Jackson 2)
+
+- **Pros:** Officially supported. Familiar Jackson DSL.
+- **Cons:** Drags **Jackson 2** (`com.fasterxml.jackson.*`) onto the classpath next to Bluetape4k's **Jackson 3** (`tools.jackson.*`). Two incompatible Jackson families coexisting is a classpath smell and violates the project's Jackson-3-only direction. Future `bluetape4k-jackson3` modules cannot rely on this pattern.
+- **Fit:** Rejected. Directly conflicts with the workspace's Jackson 3 stance.
+
+**Decision: Option A.** Option B is recorded as future work for `bluetape4k-ktor` (§9). Option C is explicitly forbidden in this module.
+
+---
+
+## 4. Architecture Decisions (Locked In)
+
+| ID | Decision | Rationale |
+|----|----------|-----------|
+| AD-1 | **Engine = Netty** via `embeddedServer(Netty, ...)`. | Default Ktor engine; aligns with most production deployments and is well-documented for SSE. |
+| AD-2 | **ContentNegotiation = `kotlinx-serialization-json`**. | See §3 Option A. Avoids Jackson 2/3 split. |
+| AD-3 | **Jackson 3 is scoped to one place**: `/books/export` NDJSON via `bluetape4k-jackson3` `ObjectMapper`. | Demonstrates Bluetape4k Jackson 3 without leaking it into ContentNegotiation. |
+| AD-4 | **DI = explicit constructor wiring** inside `fun Application.module()`. | No Koin / Spring. Keeps the workshop scope narrow and the code path inspectable. |
+| AD-5 | **In-memory `BookRepository`** behind an interface. | DB integration is out of scope; the interface keeps the door open for future R2DBC/Exposed swap-in. |
+| AD-6 | **`KLoggingChannel` in every `companion object`** of service, repository, route, and test base classes. | Workspace standard for coroutine-friendly logging. |
+| AD-7 | **`StatusPages`** maps `DomainError` to HTTP status codes AND has a catch-all `exception<Throwable>` handler. | Without the catch-all, unmapped exceptions (Ktor's own `BadRequestException`, deserialization failures, uncaught `NullPointerException`) reach Ktor's default 500 handler which may include stack traces. Order: specific subclasses first, `Throwable` last. |
+| AD-8 | **Route tests use `@Test fun foo() = testApplication { application { module(...) } }`. Pure service/repo unit tests use `runSuspendTest { }`** from `bluetape4k-junit5`. | `testApplication` returns `TestResult` and is NOT a suspend function — wrapping it inside `runSuspendTest { }` is a type error. The two harnesses serve different scopes: `testApplication` for HTTP integration; `runSuspendTest` for pure coroutine logic without the Ktor stack. |
+| AD-9 | **Domain types are `data class` and implement `java.io.Serializable`** with `serialVersionUID`. | Workspace `CLAUDE.md` mandates Serializable for all `data class`. |
+| AD-10 | **No `runBlocking` in production code.** Suspend functions all the way through routes. | Workspace coroutine policy. |
+
+---
+
+## 5. Component Design
+
+Package root: `io.bluetape4k.workshop.ktor`
+
+### 5.1 `Main.kt`
+
+- **Responsibility:** Process entry point.
+- **Shape:** `fun main()` calls `embeddedServer(Netty, port = 8080, host = "0.0.0.0") { module() }.start(wait = true)`.
+- **Notes:** No business logic. `module()` is testable independently.
+
+### 5.2 `ApplicationModule.kt`
+
+- **Responsibility:** Ktor `Application.module()` extension. **Must accept injectable collaborators** so tests can inject pre-seeded repositories without going through the public API.
+- **Signature:** `fun Application.module(repository: BookRepository = InMemoryBookRepository(), jackson3: Jackson3Support = Jackson3Support())`. `Main.kt` calls with defaults; tests pass explicit instances.
+- **Shared Json instance:** Define at file top — `internal val AppJson = Json { ignoreUnknownKeys = true; prettyPrint = false }`. Mark `internal` (not `private`) so `BookRoutes.kt` can import it with `import io.bluetape4k.workshop.ktor.AppJson`. Reference `AppJson` in both `install(ContentNegotiation) { json(AppJson) }` and the SSE encoding block.
+- **Wiring order:**
+  1. Install `CallLogging` (status + method + URI; uses `KLoggingChannel`-compatible SLF4J).
+  2. Install `ContentNegotiation` with `json(AppJson)`.
+  3. Install `SSE`.
+  4. Install `StatusPages`:
+     - `exception<BadRequestException> { call, e -> call.respond(400, mapOf("error" to (e.message ?: "Bad request"))) }`
+     - `exception<DomainError.NotFound> { call, e -> call.respond(404, mapOf("error" to e.message, "type" to "NotFound")) }`
+     - `exception<DomainError.Conflict> { call, e -> call.respond(409, mapOf("error" to e.message, "type" to "Conflict")) }`
+     - `exception<IllegalArgumentException> { call, e -> call.respond(400, mapOf("error" to (e.message ?: "Bad request"), "type" to "BadRequest")) }`
+     - **Catch-all (required):** `exception<Throwable> { call, e -> log.error(e) { "Unhandled exception" }; call.respond(500, mapOf("error" to "Internal server error", "type" to "Internal")) }`
+  5. Construct `service = BookService(repository)`.
+  6. Register routes: `routing { healthRoutes(); bookRoutes(service, jackson3) }`.
+- **Companion object:** `KLoggingChannel` logger for module-level bootstrap messages.
+
+### 5.3 `domain/Book.kt`
+
+- `@Serializable data class Book(val id: String, val title: String, val author: String, val year: Int) : java.io.Serializable`
+  - `companion object { private const val serialVersionUID: Long = 1L }`
+- Pure value object. No DB annotations.
+
+### 5.4 `domain/DomainError.kt`
+
+- `sealed class DomainError(message: String) : RuntimeException(message)`
+  - `class NotFound(id: String) : DomainError("Book not found: id=$id")`
+  - `class Conflict(message: String) : DomainError(message)`
+- `StatusPages` maps each subclass to a specific status.
+
+### 5.5 `repository/BookRepository.kt`
+
+```kotlin
+interface BookRepository {
+    /**
+     * Returns all books currently in the catalog.
+     *
+     * ## Behavior / Contract
+     * - Returns an empty list when no books exist.
+     * - Does not include books created after this call starts.
+     */
+    suspend fun findAll(): List<Book>
+
+    /**
+     * Returns a book by id, or null if not found.
+     */
+    suspend fun findById(id: String): Book?
+
+    /**
+     * Persists a new book and makes it available for subsequent reads and streams.
+     *
+     * ## Behavior / Contract
+     * - If a book with the same id already exists, throws [DomainError.Conflict].
+     * - Subsequent [findAll] and [findById] calls will include this book.
+     * - Emits to [stream] consumers immediately after persistence.
+     *
+     * @throws DomainError.Conflict if id already exists
+     * @throws IllegalArgumentException if any field fails validation (see [BookService.create])
+     */
+    suspend fun save(book: Book): Book
+
+    /**
+     * Returns a [Flow] backed by a hot [MutableSharedFlow] for SSE live streaming.
+     *
+     * ## Behavior / Contract
+     * - **Hot source:** events are emitted by the shared flow whether or not any collector is active.
+     *   Only books saved *after* a collector subscribes are delivered to that collector.
+     * - **Must not emit via blocking calls.** Emissions occur on the SSE route's coroutine context
+     *   (Netty event-loop or virtual thread). Any blocking I/O inside the flow will starve the engine.
+     * - Callers that need blocking I/O inside a collector must wrap in `withContext(Dispatchers.IO)`.
+     * - The Flow is live-only: only books saved *after* collection starts are emitted.
+     * - Each new `collect` receives its own independent subscription from the shared source.
+     */
+    fun stream(): Flow<Book>
+}
+```
+
+### 5.6 `repository/InMemoryBookRepository.kt`
+
+- Backing store: `ConcurrentHashMap<String, Book>`.
+- Stream source: `MutableSharedFlow<Book>(extraBufferCapacity = 64, onBufferOverflow = BufferOverflow.SUSPEND)`.
+  - **Rationale:** `SUSPEND` back-pressures the producer (POST handler) when consumers are slow, guaranteeing delivery. `DROP_OLDEST` would silently drop events.
+  - **Stall mitigation (required):** A slow or stalled SSE subscriber will eventually suspend `sharedFlow.emit()` inside `save()`, blocking the POST handler coroutine. Bound the wait with a timeout in `InMemoryBookRepository.save`:
+    ```kotlin
+    val emitted = withTimeoutOrNull(5_000) { sharedFlow.emit(book) } != null
+    if (!emitted) log.warn { "SSE emit timed out for book ${book.id}; book saved, event dropped" }
+    ```
+    This preserves the durability guarantee (book is written to the map regardless) while bounding POST latency. Choose a timeout appropriate for your test environment (5 s is safe for in-memory tests; adjust in production).
+- `save` emits to the shared flow after writing to the map.
+- All methods are `suspend` even if cheap, so callers cannot mistake the boundary.
+- `companion object : KLoggingChannel()`.
+
+### 5.7 `service/BookService.kt`
+
+- Coordinates validation + repository calls.
+- **Field validation constants** (define as `companion object` constants):
+  - `MAX_ID_LENGTH = 128`
+  - `MAX_TITLE_LENGTH = 500`
+  - `MAX_AUTHOR_LENGTH = 200`
+  - `YEAR_RANGE = 1..3000`
+- Validation uses Bluetape4k `requireXxx()` extensions on input parameters:
+  - `book.id.requireNotBlank("id")`, `requireMaxLength(book.id, MAX_ID_LENGTH, "id")`
+  - `book.title.requireNotBlank("title")`, `requireMaxLength(book.title, MAX_TITLE_LENGTH, "title")`
+  - `book.author.requireNotBlank("author")`, `requireMaxLength(book.author, MAX_AUTHOR_LENGTH, "author")`
+  - `book.year in YEAR_RANGE` or equivalent
+- Translates duplicate-id condition to `DomainError.Conflict`.
+- `companion object : KLoggingChannel()`.
+
+### 5.8 `routes/HealthRoutes.kt`
+
+- `fun Route.healthRoutes()`:
+  - `get("/health") { call.respondText("OK") }`.
+
+### 5.9 `routes/BookRoutes.kt`
+
+- `fun Route.bookRoutes(service: BookService, jackson3: Jackson3Support)`:
+  - `GET /books` -> `call.respond(service.list())`.
+  - `GET /books/{id}` -> `service.get(id) ?: throw DomainError.NotFound(id)`.
+  - `POST /books` -> receives `Book` via `call.receive<Book>()`, calls `service.create(...)`, responds 201 + body.
+  - `GET /books/stream` -> opens SSE via `sse("/books/stream") { service.stream().collect { book -> send(ServerSentEvent(data = AppJson.encodeToString(book))) } }`.
+    - **Path required:** Use `sse("/books/stream") { ... }`, NOT bare `sse { ... }`. The bare form mounts at the current `Route` scope (i.e., the application root `/`), which would shadow unmatched GET routes. Per Ktor 3 `Route.sse(path, handler)` vs `Route.sse(handler)` overloads.
+    - **`CancellationException` contract (mandatory):** Any error handling around `send(...)` must rethrow `CancellationException` before catching broad exceptions:
+      ```kotlin
+      try {
+          send(ServerSentEvent(data = AppJson.encodeToString(book)))
+      } catch (e: CancellationException) {
+          throw e  // client disconnected — let coroutine cancel normally
+      } catch (e: Exception) {
+          log.warn(e) { "SSE send failed for book ${book.id}" }
+      }
+      ```
+    - SSE JSON uses **`AppJson`** (imported from `ApplicationModule.kt` as `import io.bluetape4k.workshop.ktor.AppJson`), not the `Json` companion default. This ensures ContentNegotiation and SSE encoding share the same configuration.
+  - `GET /books/export` -> uses `call.respondBytesWriter(contentType = ContentType("application", "x-ndjson"))` to obtain a `ByteWriteChannel`, then calls `jackson3.writeNdjson(this, books)`.
+    ```kotlin
+    val books = service.list()
+    call.respondBytesWriter(contentType = ContentType("application", "x-ndjson")) {
+        jackson3.writeNdjson(this, books)
+    }
+    ```
+- `companion object : KLoggingChannel()`.
+
+### 5.10 `json/Jackson3Support.kt`
+
+- Thin wrapper around a Bluetape4k Jackson 3 `ObjectMapper`.
+- Exposes `suspend fun writeNdjson(out: ByteWriteChannel, books: Iterable<Book>)`.
+- **Dispatcher usage:** `ByteWriteChannel.writeStringUtf8` is a coroutine-native suspend function — it must NOT be wrapped in `withContext(Dispatchers.IO)`. Only the CPU-bound serialization step (`objectMapper.writeValueAsString(book)`) may use `withContext(Dispatchers.Default)` for large payloads. Correct pattern:
+  ```kotlin
+  suspend fun writeNdjson(out: ByteWriteChannel, books: Iterable<Book>) {
+      for (book in books) {
+          val json = objectMapper.writeValueAsString(book)  // CPU, fast in practice
+          out.writeStringUtf8(json + "\n")                  // suspend, non-blocking
+      }
+  }
+  ```
+- `companion object : KLoggingChannel()`.
+
+### 5.11 File map
+
+```
+ktor/rest-coroutines/
+├── build.gradle.kts
+├── src/main/kotlin/io/bluetape4k/workshop/ktor/
+│   ├── Main.kt
+│   ├── ApplicationModule.kt
+│   ├── domain/
+│   │   ├── Book.kt
+│   │   └── DomainError.kt
+│   ├── repository/
+│   │   ├── BookRepository.kt
+│   │   └── InMemoryBookRepository.kt
+│   ├── service/
+│   │   └── BookService.kt
+│   ├── routes/
+│   │   ├── HealthRoutes.kt
+│   │   └── BookRoutes.kt
+│   └── json/
+│       └── Jackson3Support.kt
+├── src/main/resources/
+│   └── logback.xml
+├── src/test/kotlin/io/bluetape4k/workshop/ktor/
+│   ├── AbstractKtorTest.kt
+│   ├── routes/BookRoutesTest.kt
+│   ├── routes/HealthRoutesTest.kt
+│   └── routes/BookStreamTest.kt
+└── src/test/resources/
+    ├── junit-platform.properties   # required: copy from templates/test/resources/
+    └── logback-test.xml            # required: copy from templates/test/resources/
+```
+
+---
+
+## 6. Data Flow
+
+### 6.1 Read flow (`GET /books/{id}`)
+
+```
+HTTP request
+  -> Ktor router (BookRoutes)
+  -> BookService.get(id)
+  -> BookRepository.findById(id)
+  -> ConcurrentHashMap lookup
+  -> null? -> throw DomainError.NotFound
+            -> StatusPages -> 404 + JSON error body
+  -> Book   -> ContentNegotiation (kotlinx-serialization) -> 200 + JSON
+```
+
+### 6.2 Write flow (`POST /books`)
+
+```
+HTTP request body (JSON)
+  -> ContentNegotiation deserializes to Book
+  -> BookRoutes
+  -> BookService.create(book)
+       require(book.title) etc.
+       repository.findById(book.id) != null -> DomainError.Conflict
+  -> InMemoryBookRepository.save
+       map[book.id] = book
+       sharedFlow.emit(book)        // feeds /books/stream
+  -> respond 201 Created + JSON body
+```
+
+### 6.3 SSE flow (`GET /books/stream`)
+
+```
+Client opens SSE connection
+  -> Ktor SSE plugin negotiates text/event-stream
+  -> BookRoutes opens sse("/books/stream") { } session
+  -> service.stream() returns repository.stream() : Flow<Book>
+  -> collect { book ->
+       try {
+         send(ServerSentEvent(data = AppJson.encodeToString(book)))
+       } catch (e: CancellationException) {
+         throw e  // client disconnected — propagates coroutine cancellation
+       } catch (e: Exception) {
+         log.warn(e) { "SSE send failed" }  // log, continue if transient
+       }
+     }
+  -> Connection stays open; new POSTs emit to sharedFlow (SUSPEND strategy) -> piped to client
+  -> Client disconnect cancels SSE coroutine -> CancellationException propagates -> Flow collector removed
+```
+
+### 6.4 NDJSON export flow (`GET /books/export`)
+
+```
+Client requests /books/export
+  -> BookRoutes calls service.list() (materializes current books)
+  -> call.respondBytesWriter(contentType = ContentType("application","x-ndjson")) { channel ->
+       Jackson3Support.writeNdjson(channel, books)
+         for (book in books) {
+           val json = objectMapper.writeValueAsString(book)   // CPU, in-place (no IO dispatch)
+           channel.writeStringUtf8(json + "\n")               // suspend write to response
+         }
+     }
+  -> Response body is a newline-delimited JSON stream, flushed per record
+```
+
+---
+
+## 7. API Contract
+
+All bodies are `application/json` unless noted. Errors are returned as `{"error": "<message>", "type": "<DomainError class simple name>"}`.
+
+### 7.1 `GET /health`
+
+- **200 OK**, `text/plain`, body `OK`.
+
+### 7.2 `GET /books`
+
+- **200 OK**, body:
+  ```json
+  [
+    {"id": "b-1", "title": "Kotlin in Action", "author": "Dmitry Jemerov", "year": 2017}
+  ]
+  ```
+
+### 7.3 `GET /books/{id}`
+
+- **200 OK** with `Book` body, or
+- **404 Not Found**, body `{"error": "Book not found: id=b-99", "type": "NotFound"}`.
+
+### 7.4 `POST /books`
+
+- Request body: `Book` JSON. `id` is required and must be unique.
+- **201 Created** with `Book` body, or
+- **400 Bad Request** for validation failure (`IllegalArgumentException` -> 400), or
+- **409 Conflict** when `id` already exists (`DomainError.Conflict` -> 409).
+
+**Field validation rules:**
+
+| Field | Type | Constraints |
+|-------|------|-------------|
+| `id` | String | non-blank, 1–128 characters |
+| `title` | String | non-blank, 1–500 characters |
+| `author` | String | non-blank, 1–200 characters |
+| `year` | Int | in range 1..3000 |
+
+All validation failures produce `{"error": "<message>", "type": "BadRequest"}` with 400 status.
+
+**Error response format (all endpoints):**
+
+```json
+{"error": "<human-readable message>", "type": "<error category>"}
+```
+
+| Exception | HTTP Status | `type` value |
+|-----------|-------------|-------------|
+| `DomainError.NotFound` | 404 | `"NotFound"` |
+| `DomainError.Conflict` | 409 | `"Conflict"` |
+| `IllegalArgumentException` | 400 | `"BadRequest"` |
+| Ktor `BadRequestException` (malformed body) | 400 | `"BadRequest"` |
+| Any other `Throwable` | 500 | `"Internal"` (no detail exposed) |
+
+Note: The `type` field exposes internal class names — acceptable for workshop scope; replace with opaque error codes in production.
+
+### 7.5 `GET /books/stream`
+
+- **200 OK**, `Content-Type: text/event-stream`.
+- Stream of events shaped as `data: {"id":"b-1","title":"...","author":"...","year":2017}\n\n`.
+- Connection remains open; new books posted via `POST /books` arrive as new events.
+
+### 7.6 `GET /books/export`
+
+- **200 OK**, `Content-Type: application/x-ndjson`.
+- Body is one JSON object per line, written via **bluetape4k-jackson3** `ObjectMapper`:
+  ```
+  {"id":"b-1","title":"Kotlin in Action","author":"Dmitry Jemerov","year":2017}
+  {"id":"b-2","title":"Programming Kotlin","author":"Venkat Subramaniam","year":2019}
+  ```
+
+---
+
+## 8. Used Bluetape4k Features (Bluetape4k-First Requirement Table)
+
+| Concern | Bluetape4k API used | Where applied | Notes |
+|---------|---------------------|---------------|-------|
+| Logging | `io.bluetape4k.logging.coroutines.KLoggingChannel` | `companion object` of `ApplicationModule`, `BookService`, `InMemoryBookRepository`, `BookRoutes`, `HealthRoutes`, `Jackson3Support`, `AbstractKtorTest` | Coroutine-aware logger; mandated by workspace standard. |
+| Input validation | `requireNotBlank`, `requireGreaterThan` (or equivalent) | `BookService.create` | Replaces hand-rolled `require(...)` blocks. |
+| Coroutine testing | `runSuspendTest { }` from `bluetape4k-junit5` | All suspend tests in `routes/*Test.kt` | Avoids `runBlocking` in tests. |
+| Assertions | `bluetape4k-assertions` (`shouldBeEqualTo`, `shouldNotBeNull`, `shouldContain`, etc.) | All test assertions | Workspace standard; no JUnit `assertEquals`. |
+| JSON (alt path) | `bluetape4k-jackson3` `ObjectMapper` | `Jackson3Support.writeNdjson` for `/books/export` | Demonstrates Jackson 3 usage without colliding with Ktor ContentNegotiation. |
+| Misc utilities | `bluetape4k-core` extensions (`String.requireNotBlank`, etc.) | Service / domain | Standard. |
+
+Forbidden in this module: Jackson 2 (`com.fasterxml.jackson.*`), `ktor-serialization-jackson`, Koin, Spring DI, `runBlocking` in production code, `@Synchronized`.
+
+---
+
+## 9. Missing Bluetape4k Capability (Gap)
+
+**Gap:** There is no `bluetape4k-ktor` library today.
+
+Concretely, the following helpers had to be inlined in the workshop module and would be better as a reusable library:
+
+1. A `ContentConverter` adapter over `bluetape4k-jackson3` `ObjectMapper`, so projects that prefer Jackson 3 can plug it into Ktor `ContentNegotiation` directly. (See §3 Option B — rejected at the workshop level, but valid at the library level.)
+2. NDJSON streaming helpers (`Route.respondNdjson(Iterable<T>)`) parameterized over the `ObjectMapper`.
+3. A canonical `StatusPages` mapper for Bluetape4k domain exceptions (e.g., a base `DomainError` sealed class shared across services).
+4. A `KLoggingChannel`-backed `CallLogging` formatter to keep Ktor and Bluetape4k log channels consistent.
+5. SSE convenience: `Route.sseFlow(flow: Flow<T>, encode: (T) -> String)` to remove route-level boilerplate.
+
+**Recommended follow-up:** Create `bluetape4k-projects/bluetape4k-ktor` analogous in scope to `bluetape4k-vertx`. This workshop module is intentionally written so its `json/Jackson3Support.kt` and `ApplicationModule.kt` can serve as the seed implementation.
+
+Tracking: file an issue under `bluetape4k-projects` referencing this spec.
+
+---
+
+## 10. Gradle / Build Integration
+
+### 10.0 Dependency declaration policy
+
+**Workshop CLAUDE.md** states: "버전 관리: `buildSrc/src/main/kotlin/Libs.kt` — 새 의존성은 여기 먼저 정의."
+
+This module adds new coordinates (Ktor) to `libs.versions.toml` directly for the following reason: the workshop is migrating toward the Gradle Version Catalog (`libs.versions.toml`) as the canonical source of truth. This is consistent with how the vertx, kafka, and redis modules are already declared.
+
+**Decision:** Ktor coordinates go into `libs.versions.toml`. If `Libs.kt` still references some Ktor alias later, remove the duplicate. This decision is **explicitly recorded here** to satisfy the workspace policy requirement of documenting any divergence from the CLAUDE.md rule.
+
+### 10.1 `settings.gradle.kts` (bluetape4k-workshop)
+
+Add at the appropriate location:
+
+```kotlin
+includeModules("ktor", false, true)
+```
+
+This auto-registers `:ktor:rest-coroutines` following the workspace `{domain}-{submodule}` convention.
+
+### 10.2 `gradle/libs.versions.toml` (bluetape4k-workshop)
+
+```toml
+[versions]
+ktor = "3.4.3"
+
+[libraries]
+ktor-bom                          = { module = "io.ktor:ktor-bom", version.ref = "ktor" }
+ktor-server-core                  = { module = "io.ktor:ktor-server-core" }
+ktor-server-netty                 = { module = "io.ktor:ktor-server-netty" }
+ktor-server-content-negotiation   = { module = "io.ktor:ktor-server-content-negotiation" }
+ktor-server-call-logging          = { module = "io.ktor:ktor-server-call-logging" }
+ktor-server-status-pages          = { module = "io.ktor:ktor-server-status-pages" }
+ktor-server-sse                   = { module = "io.ktor:ktor-server-sse" }
+ktor-server-test-host             = { module = "io.ktor:ktor-server-test-host" }
+ktor-serialization-kotlinx-json   = { module = "io.ktor:ktor-serialization-kotlinx-json" }
+ktor-client-core                  = { module = "io.ktor:ktor-client-core" }
+ktor-client-content-negotiation   = { module = "io.ktor:ktor-client-content-negotiation" }
+```
+
+### 10.3 `ktor/rest-coroutines/build.gradle.kts`
+
+Required pieces:
+
+```kotlin
+plugins {
+    alias(libs.plugins.kotlin.serialization)
+}
+
+dependencies {
+    implementation(platform(libs.ktor.bom))
+
+    implementation(libs.ktor.server.core)
+    implementation(libs.ktor.server.netty)
+    implementation(libs.ktor.server.content.negotiation)
+    implementation(libs.ktor.server.call.logging)
+    implementation(libs.ktor.server.status.pages)
+    implementation(libs.ktor.server.sse)
+    implementation(libs.ktor.serialization.kotlinx.json)
+
+    implementation(Libs.bluetape4k_core)
+    implementation(Libs.bluetape4k_jackson3)
+    implementation(Libs.bluetape4k_logging)
+    implementation(Libs.bluetape4k_coroutines)
+
+    testImplementation(Libs.bluetape4k_junit5)
+    testImplementation(Libs.bluetape4k_assertions)
+    testImplementation(libs.ktor.server.test.host)
+    testImplementation(libs.ktor.client.core)
+    testImplementation(libs.ktor.client.content.negotiation)
+}
+```
+
+Apply the standard workspace JVM toolchain (`Java 25`, ZGC flags) inherited from the root build.
+
+---
+
+## 11. Testing Strategy
+
+- **Framework:** JUnit 5 + MockK + bluetape4k-assertions + `bluetape4k-junit5`.
+- **Server harness:** Ktor's `testApplication { application { module(repository = ...) } }`. No real Netty.
+- **Harness split (mandatory):**
+  - Route / integration tests: `@Test fun testFoo() = testApplication { application { module(repository = preseeded) }; ... }`. NOT wrapped in `runSuspendTest`.
+  - Pure service / repository tests: `@Test fun testBar() = runSuspendTest { ... }`. No `testApplication`.
+- **Coverage targets:**
+  - `BookRoutesTest`: list, get-existing, get-missing -> 404, create -> 201, create-duplicate -> 409, validation -> 400 (pre-seed `InMemoryBookRepository` with fixture data before `testApplication`).
+  - `HealthRoutesTest`: `/health` returns `OK`.
+  - `BookStreamTest`: structured as a background subscription + event collection to avoid race conditions. Concrete pattern:
+    ```kotlin
+    @Test
+    fun testStreamReceivesEvent() = testApplication {
+        val preseeded = InMemoryBookRepository()
+        application { module(repository = preseeded) }
+
+        val sseClient = createClient { install(SSE) }
+        val events = Channel<String>(Channel.BUFFERED)
+
+        // Start subscription BEFORE the POST.
+        // testApplication block receiver is ApplicationTestBuilder (NOT CoroutineScope and NOT TestScope).
+        // Neither bare launch {} nor backgroundScope.launch {} is accessible.
+        // Create a child scope from the current suspend context explicitly:
+        val subscriptionScope = CoroutineScope(coroutineContext + SupervisorJob())
+        val subscription = subscriptionScope.launch {
+            sseClient.sse("/books/stream") {
+                incoming.collect { event ->
+                    event.data?.let { events.send(it) }
+                }
+            }
+        }
+
+        // Allow subscription to establish (in-memory; 100 ms is generous)
+        delay(100)
+
+        // POST a new book
+        val response = client.post("/books") {
+            contentType(ContentType.Application.Json)
+            setBody("""{"id":"test-1","title":"T","author":"A","year":2024}""")
+        }
+        response.status shouldBeEqualTo HttpStatusCode.Created
+
+        // Assert event arrives within 5 s
+        val received = withTimeoutOrNull(5_000) { events.receive() }
+        received.shouldNotBeNull()
+        received shouldContain "test-1"
+
+        subscription.cancel()
+        subscriptionScope.cancel()
+        events.close()
+    }
+    ```
+    Key invariants: (1) subscription launched *before* POST using `CoroutineScope(coroutineContext + SupervisorJob()).launch {}` — `testApplication` block receiver is `ApplicationTestBuilder` (not `CoroutineScope`, not `TestScope`), so neither bare `launch {}` nor `backgroundScope.launch {}` compiles; (2) `delay(100)` gives the subscriber time to register on the hot `SharedFlow` (`coroutineContext` is available inside the suspend block, so delay is virtual in the test dispatcher); (3) 5 s timeout is safe for in-memory harness; (4) `subscriptionScope.cancel()` + `events.close()` cleans up after assertion.
+  - `BookServiceTest`: pure suspend unit tests with a `FakeBookRepository`.
+  - `InMemoryBookRepositoryTest`: pure suspend unit tests via `runSuspendTest`.
+  - `Jackson3SupportTest` (optional): NDJSON round-trip with `bluetape4k-jackson3` `ObjectMapper`.
+- **Test base class `AbstractKtorTest`:** holds `companion object : KLoggingChannel()`.
+- **No real port binding in tests.**
+
+---
+
+## 12. Operational Notes
+
+- Default port: 8080 (overridable via env later — out of scope here).
+- `logback.xml`: minimal pattern-based config; one console appender at INFO; lower `io.ktor` to INFO.
+- No Docker / Testcontainers needed; module is pure JVM.
+
+**Production gaps (intentional workshop scope omissions — document before production deployment):**
+
+| Gap | Workshop stance | Production requirement |
+|-----|-----------------|------------------------|
+| **No graceful shutdown** | `embeddedServer(...).start(wait = true)` terminates immediately on SIGTERM. Active SSE clients get abrupt disconnect; in-flight POSTs may lose SSE events. | Add a JVM shutdown hook calling `server.stop(gracePeriodMillis=1000, timeoutMillis=5000)` and register `ApplicationStopping` listeners in `Application.module()`. |
+| **No request body size limit** | `call.receive<Book>()` reads the full body before validation. A multi-MB payload causes OOM before field-level constraints execute. | Configure Netty `maxRequestSize` or install a Ktor `RequestValidation` plugin that rejects oversized bodies early. |
+| **SSE stall risk** | `withTimeoutOrNull(5_000)` bounds POST latency when the SSE buffer fills. After timeout the event is logged and dropped. | Consider a per-connection `SharedFlow.emit` timeout + hard cap on concurrent SSE connections (e.g., semaphore) at the reverse-proxy or application level. |
+| **No SSE keepalive heartbeat** | Silent connection during idle periods; proxies/LBs may reap idle TCP connections after 30–60 s. | Add a `while(true) { delay(15.seconds); send(ServerSentEvent(comment = "ping")) }` coroutine inside the `sse { }` block, or use Ktor 3.4+ built-in `heartbeatPeriod` if available. |
+| **No SSE connection cap** | Unbounded concurrent SSE connections exhaust Netty worker threads and FD limits. | Add an application-level `AtomicInteger` counter or a `Semaphore`; reject connections at the route level above a defined maximum. |
+
+---
+
+## 13. Acceptance Criteria / Definition of Done
+
+The module is considered done when **all** of the following are true:
+
+### 13.1 Build & layout
+
+- [ ] `settings.gradle.kts` registers `:ktor:rest-coroutines` via `includeModules("ktor", false, true)`.
+- [ ] `gradle/libs.versions.toml` contains the Ktor 3.4.3 BOM + libraries listed in §10.2.
+- [ ] `ktor/rest-coroutines/build.gradle.kts` applies `kotlin.serialization` plugin and only the dependencies listed in §10.3.
+- [ ] The module compiles under Java 25 with the workspace's standard compiler flags.
+
+### 13.2 Code
+
+- [ ] All files from §5.11 exist with the responsibilities described in §5.
+- [ ] No file imports `com.fasterxml.jackson.*`. (Jackson 2 is absent.)
+- [ ] No file imports `io.ktor.serialization.jackson.*`.
+- [ ] `Book` is `@Serializable` (kotlinx) **and** implements `java.io.Serializable` with `serialVersionUID`.
+- [ ] Every `companion object` listed in §8 uses `KLoggingChannel`.
+- [ ] No `runBlocking` in `src/main`. No `@Synchronized` / `synchronized {}`.
+- [ ] `StatusPages` maps `DomainError.NotFound` -> 404, `DomainError.Conflict` -> 409, `IllegalArgumentException` -> 400, Ktor `BadRequestException` -> 400, and has a catch-all `exception<Throwable>` handler that returns 500 without exposing internal details.
+- [ ] Public types in `repository/`, `service/`, `json/`, `domain/` have English KDoc with `## Behavior / Contract` section for non-trivial contracts.
+
+### 13.3 Endpoints
+
+- [ ] All six endpoints from §7 respond as specified.
+- [ ] `/books/stream` is reachable at exactly `/books/stream` (not at `/`). `sse("/books/stream") { }` with explicit path is used in implementation.
+- [ ] `/books/stream` emits at least one event for each `POST /books` that follows an active subscription (guaranteed by `BufferOverflow.SUSPEND` + 5 s emit timeout strategy).
+- [ ] `/books/export` returns `application/x-ndjson` with one JSON object per line.
+
+### 13.4 Tests
+
+- [ ] `./gradlew :ktor:rest-coroutines:test` is green.
+- [ ] Route/integration tests use `@Test fun foo() = testApplication { ... }` directly (NOT wrapped in `runSuspendTest`).
+- [ ] Pure service/repository suspend tests use `runSuspendTest { }` (NOT inside `testApplication`).
+- [ ] `BookStreamTest` uses `createClient { install(SSE) }` (not `client.config { install(SSE) }`) and follows the background-subscription + Channel pattern from §11.
+- [ ] `BookStreamTest` starts the SSE subscription *before* the POST, collects events into a buffered `Channel`, and asserts at least one event matching the posted book arrives within 5 seconds (`withTimeoutOrNull(5_000)`).
+- [ ] All assertions use `bluetape4k-assertions` matchers.
+- [ ] No test uses `assertThrows`, `kotlin.test.assertFailsWith`, or `invoking { } shouldThrow`.
+- [ ] At minimum: `BookRoutesTest`, `HealthRoutesTest`, `BookStreamTest` exist and cover the cases listed in §11.
+
+### 13.5 Docs & gaps
+
+- [ ] Module README documents how to run (`./gradlew :ktor:rest-coroutines:run`) and lists all endpoints with curl examples.
+- [ ] README explicitly notes the Jackson 3 vs Jackson 2 stance (only Jackson 3 is used; Ktor JSON is `kotlinx-serialization`).
+- [ ] §9 gap is captured as a follow-up issue under `bluetape4k-projects` referencing this spec.
+
+### 13.6 Verification commands (must succeed)
+
+```bash
+./gradlew :ktor:rest-coroutines:compileKotlin
+./gradlew :ktor:rest-coroutines:test
+./gradlew :ktor:rest-coroutines:build
+./gradlew detekt
+```
+
+Each command must exit 0, and `test` must report > 0 tests run with 0 failures.
+
+---
+
+## 14. Open Questions
+
+1. Should the module also demonstrate `ktor-client` against itself (round-trip integration tests via the embedded client)? Default: yes, in `BookRoutesTest`.
+2. Should `/books/stream` send an initial replay of existing books on subscribe? Default: no (live-only) for v1; document as a future enhancement.
+3. Should the NDJSON export stream lazily from a `Flow<Book>` instead of materializing `service.list()` first? Default: list-first for v1; revisit when `BookRepository` becomes backed by a real database.
+
+---
+
+## Appendix A — Review Iteration Log
+
+### Round 1 (2026-05-25)
+
+| Reviewer | P0/P1 Findings | P2/P3 Findings |
+|----------|---------------|----------------|
+| Developer perspective (Sonnet) | 2 HIGH, 4 MEDIUM | 0 |
+| Security perspective (Sonnet) | 1 HIGH, 4 MEDIUM | 2 LOW |
+| Ops/SRE perspective (Sonnet) | 0 HIGH, 2 MEDIUM | 4 LOW |
+| User/caller perspective (Haiku) | 2 HIGH, 4 MEDIUM | 1 LOW |
+| Critic integration (Opus) | 5 P0 confirmed, 10 P1 confirmed | Several false-positive consolidations |
+| **Total Round 1** | **5 P0, 10 P1** | — |
+
+**All Round 1 P0 and P1 findings applied to spec.**
+
+Changes applied:
+- B1: AD-8 + §11 + §13.4 — `testApplication` vs `runSuspendTest` split documented
+- B2: §5.2 — `Application.module()` parameterized with injectable collaborators
+- B3: AD-7 + §5.2 — StatusPages catch-all `exception<Throwable>` + `BadRequestException` added
+- B4: §5.5 — `BookRepository.stream()` KDoc with non-blocking contract
+- B5: §5.9 + §6.4 — `call.respondBytesWriter { }` pattern made explicit
+- B6: §5.10 + §6.4 — `withContext(Dispatchers.IO)` removed from `ByteWriteChannel` writes
+- B7: §5.2 + §6.3 — shared `AppJson` instance defined
+- B8: §5.6 + §13.3 — `BufferOverflow.SUSPEND` (user approved)
+- B9: §5.9 + §6.3 — `CancellationException` rethrow contract in SSE collect
+- B10: §5.7 + §7.4 — field validation constants + per-field constraint table
+- B11: §11 — SSE test transport (`client.config { install(SSE) }`) specified
+- B12: §5.11 — `src/test/resources/` files added to file map
+- B13: §10.0 — dependency declaration policy documented (libs.versions.toml rationale)
+- B14: §7.4 — full error mapping table + field validation rules
+- B15: §13.2 — KDoc checklist item added
+
+Round 1 → all B1-B15 correctly applied (verified in Round 2).
+
+---
+
+### Round 2 (2026-05-25)
+
+| Reviewer | CRITICAL | HIGH | MEDIUM | LOW |
+|----------|---------|------|--------|-----|
+| Developer perspective (Sonnet) | 1 (N1) | 1 (N2) | 1 (N3) | 0 |
+| Security perspective (Sonnet) | 0 | 2 (S1, S2) | 2 | 0 |
+| Ops/SRE perspective (Sonnet) | 0 | 2 (OPS-1, OPS-2) | 2 | 2 |
+| User/caller perspective (Haiku) | 0 | 2 (UX-1, UX-2) | 2 | 1 |
+| **Total Round 2** | **1** | **7** | **7** | **3** |
+
+**All Round 2 findings applied:**
+- N1 (CRITICAL): §5.9 + §6.3 — `sse("/books/stream") { }` with explicit path
+- N2 (HIGH): §5.2 — catch-all 500 body adds `"type" to "Internal"`
+- N3 (MEDIUM): §5.5 KDoc — "cold Flow" corrected to "hot [MutableSharedFlow]"
+- S1+OPS-2 (HIGH, merged): §5.6 — `withTimeoutOrNull(5_000)` stall mitigation + §12 production gap table
+- S2 (HIGH): §12 — no request body size limit documented
+- OPS-1 (HIGH): §12 — no graceful shutdown documented
+- OPS-3+UX-4 (MEDIUM, merged): §11 — concrete 5 s timeout value specified in BookStreamTest pattern
+- OPS-4 (MEDIUM): §12 — SSE keepalive heartbeat documented
+- UX-1 (HIGH): §5.2 — `AppJson` visibility `internal val` + import pattern documented
+- UX-2 (HIGH): §11 — concrete BookStreamTest background-subscription + Channel pattern added
+- UX-3 (MEDIUM): §10.3 — `testImplementation(libs.ktor.client.core)` added
+
+Round 2 → all Round 2 findings correctly applied (verified in Round 3).
+
+---
+
+### Round 3 (2026-05-25) — focused review on affected areas
+
+| Reviewer | CRITICAL | HIGH | MEDIUM | LOW |
+|----------|---------|------|--------|-----|
+| Focused convergence check (Sonnet) | 0 | 1 (R3-H1) | 0 | 0 |
+| **Total Round 3** | **0** | **1** | **0** | **0** |
+
+**Round 3 finding applied:**
+- R3-H1 (HIGH): §11 BookStreamTest pattern — `launch {}` replaced with `backgroundScope.launch {}` (testApplication block is not CoroutineScope); explanation added to Key invariants.
+
+Round 3 → 1 HIGH (R3-H1) applied. Round 4 spot-check confirmed R3-H1 fix introduced a new HIGH (R4-H1: `backgroundScope` inaccessible in testApplication block).
+
+---
+
+### Round 4 (2026-05-25) — spot-check on R3-H1 fix
+
+| Reviewer | CRITICAL | HIGH | MEDIUM | LOW |
+|----------|---------|------|--------|-----|
+| Spot-check (Sonnet) | 0 | 1 (R4-H1) | 0 | 0 |
+| **Total Round 4** | **0** | **1** | **0** | **0** |
+
+**Round 4 finding applied:**
+- R4-H1 (HIGH): §11 BookStreamTest pattern — `backgroundScope.launch {}` replaced with `CoroutineScope(coroutineContext + SupervisorJob()).launch {}`; `subscriptionScope.cancel()` added to cleanup; Key invariants updated.
+
+Round 4 → CRITICAL = 0, HIGH = 0 after fix. Round 5 spot-check confirmed.
+
+---
+
+### Round 5 (2026-05-25) — final spot-check on R4-H1 fix
+
+| Reviewer | CRITICAL | HIGH | MEDIUM | LOW |
+|----------|---------|------|--------|-----|
+| Spot-check (Sonnet) | 0 | 0 | 0 | 1 (redundant subscription.cancel — harmless) |
+
+**Round 5 → CRITICAL = 0, HIGH = 0. ✅ CONVERGENCE CONFIRMED.**
+
+All reviewers (4× multi-perspective + 6-tier + critic + 5 iteration rounds): CRITICAL = 0, HIGH = 0 across Rounds 3-5.

--- a/docs/superpowers/specs/2026-05-25-ktor-rest-coroutines-design.md
+++ b/docs/superpowers/specs/2026-05-25-ktor-rest-coroutines-design.md
@@ -478,7 +478,7 @@ Add at the appropriate location:
 includeModules("ktor", false, true)
 ```
 
-This auto-registers `:ktor:rest-coroutines` following the workspace `{domain}-{submodule}` convention.
+This auto-registers `:ktor-rest-coroutines` (flat project name — `includeModules` with `withProjectName=false, withBaseDir=true` produces `basePath + "-" + dirName`). Verification: `./gradlew projects | grep ktor-rest-coroutines`.
 
 ### 10.2 `gradle/libs.versions.toml` (bluetape4k-workshop)
 
@@ -623,7 +623,7 @@ The module is considered done when **all** of the following are true:
 
 ### 13.1 Build & layout
 
-- [ ] `settings.gradle.kts` registers `:ktor:rest-coroutines` via `includeModules("ktor", false, true)`.
+- [ ] `settings.gradle.kts` registers `:ktor-rest-coroutines` (flat name) via `includeModules("ktor", false, true)`.
 - [ ] `gradle/libs.versions.toml` contains the Ktor 3.4.3 BOM + libraries listed in §10.2.
 - [ ] `ktor/rest-coroutines/build.gradle.kts` applies `kotlin.serialization` plugin and only the dependencies listed in §10.3.
 - [ ] The module compiles under Java 25 with the workspace's standard compiler flags.
@@ -648,7 +648,7 @@ The module is considered done when **all** of the following are true:
 
 ### 13.4 Tests
 
-- [ ] `./gradlew :ktor:rest-coroutines:test` is green.
+- [ ] `./gradlew :ktor-rest-coroutines:test` is green.
 - [ ] Route/integration tests use `@Test fun foo() = testApplication { ... }` directly (NOT wrapped in `runSuspendTest`).
 - [ ] Pure service/repository suspend tests use `runSuspendTest { }` (NOT inside `testApplication`).
 - [ ] `BookStreamTest` uses `createClient { install(SSE) }` (not `client.config { install(SSE) }`) and follows the background-subscription + Channel pattern from §11.
@@ -659,16 +659,16 @@ The module is considered done when **all** of the following are true:
 
 ### 13.5 Docs & gaps
 
-- [ ] Module README documents how to run (`./gradlew :ktor:rest-coroutines:run`) and lists all endpoints with curl examples.
+- [ ] Module README documents how to run (`./gradlew :ktor-rest-coroutines:run`) and lists all endpoints with curl examples.
 - [ ] README explicitly notes the Jackson 3 vs Jackson 2 stance (only Jackson 3 is used; Ktor JSON is `kotlinx-serialization`).
 - [ ] §9 gap is captured as a follow-up issue under `bluetape4k-projects` referencing this spec.
 
 ### 13.6 Verification commands (must succeed)
 
 ```bash
-./gradlew :ktor:rest-coroutines:compileKotlin
-./gradlew :ktor:rest-coroutines:test
-./gradlew :ktor:rest-coroutines:build
+./gradlew :ktor-rest-coroutines:compileKotlin
+./gradlew :ktor-rest-coroutines:test
+./gradlew :ktor-rest-coroutines:build
 ./gradlew detekt
 ```
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -95,6 +95,7 @@ kafka = "4.2.0"  # https://mvnrepository.com/artifact/org.apache.kafka/kafka-cli
 spring-kafka4 = "4.0.5"  # https://mvnrepository.com/artifact/org.springframework.kafka/spring-kafka
 
 bucket4j = "8.19.0"  # https://mvnrepository.com/artifact/com.bucket4j/bucket4j_jdk17-caffeine
+ktor = "3.4.3"  # https://mvnrepository.com/artifact/io.ktor/ktor-server-core
 vertx = "5.0.12"  # https://mvnrepository.com/artifact/io.vertx/vertx-core
 
 timefold-solver = "2.1.0"   # https://mvnrepository.com/artifact/ai.timefold.solver/timefold-solver-bom
@@ -416,6 +417,19 @@ vertx-pg-client = { module = "io.vertx:vertx-pg-client", version.ref = "vertx" }
 vertx-web-lib = { module = "io.vertx:vertx-web", version.ref = "vertx" }
 vertx-web-client = { module = "io.vertx:vertx-web-client", version.ref = "vertx" }
 vertx-junit5 = { module = "io.vertx:vertx-junit5", version.ref = "vertx" }
+
+# Ktor 3
+ktor-bom                        = { module = "io.ktor:ktor-bom", version.ref = "ktor" }
+ktor-server-core                = { module = "io.ktor:ktor-server-core" }
+ktor-server-netty               = { module = "io.ktor:ktor-server-netty" }
+ktor-server-content-negotiation = { module = "io.ktor:ktor-server-content-negotiation" }
+ktor-server-call-logging        = { module = "io.ktor:ktor-server-call-logging" }
+ktor-server-status-pages        = { module = "io.ktor:ktor-server-status-pages" }
+ktor-server-sse                 = { module = "io.ktor:ktor-server-sse" }
+ktor-server-test-host           = { module = "io.ktor:ktor-server-test-host" }
+ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json" }
+ktor-client-core                = { module = "io.ktor:ktor-client-core" }
+ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation" }
 
 # Resilience4j
 resilience4j-bom = { module = "io.github.resilience4j:resilience4j-bom", version.ref = "resilience4j" }

--- a/ktor/rest-coroutines/README.ko.md
+++ b/ktor/rest-coroutines/README.ko.md
@@ -1,0 +1,155 @@
+# ktor-rest-coroutines
+
+**Ktor 3** + Kotlin 코루틴 기반 Kotlin-first REST API 워크샵 모듈.
+Spring이나 리액티브 스트림 없이 관용적인 코루틴 HTTP, SSE 스트리밍, NDJSON 내보내기를 시연합니다.
+
+> **Locales**: [English](README.md)
+
+---
+
+## 아키텍처
+
+```
+HTTP 클라이언트
+     │
+     ▼
+┌─────────────────────────────────────────────────────────┐
+│  Ktor Application (Netty 엔진)                          │
+│                                                         │
+│  플러그인: CallLogging → ContentNegotiation → SSE       │
+│            → StatusPages                                │
+│                                                         │
+│  라우트                                                  │
+│  ├─ GET/POST/PUT/DELETE /books  (CRUD)                  │
+│  ├─ GET /books/export           (Jackson 3 NDJSON)      │
+│  ├─ GET /books/stream           (SSE 핫 스트림)          │
+│  └─ GET /health                 (활성 프로브)            │
+│                                                         │
+│  BookService ──► BookRepository (인메모리)               │
+│                      │                                  │
+│                      └── MutableSharedFlow<Book>        │
+│                           extraBufferCapacity=64        │
+│                           onBufferOverflow=SUSPEND      │
+└─────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 주요 기능
+
+| 기능 | 구현 방식 |
+|------|----------|
+| REST CRUD | Ktor 라우팅 + kotlinx-serialization-json |
+| SSE 실시간 스트림 | `sse("/books/stream")` + `MutableSharedFlow` |
+| NDJSON 내보내기 | `respondBytesWriter` + Jackson 3 (`tools.jackson.*`) |
+| 에러 매핑 | `StatusPages` — 400/404/409/500 + `"type"` 필드 |
+| 백프레셔 | `BufferOverflow.SUSPEND` + 5초 emit 타임아웃 |
+| 로깅 | Ktor `CallLogging` + bluetape4k `KLoggingChannel` |
+
+---
+
+## 엔드포인트
+
+| 메서드 | 경로 | 설명 | 상태 코드 |
+|--------|------|------|----------|
+| `GET` | `/books` | 전체 도서 목록 | 200 |
+| `GET` | `/books/{id}` | ID로 조회 | 200 / 404 |
+| `POST` | `/books` | 도서 생성 | 201 / 400 / 409 |
+| `PUT` | `/books/{id}` | 도서 수정 | 200 / 400 / 404 |
+| `DELETE` | `/books/{id}` | 도서 삭제 | 204 / 404 |
+| `GET` | `/books/export` | NDJSON 내보내기 | 200 |
+| `GET` | `/books/stream` | SSE 실시간 스트림 | 200 (chunked) |
+| `GET` | `/health` | 활성 프로브 | 200 |
+
+### 에러 응답 형식
+
+```json
+{"error": "Book not found: id=x", "type": "NotFound"}
+```
+
+`type` 값: `NotFound`, `Conflict`, `BadRequest`, `Internal`.
+
+---
+
+## curl 예제
+
+```bash
+# 전체 도서 목록
+curl http://localhost:8080/books
+
+# 도서 생성
+curl -X POST http://localhost:8080/books \
+     -H "Content-Type: application/json" \
+     -d '{"id":"b-1","title":"Kotlin in Action","author":"Jemerov","year":2017}'
+
+# ID로 조회
+curl http://localhost:8080/books/b-1
+
+# 도서 수정
+curl -X PUT http://localhost:8080/books/b-1 \
+     -H "Content-Type: application/json" \
+     -d '{"id":"b-1","title":"Kotlin in Action 2e","author":"Jemerov","year":2024}'
+
+# 도서 삭제
+curl -X DELETE http://localhost:8080/books/b-1
+
+# NDJSON 내보내기
+curl http://localhost:8080/books/export
+
+# SSE 스트림 구독 (Ctrl-C로 종료)
+curl -N http://localhost:8080/books/stream
+
+# 헬스 체크
+curl http://localhost:8080/health
+```
+
+---
+
+## Jackson 3 사용 방침
+
+이 모듈은 두 가지 직렬화 라이브러리를 목적에 따라 구분하여 사용합니다.
+
+| 목적 | 라이브러리 | 패키지 접두사 |
+|------|----------|-------------|
+| HTTP ContentNegotiation + SSE 인코딩 | kotlinx-serialization-json | `kotlinx.serialization.*` |
+| NDJSON 내보내기 (`/books/export`) | Jackson 3 (bluetape4k-jackson3) | `tools.jackson.*` |
+
+`com.fasterxml.jackson.*` (Jackson 2)는 **사용하지 않으며** 소스 import에 나타나서는 안 됩니다.
+
+---
+
+## 실행
+
+```bash
+# 서버 시작
+./gradlew :ktor-rest-coroutines:run
+
+# 테스트 실행
+./gradlew :ktor-rest-coroutines:test
+
+# 빌드
+./gradlew :ktor-rest-coroutines:build
+```
+
+---
+
+## 설정
+
+| 파라미터 | 기본값 | 설명 |
+|---------|--------|------|
+| 포트 | `8080` | Netty 리슨 포트 |
+| SSE 버퍼 크기 | `64` | `MutableSharedFlow.extraBufferCapacity` |
+| SSE emit 타임아웃 | `5 000 ms` | 느린 SSE 구독자 최대 대기 시간 |
+
+---
+
+## 프로덕션 한계
+
+이 워크샵 모듈은 의도적으로 최소한의 구현입니다.
+[spec §12 Production Gaps](../../docs/superpowers/specs/2026-05-25-ktor-rest-coroutines-design.md)에서 전체 목록을 확인하세요.
+
+- 인증/인가 없음
+- 인메모리 스토리지만 지원 (DB 백엔드 없음)
+- 페이지네이션/커서 없음
+- 레이트 리미팅 없음
+- SSE reconnect/replay 미구현 (`lastEventId` 미지원)

--- a/ktor/rest-coroutines/README.md
+++ b/ktor/rest-coroutines/README.md
@@ -1,0 +1,182 @@
+# ktor-rest-coroutines
+
+Kotlin-first REST API workshop built with **Ktor 3** and Kotlin coroutines.
+Demonstrates idiomatic coroutine-first HTTP, SSE streaming, and NDJSON export without Spring or reactive streams.
+
+> **Locales**: [한국어](README.ko.md)
+
+---
+
+## Architecture
+
+```
+HTTP client
+     │
+     ▼
+┌─────────────────────────────────────────────────────────┐
+│  Ktor Application (Netty engine)                        │
+│                                                         │
+│  Plugins: CallLogging → ContentNegotiation → SSE        │
+│           → StatusPages                                 │
+│                                                         │
+│  Routes                                                 │
+│  ├─ GET/POST/PUT/DELETE /books  (CRUD)                  │
+│  ├─ GET /books/export           (NDJSON via Jackson 3)  │
+│  ├─ GET /books/stream           (SSE hot stream)        │
+│  └─ GET /health                 (liveness probe)        │
+│                                                         │
+│  BookService ──► BookRepository (InMemory)              │
+│                      │                                  │
+│                      └── MutableSharedFlow<Book>        │
+│                           extraBufferCapacity=64        │
+│                           onBufferOverflow=SUSPEND      │
+└─────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Features
+
+| Feature | Implementation |
+|---------|---------------|
+| REST CRUD | Ktor routing + kotlinx-serialization-json |
+| SSE live stream | `sse("/books/stream")` + `MutableSharedFlow` |
+| NDJSON export | `respondBytesWriter` + Jackson 3 (`tools.jackson.*`) |
+| Error mapping | `StatusPages` — 400 / 404 / 409 / 500 with `"type"` field |
+| Backpressure | `BufferOverflow.SUSPEND` + 5 s emit timeout |
+| Logging | Ktor `CallLogging` + bluetape4k `KLoggingChannel` |
+
+---
+
+## Endpoints
+
+| Method | Path | Description | Status |
+|--------|------|-------------|--------|
+| `GET` | `/books` | List all books | 200 |
+| `GET` | `/books/{id}` | Get by id | 200 / 404 |
+| `POST` | `/books` | Create book | 201 / 400 / 409 |
+| `PUT` | `/books/{id}` | Update book | 200 / 400 / 404 |
+| `DELETE` | `/books/{id}` | Delete book | 204 / 404 |
+| `GET` | `/books/export` | NDJSON export | 200 |
+| `GET` | `/books/stream` | SSE live stream | 200 (chunked) |
+| `GET` | `/health` | Liveness probe | 200 |
+
+### Error response format
+
+```json
+{"error": "Book not found: id=x", "type": "NotFound"}
+```
+
+`type` values: `NotFound`, `Conflict`, `BadRequest`, `Internal`.
+
+---
+
+## curl Examples
+
+```bash
+# List all books
+curl http://localhost:8080/books
+
+# Create a book
+curl -X POST http://localhost:8080/books \
+     -H "Content-Type: application/json" \
+     -d '{"id":"b-1","title":"Kotlin in Action","author":"Jemerov","year":2017}'
+
+# Get by id
+curl http://localhost:8080/books/b-1
+
+# Update a book
+curl -X PUT http://localhost:8080/books/b-1 \
+     -H "Content-Type: application/json" \
+     -d '{"id":"b-1","title":"Kotlin in Action 2e","author":"Jemerov","year":2024}'
+
+# Delete a book
+curl -X DELETE http://localhost:8080/books/b-1
+
+# NDJSON export
+curl http://localhost:8080/books/export
+
+# SSE stream (stays open — Ctrl-C to stop)
+curl -N http://localhost:8080/books/stream
+
+# Health check
+curl http://localhost:8080/health
+```
+
+---
+
+## Jackson 3 Stance
+
+This module uses two serialization libraries for different purposes:
+
+| Purpose | Library | Package prefix |
+|---------|---------|----------------|
+| HTTP ContentNegotiation + SSE encoding | kotlinx-serialization-json | `kotlinx.serialization.*` |
+| NDJSON export (`/books/export`) | Jackson 3 via bluetape4k-jackson3 | `tools.jackson.*` |
+
+`com.fasterxml.jackson.*` (Jackson 2) is **not used** and must not appear in source imports.
+
+---
+
+## Run
+
+```bash
+# Start the server
+./gradlew :ktor-rest-coroutines:run
+
+# Run tests
+./gradlew :ktor-rest-coroutines:test
+
+# Build fat JAR
+./gradlew :ktor-rest-coroutines:build
+```
+
+---
+
+## Configuration
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| Port | `8080` | Netty listen port |
+| SSE buffer capacity | `64` | `MutableSharedFlow.extraBufferCapacity` |
+| SSE emit timeout | `5 000 ms` | Max time to wait for a slow SSE subscriber |
+
+---
+
+## Dependencies
+
+```kotlin
+implementation(platform(libs.ktor.bom))          // version coordination
+implementation(libs.ktor.server.core)
+implementation(libs.ktor.server.netty)
+implementation(libs.ktor.server.content.negotiation)
+implementation(libs.ktor.server.call.logging)
+implementation(libs.ktor.server.status.pages)
+implementation(libs.ktor.server.sse)
+implementation(libs.ktor.serialization.kotlinx.json)
+implementation(libs.kotlinx.serialization.json)
+implementation(libs.bluetape4k.jackson3)          // NDJSON export only
+implementation(libs.jackson3.module.kotlin)
+```
+
+---
+
+## Production Gaps
+
+This workshop module is intentionally minimal. See
+[spec §12 Production Gaps](../../docs/superpowers/specs/2026-05-25-ktor-rest-coroutines-design.md)
+for a full list, including:
+
+- No authentication or authorization
+- In-memory storage only (no DB backend)
+- No pagination or cursor support
+- No rate limiting
+- SSE has no reconnect/replay (`lastEventId` not implemented)
+
+---
+
+## Follow-up: bluetape4k-ktor
+
+A planned `bluetape4k-ktor` library module would extract reusable patterns from this workshop
+(SSE helpers, NDJSON responder, StatusPages builder, structured error model) into a
+publishable artifact for bluetape4k consumers.

--- a/ktor/rest-coroutines/build.gradle.kts
+++ b/ktor/rest-coroutines/build.gradle.kts
@@ -1,0 +1,38 @@
+plugins {
+    alias(libs.plugins.kotlin.serialization)
+    application
+}
+
+application {
+    mainClass.set("io.bluetape4k.workshop.ktor.MainKt")
+}
+
+configurations {
+    testImplementation.get().extendsFrom(compileOnly.get(), runtimeOnly.get())
+}
+
+dependencies {
+    implementation(platform(libs.ktor.bom))
+
+    implementation(libs.ktor.server.core)
+    implementation(libs.ktor.server.netty)
+    implementation(libs.ktor.server.content.negotiation)
+    implementation(libs.ktor.server.call.logging)
+    implementation(libs.ktor.server.status.pages)
+    implementation(libs.ktor.server.sse)
+    implementation(libs.ktor.serialization.kotlinx.json)
+    implementation(libs.kotlinx.serialization.json)
+
+    implementation(libs.bluetape4k.core)
+    implementation(libs.bluetape4k.logging)
+    implementation(libs.bluetape4k.coroutines)
+    implementation(libs.bluetape4k.jackson3)
+    implementation(libs.jackson3.module.kotlin)
+
+    testImplementation(libs.bluetape4k.junit5)
+    testImplementation(libs.bluetape4k.assertions)
+    testImplementation(libs.kotlinx.coroutines.test.lib)
+    testImplementation(libs.ktor.server.test.host)
+    testImplementation(libs.ktor.client.core)
+    testImplementation(libs.ktor.client.content.negotiation)
+}

--- a/ktor/rest-coroutines/src/main/kotlin/io/bluetape4k/workshop/ktor/ApplicationModule.kt
+++ b/ktor/rest-coroutines/src/main/kotlin/io/bluetape4k/workshop/ktor/ApplicationModule.kt
@@ -1,0 +1,101 @@
+package io.bluetape4k.workshop.ktor
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.workshop.ktor.domain.DomainError
+import io.bluetape4k.workshop.ktor.json.Jackson3Support
+import io.bluetape4k.workshop.ktor.repository.BookRepository
+import io.bluetape4k.workshop.ktor.repository.InMemoryBookRepository
+import io.bluetape4k.workshop.ktor.routes.bookRoutes
+import io.bluetape4k.workshop.ktor.routes.healthRoutes
+import io.bluetape4k.workshop.ktor.service.BookService
+import io.ktor.http.HttpStatusCode
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.Application
+import io.ktor.server.application.install
+import io.ktor.server.plugins.BadRequestException
+import io.ktor.server.plugins.calllogging.CallLogging
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.plugins.statuspages.StatusPages
+import io.ktor.server.response.respond
+import io.ktor.server.sse.SSE
+import kotlinx.serialization.json.Json
+
+private object ApplicationModuleLog : KLogging()
+
+/**
+ * Shared [Json] instance used by ContentNegotiation and SSE encoding in BookRoutes.
+ *
+ * `internal` visibility so `BookRoutes.kt` can import it as
+ * `import io.bluetape4k.workshop.ktor.AppJson`.
+ */
+internal val AppJson = Json {
+    prettyPrint = false
+    isLenient = true
+    ignoreUnknownKeys = true
+    encodeDefaults = true
+}
+
+/**
+ * Configures the Ktor [Application] with all plugins, status pages, and routes.
+ *
+ * ## Behavior / Contract
+ * - Plugin install order: [CallLogging] → [ContentNegotiation] → [SSE] → [StatusPages].
+ * - StatusPages handlers are registered from specific to general; [Throwable] catch-all is last.
+ * - [repository] and [jackson3] are injectable for testing.
+ *
+ * ```kotlin
+ * embeddedServer(Netty, port = 8080) { module() }.start(wait = true)
+ * ```
+ */
+fun Application.module(
+    repository: BookRepository = InMemoryBookRepository(),
+    jackson3: Jackson3Support = Jackson3Support(),
+) {
+    val service = BookService(repository)
+
+    install(CallLogging)
+
+    install(ContentNegotiation) {
+        json(AppJson)
+    }
+
+    install(SSE)
+
+    install(StatusPages) {
+        // Specific domain errors first
+        exception<DomainError.NotFound> { call, cause ->
+            call.respond(
+                HttpStatusCode.NotFound,
+                mapOf("error" to cause.message, "type" to "NotFound"),
+            )
+        }
+        exception<DomainError.Conflict> { call, cause ->
+            call.respond(
+                HttpStatusCode.Conflict,
+                mapOf("error" to cause.message, "type" to "Conflict"),
+            )
+        }
+        exception<IllegalArgumentException> { call, cause ->
+            call.respond(
+                HttpStatusCode.BadRequest,
+                mapOf("error" to (cause.message ?: "Bad request"), "type" to "BadRequest"),
+            )
+        }
+        exception<BadRequestException> { call, cause ->
+            call.respond(
+                HttpStatusCode.BadRequest,
+                mapOf("error" to (cause.message ?: "Bad request"), "type" to "BadRequest"),
+            )
+        }
+        // Catch-all must be last and must include "type":"Internal"
+        exception<Throwable> { call, _ ->
+            call.respond(
+                HttpStatusCode.InternalServerError,
+                mapOf("error" to "Internal server error", "type" to "Internal"),
+            )
+        }
+    }
+
+    healthRoutes()
+    bookRoutes(service, jackson3)
+}

--- a/ktor/rest-coroutines/src/main/kotlin/io/bluetape4k/workshop/ktor/Main.kt
+++ b/ktor/rest-coroutines/src/main/kotlin/io/bluetape4k/workshop/ktor/Main.kt
@@ -1,0 +1,27 @@
+package io.bluetape4k.workshop.ktor
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.info
+import io.ktor.server.engine.embeddedServer
+import io.ktor.server.netty.Netty
+
+private object MainLog : KLogging()
+
+/**
+ * Entry point for the `ktor-rest-coroutines` workshop application.
+ *
+ * Starts a Netty-backed Ktor server on port 8080.
+ *
+ * ```
+ * ./gradlew :ktor-rest-coroutines:run
+ * ```
+ */
+fun main() {
+    MainLog.log.info { "Starting ktor-rest-coroutines workshop server on port 8080" }
+    embeddedServer(
+        factory = Netty,
+        port = 8080,
+        host = "0.0.0.0",
+        module = { module() },
+    ).start(wait = true)
+}

--- a/ktor/rest-coroutines/src/main/kotlin/io/bluetape4k/workshop/ktor/domain/Book.kt
+++ b/ktor/rest-coroutines/src/main/kotlin/io/bluetape4k/workshop/ktor/domain/Book.kt
@@ -1,0 +1,28 @@
+package io.bluetape4k.workshop.ktor.domain
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Represents a book in the catalog.
+ *
+ * ## Behavior / Contract
+ * - `@Serializable` (kotlinx) enables compile-time JSON serialization via ContentNegotiation and SSE encoding.
+ *   This is independent of Jackson 3 serialization used for NDJSON export.
+ * - Implements `java.io.Serializable` (workspace convention for all data classes).
+ * - Pure value object; no database annotations.
+ *
+ * ```kotlin
+ * val book = Book(id = "b-1", title = "Kotlin in Action", author = "Jemerov", year = 2017)
+ * ```
+ */
+@Serializable
+data class Book(
+    val id: String,
+    val title: String,
+    val author: String,
+    val year: Int,
+) : java.io.Serializable {
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}

--- a/ktor/rest-coroutines/src/main/kotlin/io/bluetape4k/workshop/ktor/domain/DomainError.kt
+++ b/ktor/rest-coroutines/src/main/kotlin/io/bluetape4k/workshop/ktor/domain/DomainError.kt
@@ -1,0 +1,16 @@
+package io.bluetape4k.workshop.ktor.domain
+
+/**
+ * Domain-specific exception hierarchy for the book catalog.
+ *
+ * ## Behavior / Contract
+ * - [NotFound] maps to HTTP 404 via StatusPages in `ApplicationModule`.
+ * - [Conflict] maps to HTTP 409 via StatusPages in `ApplicationModule`.
+ */
+sealed class DomainError(message: String) : RuntimeException(message) {
+    /** Thrown when a book with the given id does not exist. Maps to HTTP 404. */
+    class NotFound(id: String) : DomainError("Book not found: id=$id")
+
+    /** Thrown when a book with the same id already exists. Maps to HTTP 409. */
+    class Conflict(message: String) : DomainError(message)
+}

--- a/ktor/rest-coroutines/src/main/kotlin/io/bluetape4k/workshop/ktor/json/Jackson3Support.kt
+++ b/ktor/rest-coroutines/src/main/kotlin/io/bluetape4k/workshop/ktor/json/Jackson3Support.kt
@@ -1,0 +1,35 @@
+package io.bluetape4k.workshop.ktor.json
+
+import io.bluetape4k.logging.KLogging
+import io.ktor.utils.io.ByteWriteChannel
+import io.ktor.utils.io.writeStringUtf8
+import tools.jackson.databind.ObjectMapper
+import tools.jackson.module.kotlin.jacksonObjectMapper
+
+/**
+ * Jackson 3 support for NDJSON (newline-delimited JSON) export.
+ *
+ * ## Behavior / Contract
+ * - Uses `tools.jackson.*` (Jackson 3) exclusively — no `com.fasterxml.jackson.*` imports.
+ * - [writeNdjson] writes one JSON object per line to the provided [ByteWriteChannel].
+ * - [ByteWriteChannel.writeStringUtf8] is a non-blocking suspend extension — **no `withContext(Dispatchers.IO)` needed**.
+ */
+class Jackson3Support {
+
+    companion object : KLogging() {
+        val objectMapper: ObjectMapper = jacksonObjectMapper()
+    }
+
+    /**
+     * Writes each element of [items] as a JSON line followed by `\n` to [channel].
+     *
+     * @param channel the [ByteWriteChannel] to write to (typically from `respondBytesWriter`).
+     * @param items the objects to serialize, one per line.
+     */
+    suspend fun <T : Any> writeNdjson(channel: ByteWriteChannel, items: Iterable<T>) {
+        for (item in items) {
+            val line = objectMapper.writeValueAsString(item) + "\n"
+            channel.writeStringUtf8(line)
+        }
+    }
+}

--- a/ktor/rest-coroutines/src/main/kotlin/io/bluetape4k/workshop/ktor/repository/BookRepository.kt
+++ b/ktor/rest-coroutines/src/main/kotlin/io/bluetape4k/workshop/ktor/repository/BookRepository.kt
@@ -1,0 +1,52 @@
+package io.bluetape4k.workshop.ktor.repository
+
+import io.bluetape4k.workshop.ktor.domain.Book
+import io.bluetape4k.workshop.ktor.domain.DomainError
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Repository abstraction for book catalog operations.
+ *
+ * ## Behavior / Contract
+ * - [save] throws [DomainError.Conflict] when a book with the same id already exists.
+ * - [update] throws [DomainError.NotFound] when the target id does not exist.
+ * - [delete] throws [DomainError.NotFound] when the target id does not exist.
+ * - [stream] returns a hot [kotlinx.coroutines.flow.SharedFlow] — only events emitted after
+ *   subscription are delivered. No replay buffer.
+ */
+interface BookRepository {
+
+    /** Returns all books in the catalog. */
+    suspend fun findAll(): List<Book>
+
+    /** Returns the book with the given [id], or `null` if it does not exist. */
+    suspend fun findById(id: String): Book?
+
+    /**
+     * Persists [book] and emits it to the live stream.
+     *
+     * @throws DomainError.Conflict if a book with [Book.id] already exists.
+     */
+    suspend fun save(book: Book): Book
+
+    /**
+     * Replaces the book at [id] with [book].
+     *
+     * @throws DomainError.NotFound if [id] does not exist.
+     */
+    suspend fun update(id: String, book: Book): Book
+
+    /**
+     * Removes the book at [id].
+     *
+     * @throws DomainError.NotFound if [id] does not exist.
+     */
+    suspend fun delete(id: String)
+
+    /**
+     * Returns a hot [Flow] of books emitted whenever a book is saved or updated.
+     *
+     * Backed by a [kotlinx.coroutines.flow.MutableSharedFlow] — live-only delivery, no replay.
+     */
+    fun stream(): Flow<Book>
+}

--- a/ktor/rest-coroutines/src/main/kotlin/io/bluetape4k/workshop/ktor/repository/InMemoryBookRepository.kt
+++ b/ktor/rest-coroutines/src/main/kotlin/io/bluetape4k/workshop/ktor/repository/InMemoryBookRepository.kt
@@ -1,0 +1,75 @@
+package io.bluetape4k.workshop.ktor.repository
+
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.logging.warn
+import io.bluetape4k.support.requireNotBlank
+import io.bluetape4k.workshop.ktor.domain.Book
+import io.bluetape4k.workshop.ktor.domain.DomainError
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.withTimeoutOrNull
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Thread-safe in-memory implementation of [BookRepository].
+ *
+ * ## Behavior / Contract
+ * - Backed by a [ConcurrentHashMap] for O(1) reads/writes.
+ * - SSE stream backed by a [MutableSharedFlow] with `extraBufferCapacity = 64`
+ *   and `onBufferOverflow = BufferOverflow.SUSPEND`.
+ * - [save] and [update] attempt `sharedFlow.emit(book)` with a 5-second timeout so
+ *   a stalled SSE subscriber cannot block the HTTP handler indefinitely.
+ *   The book is always persisted regardless of whether the emit succeeds.
+ */
+class InMemoryBookRepository : BookRepository {
+
+    companion object : KLoggingChannel() {
+        private const val EMIT_TIMEOUT_MS = 5_000L
+    }
+
+    private val store = ConcurrentHashMap<String, Book>()
+    private val sharedFlow = MutableSharedFlow<Book>(
+        extraBufferCapacity = 64,
+        onBufferOverflow = BufferOverflow.SUSPEND,
+    )
+
+    override suspend fun findAll(): List<Book> = store.values.toList()
+
+    override suspend fun findById(id: String): Book? {
+        id.requireNotBlank("id")
+        return store[id]
+    }
+
+    override suspend fun save(book: Book): Book {
+        if (store.putIfAbsent(book.id, book) != null) {
+            throw DomainError.Conflict("Book already exists: id=${book.id}")
+        }
+        emitWithTimeout(book)
+        return book
+    }
+
+    override suspend fun update(id: String, book: Book): Book {
+        id.requireNotBlank("id")
+        store[id] ?: throw DomainError.NotFound(id)
+        val updated = book.copy(id = id)
+        store[id] = updated
+        emitWithTimeout(updated)
+        return updated
+    }
+
+    override suspend fun delete(id: String) {
+        id.requireNotBlank("id")
+        store.remove(id) ?: throw DomainError.NotFound(id)
+    }
+
+    override fun stream(): Flow<Book> = sharedFlow.asSharedFlow()
+
+    private suspend fun emitWithTimeout(book: Book) {
+        val emitted = withTimeoutOrNull(EMIT_TIMEOUT_MS) { sharedFlow.emit(book) } != null
+        if (!emitted) {
+            log.warn { "SSE emit timed out for book ${book.id}; book saved, event dropped" }
+        }
+    }
+}

--- a/ktor/rest-coroutines/src/main/kotlin/io/bluetape4k/workshop/ktor/routes/BookRoutes.kt
+++ b/ktor/rest-coroutines/src/main/kotlin/io/bluetape4k/workshop/ktor/routes/BookRoutes.kt
@@ -1,0 +1,105 @@
+package io.bluetape4k.workshop.ktor.routes
+
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.logging.debug
+import io.bluetape4k.logging.warn
+import io.bluetape4k.workshop.ktor.AppJson
+import io.bluetape4k.workshop.ktor.domain.Book
+import io.bluetape4k.workshop.ktor.json.Jackson3Support
+import io.bluetape4k.workshop.ktor.service.BookService
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.Application
+import io.ktor.server.request.receive
+import io.ktor.server.response.respond
+import io.ktor.server.response.respondBytesWriter
+import io.ktor.server.routing.delete
+import io.ktor.server.routing.get
+import io.ktor.server.routing.post
+import io.ktor.server.routing.put
+import io.ktor.server.routing.route
+import io.ktor.server.routing.routing
+import io.ktor.server.sse.sse
+import io.ktor.sse.ServerSentEvent
+import kotlinx.coroutines.CancellationException
+
+// Extension functions cannot have companion objects — use a file-private holder.
+private object BookRoutesLog : KLoggingChannel()
+
+/**
+ * Registers all book catalog routes on the [Application].
+ *
+ * ## Routes
+ * - `GET  /books`             — list all books
+ * - `GET  /books/{id}`        — get book by id
+ * - `POST /books`             — create book (201 Created)
+ * - `PUT  /books/{id}`        — update book
+ * - `DELETE /books/{id}`      — delete book (204 No Content)
+ * - `GET  /books/export`      — NDJSON export (application/x-ndjson)
+ * - `GET  /books/stream`      — SSE live stream
+ *
+ * ## Behavior / Contract
+ * - `sse("/books/stream")` is registered at the **top-level routing scope**, NOT inside
+ *   `route("/books")`, to avoid the double-prefix `/books/books/stream`.
+ * - SSE collect block rethrows [CancellationException] before any broad catch.
+ * - NDJSON export uses [Jackson3Support.writeNdjson] via [respondBytesWriter] — no `withContext` needed.
+ */
+fun Application.bookRoutes(service: BookService, jackson3: Jackson3Support) {
+    routing {
+        route("/books") {
+            get {
+                call.respond(service.list())
+            }
+
+            get("/export") {
+                val books = service.list()
+                call.respondBytesWriter(contentType = ContentType("application", "x-ndjson")) {
+                    jackson3.writeNdjson(this, books)
+                }
+            }
+
+            get("/{id}") {
+                val id = call.parameters["id"] ?: throw IllegalArgumentException("Missing id parameter")
+                call.respond(service.get(id))
+            }
+
+            post {
+                val book = call.receive<Book>()
+                val created = service.create(book)
+                call.respond(HttpStatusCode.Created, created)
+            }
+
+            put("/{id}") {
+                val id = call.parameters["id"] ?: throw IllegalArgumentException("Missing id parameter")
+                val book = call.receive<Book>()
+                call.respond(service.update(id, book))
+            }
+
+            delete("/{id}") {
+                val id = call.parameters["id"] ?: throw IllegalArgumentException("Missing id parameter")
+                service.delete(id)
+                call.respond(HttpStatusCode.NoContent)
+            }
+        }
+
+        // CRITICAL: sse("/books/stream") at top-level routing scope — NOT inside route("/books") { }
+        // A bare sse { } would mount at application root instead of the intended path.
+        sse("/books/stream") {
+            BookRoutesLog.log.debug { "SSE client connected to /books/stream" }
+            try {
+                service.stream().collect { book ->
+                    try {
+                        send(ServerSentEvent(data = AppJson.encodeToString(book)))
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Exception) {
+                        BookRoutesLog.log.warn(e) { "SSE send failed for book ${book.id}" }
+                    }
+                }
+            } catch (e: CancellationException) {
+                BookRoutesLog.log.debug { "SSE client disconnected from /books/stream" }
+                throw e
+            }
+        }
+    }
+}

--- a/ktor/rest-coroutines/src/main/kotlin/io/bluetape4k/workshop/ktor/routes/HealthRoutes.kt
+++ b/ktor/rest-coroutines/src/main/kotlin/io/bluetape4k/workshop/ktor/routes/HealthRoutes.kt
@@ -1,0 +1,20 @@
+package io.bluetape4k.workshop.ktor.routes
+
+import io.ktor.server.application.Application
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.get
+import io.ktor.server.routing.routing
+
+/**
+ * Registers the `/health` liveness endpoint.
+ *
+ * ## Behavior / Contract
+ * - `GET /health` always returns HTTP 200 with body `OK`.
+ */
+fun Application.healthRoutes() {
+    routing {
+        get("/health") {
+            call.respondText("OK")
+        }
+    }
+}

--- a/ktor/rest-coroutines/src/main/kotlin/io/bluetape4k/workshop/ktor/service/BookService.kt
+++ b/ktor/rest-coroutines/src/main/kotlin/io/bluetape4k/workshop/ktor/service/BookService.kt
@@ -1,0 +1,86 @@
+package io.bluetape4k.workshop.ktor.service
+
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.support.requireInRange
+import io.bluetape4k.support.requireNotBlank
+import io.bluetape4k.workshop.ktor.domain.Book
+import io.bluetape4k.workshop.ktor.domain.DomainError
+import io.bluetape4k.workshop.ktor.repository.BookRepository
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Application service for the book catalog.
+ *
+ * ## Behavior / Contract
+ * - [create] validates all fields via bluetape4k `require*` extensions before delegating to the repository.
+ * - [stream] is non-suspend and returns the repository's hot [Flow].
+ */
+class BookService(private val repository: BookRepository) {
+
+    companion object : KLoggingChannel() {
+        const val MAX_ID_LENGTH = 128
+        const val MAX_TITLE_LENGTH = 500
+        const val MAX_AUTHOR_LENGTH = 200
+        val YEAR_RANGE = 1..3000
+    }
+
+    /** Returns all books in the catalog. */
+    suspend fun list(): List<Book> = repository.findAll()
+
+    /**
+     * Returns the book with [id], or `null` if not found.
+     *
+     * @throws DomainError.NotFound if the book does not exist.
+     */
+    suspend fun get(id: String): Book =
+        repository.findById(id) ?: throw DomainError.NotFound(id)
+
+    /**
+     * Validates and creates a new book.
+     *
+     * @throws IllegalArgumentException if any field is blank, too long, or year is out of range.
+     * @throws DomainError.Conflict if a book with the same id already exists.
+     */
+    suspend fun create(book: Book): Book {
+        validateBook(book)
+        return repository.save(book)
+    }
+
+    /**
+     * Validates and updates an existing book.
+     *
+     * @throws IllegalArgumentException if any field is blank or out of range.
+     * @throws DomainError.NotFound if the book does not exist.
+     */
+    suspend fun update(id: String, book: Book): Book {
+        validateBook(book)
+        return repository.update(id, book)
+    }
+
+    /**
+     * Deletes the book with [id].
+     *
+     * @throws DomainError.NotFound if the book does not exist.
+     */
+    suspend fun delete(id: String) = repository.delete(id)
+
+    /**
+     * Returns a hot [Flow] of books emitted on each [create] or [update].
+     *
+     * Live-only; no replay for late subscribers.
+     */
+    fun stream(): Flow<Book> = repository.stream()
+
+    private fun validateBook(book: Book) {
+        book.id.requireNotBlank("id")
+        require(book.id.length <= MAX_ID_LENGTH) { "id must not exceed $MAX_ID_LENGTH characters" }
+
+        book.title.requireNotBlank("title")
+        require(book.title.length <= MAX_TITLE_LENGTH) { "title must not exceed $MAX_TITLE_LENGTH characters" }
+
+        book.author.requireNotBlank("author")
+        require(book.author.length <= MAX_AUTHOR_LENGTH) { "author must not exceed $MAX_AUTHOR_LENGTH characters" }
+
+        book.year.requireInRange(YEAR_RANGE.first, YEAR_RANGE.last, "year")
+    }
+}

--- a/ktor/rest-coroutines/src/main/resources/logback.xml
+++ b/ktor/rest-coroutines/src/main/resources/logback.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE" />
+    </root>
+
+    <logger name="io.bluetape4k.workshop" level="DEBUG" />
+    <logger name="io.ktor" level="INFO" />
+</configuration>

--- a/ktor/rest-coroutines/src/test/kotlin/io/bluetape4k/workshop/ktor/AbstractKtorTest.kt
+++ b/ktor/rest-coroutines/src/test/kotlin/io/bluetape4k/workshop/ktor/AbstractKtorTest.kt
@@ -1,0 +1,30 @@
+package io.bluetape4k.workshop.ktor
+
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.workshop.ktor.domain.Book
+import org.junit.jupiter.api.TestInstance
+
+/**
+ * Base class for Ktor integration tests.
+ *
+ * ## Behavior / Contract
+ * - `@TestInstance(PER_CLASS)` is mandatory for abstract test classes per workspace convention.
+ * - Provides shared [Book] fixture builders to keep test data consistent.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+abstract class AbstractKtorTest {
+
+    companion object : KLoggingChannel()
+
+    protected fun createBook(
+        id: String = "book-1",
+        title: String = "Kotlin in Action",
+        author: String = "Jemerov",
+        year: Int = 2017,
+    ): Book = Book(id = id, title = title, author = author, year = year)
+
+    protected fun createBooks(count: Int): List<Book> =
+        (1..count).map { i ->
+            Book(id = "book-$i", title = "Title $i", author = "Author $i", year = 2000 + i)
+        }
+}

--- a/ktor/rest-coroutines/src/test/kotlin/io/bluetape4k/workshop/ktor/repository/InMemoryBookRepositoryTest.kt
+++ b/ktor/rest-coroutines/src/test/kotlin/io/bluetape4k/workshop/ktor/repository/InMemoryBookRepositoryTest.kt
@@ -1,0 +1,137 @@
+package io.bluetape4k.workshop.ktor.repository
+
+import io.bluetape4k.workshop.ktor.AbstractKtorTest
+import io.bluetape4k.workshop.ktor.domain.Book
+import io.bluetape4k.workshop.ktor.domain.DomainError
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeoutOrNull
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldNotBeNull
+import org.junit.jupiter.api.Test
+import kotlin.test.assertFailsWith
+
+class InMemoryBookRepositoryTest : AbstractKtorTest() {
+
+    private fun repo() = InMemoryBookRepository()
+
+    private val book1 = Book("b-1", "Kotlin in Action", "Jemerov", 2017)
+    private val book2 = Book("b-2", "Clean Code", "Martin", 2008)
+
+    @Test
+    fun `save and findById returns saved book`() = runTest {
+        val repo = repo()
+        repo.save(book1)
+
+        val found = repo.findById(book1.id)
+        found shouldBeEqualTo book1
+    }
+
+    @Test
+    fun `findById returns null for unknown id`() = runTest {
+        val repo = repo()
+        repo.findById("no-such-id").shouldBeNull()
+    }
+
+    @Test
+    fun `findAll returns all saved books`() = runTest {
+        val repo = repo()
+        repo.save(book1)
+        repo.save(book2)
+
+        val all = repo.findAll()
+        all.size shouldBeEqualTo 2
+        all.any { it.id == book1.id } shouldBeEqualTo true
+        all.any { it.id == book2.id } shouldBeEqualTo true
+    }
+
+    @Test
+    fun `save throws DomainError Conflict on duplicate id`() = runTest {
+        val repo = repo()
+        repo.save(book1)
+
+        assertFailsWith<DomainError.Conflict> {
+            repo.save(book1.copy(title = "Different Title"))
+        }
+    }
+
+    @Test
+    fun `update replaces book content`() = runTest {
+        val repo = repo()
+        repo.save(book1)
+
+        val updated = repo.update(book1.id, book1.copy(title = "Updated Title"))
+        updated.title shouldBeEqualTo "Updated Title"
+        repo.findById(book1.id)?.title shouldBeEqualTo "Updated Title"
+    }
+
+    @Test
+    fun `update throws DomainError NotFound for unknown id`() = runTest {
+        val repo = repo()
+
+        assertFailsWith<DomainError.NotFound> {
+            repo.update("no-such-id", book1)
+        }
+    }
+
+    @Test
+    fun `delete removes book`() = runTest {
+        val repo = repo()
+        repo.save(book1)
+        repo.delete(book1.id)
+
+        repo.findById(book1.id).shouldBeNull()
+    }
+
+    @Test
+    fun `delete throws DomainError NotFound for unknown id`() = runTest {
+        val repo = repo()
+
+        assertFailsWith<DomainError.NotFound> {
+            repo.delete("no-such-id")
+        }
+    }
+
+    @Test
+    fun `stream emits book after save`() = runTest {
+        val repo = repo()
+        val received = Channel<Book>(Channel.BUFFERED)
+
+        // runTest provides TestScope, so launch {} is available
+        val job = launch { repo.stream().collect { received.send(it) } }
+        delay(50) // let subscriber register on hot SharedFlow
+
+        repo.save(book1)
+
+        val result = withTimeoutOrNull(2_000) { received.receive() }
+        result.shouldNotBeNull()
+        result shouldBeEqualTo book1
+
+        job.cancel()
+        received.close()
+    }
+
+    @Test
+    fun `stream emits book after update`() = runTest {
+        val repo = repo()
+        repo.save(book1)
+
+        val received = Channel<Book>(Channel.BUFFERED)
+        val job = launch { repo.stream().collect { received.send(it) } }
+        delay(50)
+
+        val updated = repo.update(book1.id, book1.copy(year = 2025))
+
+        val result = withTimeoutOrNull(2_000) { received.receive() }
+        result.shouldNotBeNull()
+        result?.year shouldBeEqualTo 2025
+        result shouldBeEqualTo updated
+
+        job.cancel()
+        received.close()
+    }
+}

--- a/ktor/rest-coroutines/src/test/kotlin/io/bluetape4k/workshop/ktor/routes/BookRoutesTest.kt
+++ b/ktor/rest-coroutines/src/test/kotlin/io/bluetape4k/workshop/ktor/routes/BookRoutesTest.kt
@@ -1,0 +1,191 @@
+package io.bluetape4k.workshop.ktor.routes
+
+import io.bluetape4k.workshop.ktor.AbstractKtorTest
+import io.bluetape4k.workshop.ktor.domain.Book
+import io.bluetape4k.workshop.ktor.domain.DomainError
+import io.bluetape4k.workshop.ktor.module
+import io.bluetape4k.workshop.ktor.repository.BookRepository
+import io.bluetape4k.workshop.ktor.repository.InMemoryBookRepository
+import io.ktor.client.request.delete
+import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.client.request.put
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.server.testing.testApplication
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldContain
+import io.bluetape4k.assertions.shouldNotContain
+import org.junit.jupiter.api.Test
+
+class BookRoutesTest : AbstractKtorTest() {
+
+    @Test
+    fun `GET books returns empty list when repository is empty`() = testApplication {
+        application { module() }
+
+        val response = client.get("/books")
+
+        response.status shouldBeEqualTo HttpStatusCode.OK
+        response.bodyAsText() shouldBeEqualTo "[]"
+    }
+
+    @Test
+    fun `GET books returns all seeded books`() = testApplication {
+        val repository = InMemoryBookRepository()
+        val books = createBooks(3)
+        books.forEach { repository.save(it) }
+        application { module(repository = repository) }
+
+        val response = client.get("/books")
+
+        response.status shouldBeEqualTo HttpStatusCode.OK
+        val body = response.bodyAsText()
+        books.forEach { body shouldContain it.id }
+    }
+
+    @Test
+    fun `GET books by id returns book when it exists`() = testApplication {
+        val repository = InMemoryBookRepository()
+        val book = createBook(id = "exists-1")
+        repository.save(book)
+        application { module(repository = repository) }
+
+        val response = client.get("/books/${book.id}")
+
+        response.status shouldBeEqualTo HttpStatusCode.OK
+        response.bodyAsText() shouldContain book.id
+    }
+
+    @Test
+    fun `GET books by id returns 404 with type NotFound when missing`() = testApplication {
+        application { module() }
+
+        val response = client.get("/books/no-such-id")
+
+        response.status shouldBeEqualTo HttpStatusCode.NotFound
+        response.bodyAsText() shouldContain "NotFound"
+    }
+
+    @Test
+    fun `POST books creates book and returns 201`() = testApplication {
+        application { module() }
+
+        val response = client.post("/books") {
+            contentType(ContentType.Application.Json)
+            setBody("""{"id":"new-1","title":"Clean Code","author":"Martin","year":2008}""")
+        }
+
+        response.status shouldBeEqualTo HttpStatusCode.Created
+        response.bodyAsText() shouldContain "new-1"
+    }
+
+    @Test
+    fun `POST books returns 409 Conflict for duplicate id`() = testApplication {
+        val repository = InMemoryBookRepository()
+        repository.save(createBook(id = "dup-1"))
+        application { module(repository = repository) }
+
+        val response = client.post("/books") {
+            contentType(ContentType.Application.Json)
+            setBody("""{"id":"dup-1","title":"Any","author":"Author","year":2020}""")
+        }
+
+        response.status shouldBeEqualTo HttpStatusCode.Conflict
+        response.bodyAsText() shouldContain "Conflict"
+    }
+
+    @Test
+    fun `POST books returns 400 when title is blank`() = testApplication {
+        application { module() }
+
+        val response = client.post("/books") {
+            contentType(ContentType.Application.Json)
+            setBody("""{"id":"bad-1","title":"","author":"Author","year":2020}""")
+        }
+
+        response.status shouldBeEqualTo HttpStatusCode.BadRequest
+        response.bodyAsText() shouldContain "BadRequest"
+    }
+
+    @Test
+    fun `POST books returns 400 when id is blank`() = testApplication {
+        application { module() }
+
+        val response = client.post("/books") {
+            contentType(ContentType.Application.Json)
+            setBody("""{"id":"","title":"Title","author":"Author","year":2020}""")
+        }
+
+        response.status shouldBeEqualTo HttpStatusCode.BadRequest
+        response.bodyAsText() shouldContain "BadRequest"
+    }
+
+    @Test
+    fun `POST books returns 400 when year is out of range`() = testApplication {
+        application { module() }
+
+        val response = client.post("/books") {
+            contentType(ContentType.Application.Json)
+            setBody("""{"id":"bad-year","title":"Title","author":"Author","year":0}""")
+        }
+
+        response.status shouldBeEqualTo HttpStatusCode.BadRequest
+        response.bodyAsText() shouldContain "BadRequest"
+    }
+
+    @Test
+    fun `GET books export returns NDJSON with one line per book`() = testApplication {
+        val repository = InMemoryBookRepository()
+        val books = createBooks(3)
+        books.forEach { repository.save(it) }
+        application { module(repository = repository) }
+
+        val response = client.get("/books/export")
+
+        response.status shouldBeEqualTo HttpStatusCode.OK
+        response.contentType().toString() shouldContain "x-ndjson"
+
+        val lines = response.bodyAsText().trim().lines().filter { it.isNotBlank() }
+        lines.size shouldBeEqualTo books.size
+        books.forEach { book ->
+            lines.any { it.contains(book.id) } shouldBeEqualTo true
+        }
+    }
+
+    @Test
+    fun `GET health succeeds even with SSE installed`() = testApplication {
+        application { module() }
+
+        val response = client.get("/health")
+
+        response.status shouldBeEqualTo HttpStatusCode.OK
+        response.bodyAsText() shouldBeEqualTo "OK"
+    }
+
+    @Test
+    fun `unhandled exception returns 500 with type Internal and no stack trace`() = testApplication {
+        val fakeRepository = object : BookRepository {
+            override suspend fun findAll(): List<Book> = throw RuntimeException("boom")
+            override suspend fun findById(id: String): Book? = null
+            override suspend fun save(book: Book): Book = throw UnsupportedOperationException()
+            override suspend fun update(id: String, book: Book): Book = throw UnsupportedOperationException()
+            override suspend fun delete(id: String) = throw UnsupportedOperationException()
+            override fun stream(): Flow<Book> = emptyFlow()
+        }
+        application { module(repository = fakeRepository) }
+
+        val response = client.get("/books")
+
+        response.status shouldBeEqualTo HttpStatusCode.InternalServerError
+        val body = response.bodyAsText()
+        body shouldContain "Internal"
+        body shouldNotContain "RuntimeException"
+        body shouldNotContain "at io."
+    }
+}

--- a/ktor/rest-coroutines/src/test/kotlin/io/bluetape4k/workshop/ktor/routes/BookStreamTest.kt
+++ b/ktor/rest-coroutines/src/test/kotlin/io/bluetape4k/workshop/ktor/routes/BookStreamTest.kt
@@ -1,0 +1,110 @@
+package io.bluetape4k.workshop.ktor.routes
+
+import io.bluetape4k.workshop.ktor.AbstractKtorTest
+import io.bluetape4k.workshop.ktor.module
+import io.bluetape4k.workshop.ktor.repository.InMemoryBookRepository
+import io.ktor.client.plugins.sse.SSE
+import io.ktor.client.plugins.sse.sse
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.server.testing.testApplication
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.assertions.shouldContain
+import org.junit.jupiter.api.Test
+
+class BookStreamTest : AbstractKtorTest() {
+
+    /**
+     * Verifies SSE stream emits an event after a book is POSTed.
+     *
+     * ## Implementation notes
+     * - `testApplication` receiver is `ApplicationTestBuilder`, NOT a `CoroutineScope`.
+     * - `backgroundScope` is not accessible here; use `CoroutineScope(coroutineContext + SupervisorJob())`.
+     * - Subscribe first, then delay to let the subscription register on the hot SharedFlow.
+     */
+    @Test
+    fun `SSE stream emits event after POST`() = testApplication {
+        val preseeded = InMemoryBookRepository()
+        application { module(repository = preseeded) }
+
+        val sseClient = createClient { install(SSE) }
+        val events = Channel<String>(Channel.BUFFERED)
+
+        // testApplication block receiver = ApplicationTestBuilder (not CoroutineScope/TestScope).
+        // Neither bare launch{} nor backgroundScope.launch{} is accessible here.
+        val subscriptionScope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+        val subscription = subscriptionScope.launch {
+            sseClient.sse("/books/stream") {
+                incoming.collect { event ->
+                    event.data?.let { events.send(it) }
+                }
+            }
+        }
+
+        delay(100) // allow subscription to register on hot SharedFlow
+
+        val response = client.post("/books") {
+            contentType(ContentType.Application.Json)
+            setBody("""{"id":"stream-1","title":"Streaming Book","author":"Author","year":2024}""")
+        }
+        response.status shouldBeEqualTo HttpStatusCode.Created
+
+        val received = withTimeoutOrNull(5_000) { events.receive() }
+        received.shouldNotBeNull()
+        received shouldContain "stream-1"
+
+        subscription.cancel()
+        subscriptionScope.cancel()
+        events.close()
+    }
+
+    @Test
+    fun `SSE stream does not deliver events to late subscriber`() = testApplication {
+        val repository = InMemoryBookRepository()
+        application { module(repository = repository) }
+
+        // POST a book BEFORE subscribing — hot SharedFlow means late subscriber misses it
+        val postResponse = client.post("/books") {
+            contentType(ContentType.Application.Json)
+            setBody("""{"id":"early-1","title":"Early Book","author":"Author","year":2023}""")
+        }
+        postResponse.status shouldBeEqualTo HttpStatusCode.Created
+
+        delay(50) // ensure POST processed
+
+        val sseClient = createClient { install(SSE) }
+        val events = Channel<String>(Channel.BUFFERED)
+
+        val subscriptionScope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+        val subscription = subscriptionScope.launch {
+            sseClient.sse("/books/stream") {
+                incoming.collect { event ->
+                    event.data?.let { events.send(it) }
+                }
+            }
+        }
+
+        delay(100) // allow subscription to connect
+
+        // Late subscriber should receive nothing for the already-emitted event
+        val received = withTimeoutOrNull(500) { events.receive() }
+        received shouldBeEqualTo null
+
+        subscription.cancel()
+        subscriptionScope.cancel()
+        events.close()
+    }
+}

--- a/ktor/rest-coroutines/src/test/kotlin/io/bluetape4k/workshop/ktor/routes/HealthRoutesTest.kt
+++ b/ktor/rest-coroutines/src/test/kotlin/io/bluetape4k/workshop/ktor/routes/HealthRoutesTest.kt
@@ -1,0 +1,21 @@
+package io.bluetape4k.workshop.ktor.routes
+
+import io.bluetape4k.workshop.ktor.AbstractKtorTest
+import io.bluetape4k.workshop.ktor.module
+import io.ktor.client.request.get
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.testing.testApplication
+import io.bluetape4k.assertions.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+
+class HealthRoutesTest : AbstractKtorTest() {
+
+    @Test
+    fun `GET health returns 200 OK`() = testApplication {
+        application { module() }
+
+        val response = client.get("/health")
+
+        response.status shouldBeEqualTo HttpStatusCode.OK
+    }
+}

--- a/ktor/rest-coroutines/src/test/kotlin/io/bluetape4k/workshop/ktor/service/BookServiceTest.kt
+++ b/ktor/rest-coroutines/src/test/kotlin/io/bluetape4k/workshop/ktor/service/BookServiceTest.kt
@@ -1,0 +1,167 @@
+package io.bluetape4k.workshop.ktor.service
+
+import io.bluetape4k.workshop.ktor.AbstractKtorTest
+import io.bluetape4k.workshop.ktor.domain.Book
+import io.bluetape4k.workshop.ktor.domain.DomainError
+import io.bluetape4k.workshop.ktor.repository.InMemoryBookRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.test.runTest
+import io.bluetape4k.assertions.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+import kotlin.test.assertFailsWith
+
+class BookServiceTest : AbstractKtorTest() {
+
+    private fun service(repository: InMemoryBookRepository = InMemoryBookRepository()) =
+        BookService(repository)
+
+    private fun validBook(
+        id: String = "v-1",
+        title: String = "Valid Title",
+        author: String = "Valid Author",
+        year: Int = 2020,
+    ) = Book(id = id, title = title, author = author, year = year)
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Happy path
+    // ──────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `create returns saved book for valid input`() = runTest {
+        val svc = service()
+        val book = svc.create(validBook())
+        book.id shouldBeEqualTo "v-1"
+    }
+
+    @Test
+    fun `get returns saved book`() = runTest {
+        val svc = service()
+        svc.create(validBook(id = "get-1"))
+        val found = svc.get("get-1")
+        found.id shouldBeEqualTo "get-1"
+    }
+
+    @Test
+    fun `get throws DomainError NotFound for unknown id`() = runTest {
+        assertFailsWith<DomainError.NotFound> {
+            service().get("no-such")
+        }
+    }
+
+    @Test
+    fun `create throws DomainError Conflict for duplicate id`() = runTest {
+        val svc = service()
+        svc.create(validBook(id = "dup"))
+        assertFailsWith<DomainError.Conflict> {
+            svc.create(validBook(id = "dup"))
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // id validation
+    // ──────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `create throws IllegalArgumentException when id is blank`() = runTest {
+        assertFailsWith<IllegalArgumentException> {
+            service().create(validBook(id = ""))
+        }
+    }
+
+    @Test
+    fun `create throws IllegalArgumentException when id exceeds max length`() = runTest {
+        val longId = "x".repeat(BookService.MAX_ID_LENGTH + 1)
+        assertFailsWith<IllegalArgumentException> {
+            service().create(validBook(id = longId))
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // title validation
+    // ──────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `create throws IllegalArgumentException when title is blank`() = runTest {
+        assertFailsWith<IllegalArgumentException> {
+            service().create(validBook(title = ""))
+        }
+    }
+
+    @Test
+    fun `create throws IllegalArgumentException when title exceeds max length`() = runTest {
+        val longTitle = "t".repeat(BookService.MAX_TITLE_LENGTH + 1)
+        assertFailsWith<IllegalArgumentException> {
+            service().create(validBook(title = longTitle))
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // author validation
+    // ──────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `create throws IllegalArgumentException when author is blank`() = runTest {
+        assertFailsWith<IllegalArgumentException> {
+            service().create(validBook(author = ""))
+        }
+    }
+
+    @Test
+    fun `create throws IllegalArgumentException when author exceeds max length`() = runTest {
+        val longAuthor = "a".repeat(BookService.MAX_AUTHOR_LENGTH + 1)
+        assertFailsWith<IllegalArgumentException> {
+            service().create(validBook(author = longAuthor))
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // year validation
+    // ──────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `create throws IllegalArgumentException when year is below range`() = runTest {
+        assertFailsWith<IllegalArgumentException> {
+            service().create(validBook(year = BookService.YEAR_RANGE.first - 1))
+        }
+    }
+
+    @Test
+    fun `create throws IllegalArgumentException when year is above range`() = runTest {
+        assertFailsWith<IllegalArgumentException> {
+            service().create(validBook(year = BookService.YEAR_RANGE.last + 1))
+        }
+    }
+
+    @Test
+    fun `create accepts year at lower boundary`() = runTest {
+        val book = service().create(validBook(id = "y-low", year = BookService.YEAR_RANGE.first))
+        book.year shouldBeEqualTo BookService.YEAR_RANGE.first
+    }
+
+    @Test
+    fun `create accepts year at upper boundary`() = runTest {
+        val book = service().create(validBook(id = "y-high", year = BookService.YEAR_RANGE.last))
+        book.year shouldBeEqualTo BookService.YEAR_RANGE.last
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // delete + update
+    // ──────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `delete removes book from list`() = runTest {
+        val svc = service()
+        svc.create(validBook(id = "del-1"))
+        svc.delete("del-1")
+        svc.list().size shouldBeEqualTo 0
+    }
+
+    @Test
+    fun `update replaces book content`() = runTest {
+        val svc = service()
+        svc.create(validBook(id = "upd-1"))
+        val updated = svc.update("upd-1", validBook(id = "upd-1", title = "New Title"))
+        updated.title shouldBeEqualTo "New Title"
+    }
+}

--- a/ktor/rest-coroutines/src/test/resources/junit-platform.properties
+++ b/ktor/rest-coroutines/src/test/resources/junit-platform.properties
@@ -1,0 +1,6 @@
+junit.jupiter.extensions.autodetection.enabled=true
+junit.jupiter.testinstance.lifecycle.default=per_class
+
+junit.jupiter.execution.parallel.enabled=false
+junit.jupiter.execution.parallel.mode.default=same_thread
+junit.jupiter.execution.parallel.mode.classes.default=concurrent

--- a/ktor/rest-coroutines/src/test/resources/logback-test.xml
+++ b/ktor/rest-coroutines/src/test/resources/logback-test.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration scan="true">
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE" />
+    </root>
+
+    <logger name="io.bluetape4k.workshop" level="DEBUG" />
+    <logger name="io.ktor" level="INFO" />
+</configuration>

--- a/scripts/smoke-validate.sh
+++ b/scripts/smoke-validate.sh
@@ -50,6 +50,7 @@ case "${1:-help}" in
       :spring-security-mvc-hello:test \
       :spring-security-webflux-hello-security:test \
       :spring-security-webflux-jwt:test \
+      :ktor-rest-coroutines:test \
       :vertx-coroutines:test \
       :virtualthreads-rules:test \
       --continue"
@@ -147,7 +148,7 @@ case "${1:-help}" in
   stale-check)
     echo "=== Gradle project count ==="
     count=$("$GRADLEW" projects --console=plain 2>/dev/null | grep -Ec "Project ':" || true)
-    expected=69
+    expected=76
     echo "Active modules: $count (expected: $expected)"
     [ "$count" -eq "$expected" ] || echo "WARNING: Gradle project count drifted."
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -28,6 +28,7 @@ includeModules("image-processing", false, true)
 includeModules("io", false, false)
 includeModules("json", false, false)
 includeModules("kotlin", false, true)
+includeModules("ktor", false, true)
 includeModules("leader", false, true)   // leader-leader-election: distributed leader election workshop example
 // includeModules("mapping", false, true)  // archived: mapping/mapstruct removed in #78 (low BT value)
 includeModules("messaging", false, true)


### PR DESCRIPTION
## Summary

Implements the `ktor/rest-coroutines` workshop module — a Kotlin-first Ktor 3 REST API example demonstrating idiomatic coroutine-first HTTP, SSE streaming, and NDJSON export without Spring or reactive streams.

Closes #14

---

## Changes

### New module: `ktor/rest-coroutines`

**Domain**: `Book` (@Serializable + java.io.Serializable), `DomainError` sealed class

**Repository**: `InMemoryBookRepository` — ConcurrentHashMap + MutableSharedFlow with BufferOverflow.SUSPEND + 5s emit timeout

**Service**: `BookService` — validates id/title/author/year via bluetape4k require* extensions

**Application wiring**: `ApplicationModule` — CallLogging→ContentNegotiation→SSE→StatusPages; `internal val AppJson`; StatusPages with `"type"` field on all error responses

**Routes**:
- GET/POST/PUT/DELETE /books (CRUD)
- GET /books/export — NDJSON via Jackson 3 + respondBytesWriter
- GET /books/stream — SSE at top-level routing scope
- GET /health — liveness probe

### Catalog + settings
- `gradle/libs.versions.toml` — 11 Ktor 3 library aliases
- `settings.gradle.kts` — includeModules("ktor", false, true)
- `scripts/smoke-validate.sh` — added :ktor-rest-coroutines:test; updated expected=76

---

## Test Results

```
InMemoryBookRepositoryTest : 10 tests, 0 failures
BookRoutesTest             : 12 tests, 0 failures
BookStreamTest             :  2 tests, 0 failures
HealthRoutesTest           :  1 tests, 0 failures
BookServiceTest            : 16 tests, 0 failures
Total                       : 41 tests, 0 failures
```

Build: `./gradlew :ktor-rest-coroutines:build` → BUILD SUCCESSFUL

---

## Key Implementation Notes

- `sse("/books/stream")` — explicit path; bare `sse {}` mounts at application root
- `withTimeoutOrNull(5_000)` around `sharedFlow.emit()` prevents stalled SSE subscriber blocking HTTP handlers
- `testApplication {}` SSE test uses `CoroutineScope(Dispatchers.Default + SupervisorJob())` — `ApplicationTestBuilder.coroutineContext` is String (Ktor DSL), not CoroutineContext
- `KLoggingChannel` → `io.bluetape4k.logging.coroutines.KLoggingChannel`
- bluetape4k Logger lambda extensions require explicit import: `import io.bluetape4k.logging.warn`