### PR TITLE
feat: leader-election advanced patterns — LockExtender, LockAssert, SuspendLeader, EventListener (PR-A)

### DIFF
--- a/docs/lessons/2026-05-25-leader-election-advanced-patterns.md
+++ b/docs/lessons/2026-05-25-leader-election-advanced-patterns.md
@@ -1,0 +1,99 @@
+# Lessons — leader-election 고급 패턴 예제 (PR-A)
+
+**날짜**: 2026-05-25  
+**브랜치**: feat/leader-election-advanced  
+**이슈**: #10 bluetape4k-leader 예제 제작
+
+---
+
+## 작업 요약
+
+`leader/leader-election` 모듈에 `bluetape4k-leader` v0.2.1의 고급 API 예제를 추가했다:
+- `LockExtender.extendActiveLock()` — 잠금 임차 연장
+- `LockAssert.assertLocked()` / `isLocked()` — 잠금 소유 런타임 검증
+- `LettuceSuspendLeaderElector` — 코루틴 기반 리더 선출
+- `ListeningLeaderElector` + `events: Flow` / `LeaderElectionListener` — 이벤트 옵저버
+
+---
+
+## 핵심 발견사항
+
+### 1. `LeaderElectionListener` 콜백 시그니처에 `state` 파라미터 없음
+
+- **증상**: 컴파일 오류 — `onElected(lockName: String, state: LeaderState)` 시그니처로 구현 시 "Nothing to override"
+- **원인**: 실제 인터페이스 시그니처는 `onElected(lockName: String)` (state 파라미터 없음)
+- **교훈**: API 시그니처를 IDE 자동완성 또는 소스 jar 디컴파일로 먼저 확인해야 함
+
+### 2. `SuspendedJobTester`는 `io.bluetape4k.junit5.coroutines` 패키지에 있음
+
+- **잘못된 import**: `io.bluetape4k.junit5.concurrency.SuspendedJobTester`
+- **올바른 import**: `io.bluetape4k.junit5.coroutines.SuspendedJobTester`
+- **교훈**: `bluetape4k-junit5` 소스 jar에서 실제 패키지 경로 확인 필수
+
+### 3. `SuspendedJobTester.run()`은 `suspend fun` → `runBlocking` 필요
+
+- 비가상 시간 테스트(실제 Redis I/O 포함)이므로 `runTest` 대신 `runBlocking` 사용
+- `runTest`는 가상 시간을 진행시켜 `delay(300)` 같은 실제 잠금 대기를 건너뜀
+
+### 4. 동시성 테스트: sequential 실행은 contention이 아님
+
+- **잘못된 패턴**: `elector1.runIfLeader(...)` → `elector2.runIfLeader(...)` (순차 실행)
+  - elector1이 먼저 완료되면 lock 해제 → elector2가 정상 획득
+- **올바른 패턴**: elector1 body 내부에서 elector2 시도 (중첩 패턴)
+  ```kotlin
+  val result1 = elector1.runIfLeader(lockName) {
+      result2 = elector2.runIfLeader(lockName) { "follower" }  // 잠금 보유 중 경합
+      "leader"
+  }
+  ```
+
+### 5. Spring: 동일 타입 bean 2개 → `@Qualifier` 필수
+
+- `StatefulRedisConnection<String, String>` bean 2개 (`lettuceConnection`, `lettuceSuspendConnection`)
+- 파라미터 이름 매칭은 `-parameters` 컴파일러 플래그 의존 → 리팩토링에 취약
+- **명시적 `@Qualifier`가 항상 안전**
+
+### 6. `CancellationException` swallow 주의
+
+- Flow collector의 `catch (e: Exception)` 블록이 `CancellationException`을 삼킴
+- `scope.cancel()` 시 정상 취소가 오류로 로깅됨
+- 항상 `catch (e: CancellationException) { throw e }` 먼저 추가
+
+### 7. SharedFlow `replay=0` 경쟁 조건
+
+- `scope.launch { flow.collect {} }` 후 즉시 emit 시 subscriber가 아직 등록 전일 수 있음
+- `replay=0`이면 구독 전 이벤트는 유실됨
+- **해결**: emit 전 `Thread.sleep(100)` 또는 `subscriptionCount.first { it > 0 }` 대기
+
+### 8. `LettuceSuspendLeaderElector`에는 별도 connection 필요
+
+- 동일 connection을 blocking/suspend elector가 공유하면 pipelined command ordering 오류 발생
+- **패턴**: Spring config에 `lettuceSuspendConnection` 별도 bean 선언
+
+---
+
+## 테스트 결과
+
+```
+Module : :leader-leader-election
+Result : 26 passing, 0 failed, 0 skipped
+Command: ./gradlew :leader-leader-election:test --no-daemon
+```
+
+---
+
+## 코드 리뷰 결과
+
+| 우선순위 | 이슈 | 처리 |
+|---------|------|------|
+| HIGH | CancellationException swallowed in Flow collector | ✅ 수정 |
+| HIGH | `assertThrows` → `assertFailsWith` | ✅ 수정 |
+| HIGH | SharedFlow replay=0 race condition | ✅ 수정 |
+| MEDIUM | suspendLeaderElector missing @Qualifier | ✅ 수정 |
+
+---
+
+## 미래 작업
+
+- **PR-B**: `leader/leader-zookeeper/` 모듈 — ZooKeeper backend 예제 (Type-A Full Design)
+- **PR-C**: `leader/leader-k8s/` 모듈 — Kubernetes leader election 예제 (Type-A Full Design)

--- a/leader/leader-election/build.gradle.kts
+++ b/leader/leader-election/build.gradle.kts
@@ -38,7 +38,9 @@ dependencies {
 
     // Test
     testImplementation(project(":shared"))
+    testImplementation(libs.bluetape4k.coroutines)
     testImplementation(libs.bluetape4k.junit5)
+    testImplementation(libs.kotlinx.coroutines.test.lib)
     testImplementation(libs.bluetape4k.testcontainers)
     testImplementation(libs.bluetape4k.assertions)
     testImplementation(libs.spring.boot.starter.test) {

--- a/leader/leader-election/src/main/kotlin/io/bluetape4k/workshop/leader/config/LeaderElectionConfig.kt
+++ b/leader/leader-election/src/main/kotlin/io/bluetape4k/workshop/leader/config/LeaderElectionConfig.kt
@@ -1,12 +1,15 @@
 package io.bluetape4k.workshop.leader.config
 
-import io.bluetape4k.leader.LeaderElector
-import io.bluetape4k.leader.lettuce.LettuceLeaderElector
 import io.bluetape4k.leader.LeaderElectionOptions
-import io.bluetape4k.logging.*
+import io.bluetape4k.leader.ListeningLeaderElector
+import io.bluetape4k.leader.lettuce.LettuceLeaderElector
+import io.bluetape4k.leader.lettuce.LettuceSuspendLeaderElector
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
 import io.lettuce.core.RedisClient
 import io.lettuce.core.api.StatefulRedisConnection
 import io.lettuce.core.codec.StringCodec
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -15,14 +18,20 @@ import kotlin.time.toKotlinDuration
 /**
  * Spring Boot configuration for the leader election infrastructure.
  *
- * Wires [RedisClient], [StatefulRedisConnection], and [LeaderElector] as Spring beans.
+ * Wires [RedisClient], [StatefulRedisConnection], [ListeningLeaderElector], and
+ * [LettuceSuspendLeaderElector] as Spring beans.
  *
  * ## Behavior / Contract
  * - [redisClient] is shut down via `destroyMethod = "shutdown"` on context close.
- * - [lettuceConnection] is closed via `destroyMethod = "close"` on context close.
- * - [LeaderElectionOptions] uses `kotlin.time.Duration`; [LeaderElectionProperties] carries
- *   `java.time.Duration` (Spring `@ConfigurationProperties` binding). The conversion
- *   `toKotlinDuration()` is applied explicitly here.
+ * - [lettuceConnection] and [lettuceSuspendConnection] are closed via `destroyMethod = "close"`.
+ * - The primary [leaderElector] bean is a [ListeningLeaderElector] wrapping a
+ *   [LettuceLeaderElector]. All `runIfLeader` calls emit [io.bluetape4k.leader.LeaderElectionEvent]s
+ *   observable via [ListeningLeaderElector.events] or [io.bluetape4k.leader.LeaderElectionListener].
+ * - [suspendLeaderElector] opens a second dedicated connection to avoid shared pipelined
+ *   command state with the blocking elector.
+ * - [LeaderElectionOptions] requires `kotlin.time.Duration`; [LeaderElectionProperties] carries
+ *   `java.time.Duration` (Spring `@ConfigurationProperties` binding). `toKotlinDuration()`
+ *   conversion is applied explicitly here.
  */
 @Configuration
 @EnableConfigurationProperties(LeaderElectionProperties::class)
@@ -41,28 +50,63 @@ class LeaderElectionConfig {
     }
 
     /**
-     * Opens a [StatefulRedisConnection] from the given [RedisClient].
+     * Opens the primary [StatefulRedisConnection] for the blocking [LettuceLeaderElector].
      * Closed via `destroyMethod = "close"` on Spring context close.
      */
     @Bean(destroyMethod = "close")
-    fun lettuceConnection(client: RedisClient): StatefulRedisConnection<String, String> {
-        return client.connect(StringCodec.UTF8)
-    }
+    fun lettuceConnection(client: RedisClient): StatefulRedisConnection<String, String> =
+        client.connect(StringCodec.UTF8)
 
     /**
-     * Creates a [LeaderElector] backed by Lettuce/Redis.
+     * Opens a dedicated [StatefulRedisConnection] for [LettuceSuspendLeaderElector].
+     *
+     * A separate connection prevents the blocking and suspend electors from sharing
+     * pipelined command state, which can cause ordering issues under concurrent use.
+     */
+    @Bean(name = ["lettuceSuspendConnection"], destroyMethod = "close")
+    fun lettuceSuspendConnection(client: RedisClient): StatefulRedisConnection<String, String> =
+        client.connect(StringCodec.UTF8)
+
+    /**
+     * Creates a [ListeningLeaderElector] that wraps a [LettuceLeaderElector].
+     *
+     * Using [ListeningLeaderElector] as the primary [io.bluetape4k.leader.LeaderElector] bean
+     * ensures all `runIfLeader` calls — including those in
+     * [io.bluetape4k.workshop.leader.job.LeaderScheduledJobService] — emit
+     * [io.bluetape4k.leader.LeaderElectionEvent]s observable by
+     * [io.bluetape4k.workshop.leader.service.LeaderEventListenerService].
      *
      * IMPORTANT: [LeaderElectionOptions] requires `kotlin.time.Duration`, while
      * [LeaderElectionProperties] stores `java.time.Duration` (Spring binding).
-     * Explicit `toKotlinDuration()` conversion is mandatory here.
+     * Explicit `toKotlinDuration()` conversion is mandatory.
      */
     @Bean
     fun leaderElector(
-        connection: StatefulRedisConnection<String, String>,
+        @Qualifier("lettuceConnection") connection: StatefulRedisConnection<String, String>,
         props: LeaderElectionProperties,
-    ): LeaderElector = LettuceLeaderElector(
-        connection,
-        LeaderElectionOptions(
+    ): ListeningLeaderElector = ListeningLeaderElector(
+        LettuceLeaderElector(
+            connection,
+            LeaderElectionOptions(
+                waitTime = props.waitTime.toKotlinDuration(),
+                leaseTime = props.leaseTime.toKotlinDuration(),
+            ),
+        )
+    )
+
+    /**
+     * Creates a [LettuceSuspendLeaderElector] for coroutine-based leader election.
+     *
+     * Uses a dedicated [lettuceSuspendConnection] to avoid sharing pipelined command state
+     * with the blocking [leaderElector].
+     */
+    @Bean
+    fun suspendLeaderElector(
+        lettuceSuspendConnection: StatefulRedisConnection<String, String>,
+        props: LeaderElectionProperties,
+    ): LettuceSuspendLeaderElector = LettuceSuspendLeaderElector(
+        connection = lettuceSuspendConnection,
+        options = LeaderElectionOptions(
             waitTime = props.waitTime.toKotlinDuration(),
             leaseTime = props.leaseTime.toKotlinDuration(),
         ),

--- a/leader/leader-election/src/main/kotlin/io/bluetape4k/workshop/leader/config/LeaderElectionConfig.kt
+++ b/leader/leader-election/src/main/kotlin/io/bluetape4k/workshop/leader/config/LeaderElectionConfig.kt
@@ -102,7 +102,7 @@ class LeaderElectionConfig {
      */
     @Bean
     fun suspendLeaderElector(
-        lettuceSuspendConnection: StatefulRedisConnection<String, String>,
+        @Qualifier("lettuceSuspendConnection") lettuceSuspendConnection: StatefulRedisConnection<String, String>,
         props: LeaderElectionProperties,
     ): LettuceSuspendLeaderElector = LettuceSuspendLeaderElector(
         connection = lettuceSuspendConnection,

--- a/leader/leader-election/src/main/kotlin/io/bluetape4k/workshop/leader/job/LockAssertJob.kt
+++ b/leader/leader-election/src/main/kotlin/io/bluetape4k/workshop/leader/job/LockAssertJob.kt
@@ -1,0 +1,57 @@
+package io.bluetape4k.workshop.leader.job
+
+import io.bluetape4k.leader.LockAssert
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.info
+import io.bluetape4k.support.requireNotBlank
+import org.springframework.stereotype.Component
+
+/**
+ * Leader-guarded job that demonstrates lock ownership verification using [LockAssert].
+ *
+ * [LockAssert.assertLocked] and [LockAssert.isLocked] let job code verify at runtime
+ * that the distributed lock is still held by this instance. This is useful for:
+ * - Early-exit guards before expensive operations.
+ * - Defensive checks in helper methods that assume leader ownership.
+ * - Integration tests verifying that AOP wiring propagates the lock handle correctly.
+ *
+ * ## Behavior / Contract
+ * - [LockAssert.assertLocked] throws [IllegalStateException] when called outside of a
+ *   `runIfLeader` context (i.e., lock handle not present on the current thread).
+ * - [LockAssert.isLocked] returns `false` rather than throwing, and is safe to call
+ *   anywhere as a guard condition.
+ * - This bean is registered as `@Component` so it is auto-injected into
+ *   [LeaderScheduledJobService] via `List<LeaderGuardedJob>`.
+ */
+@Component
+class LockAssertJob : LeaderGuardedJob {
+
+    override val lockName = "leader:lock-assert-demo"
+
+    init {
+        lockName.requireNotBlank("lockName")
+    }
+
+    override fun execute() {
+        log.info { "[LockAssertJob] Starting — verifying lock ownership via LockAssert" }
+
+        // Verify this instance holds the distributed lock before doing real work.
+        // assertLocked() throws IllegalStateException if called outside runIfLeader context.
+        LockAssert.assertLocked()
+        log.info { "[LockAssertJob] assertLocked() passed — this instance is the elected leader" }
+
+        // isLocked() is a non-throwing alternative for conditional guards.
+        if (LockAssert.isLocked()) {
+            log.info { "[LockAssertJob] isLocked() == true — safe to proceed with leader-only work" }
+        }
+
+        // Named variant: assertLocked(lockName) verifies ownership of a specific lock.
+        LockAssert.assertLocked(lockName)
+        log.info { "[LockAssertJob] assertLocked(\"$lockName\") passed" }
+
+        Thread.sleep(20)
+        log.info { "[LockAssertJob] Job complete" }
+    }
+
+    companion object : KLogging()
+}

--- a/leader/leader-election/src/main/kotlin/io/bluetape4k/workshop/leader/job/LockExtenderJob.kt
+++ b/leader/leader-election/src/main/kotlin/io/bluetape4k/workshop/leader/job/LockExtenderJob.kt
@@ -1,0 +1,66 @@
+package io.bluetape4k.workshop.leader.job
+
+import io.bluetape4k.leader.LockExtender
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import io.bluetape4k.logging.info
+import io.bluetape4k.logging.warn
+import io.bluetape4k.support.requireNotBlank
+import org.springframework.stereotype.Component
+import java.time.Duration
+
+/**
+ * Leader-guarded job that demonstrates runtime lease extension using [LockExtender].
+ *
+ * When a job body runs longer than the configured lease TTL, the leader lock can expire
+ * before the job finishes, allowing another instance to acquire the lock and cause
+ * split-brain execution. [LockExtender.extendActiveLock] prevents this by extending
+ * the current lease from within the job body.
+ *
+ * ## Behavior / Contract
+ * - Calls [LockExtender.extendActiveLock] after the first work phase to renew the lease.
+ * - Returns `false` (extension failed) only when the lock is no longer held by this instance
+ *   (e.g., another node already took over). The job logs a warning but continues, demonstrating
+ *   the check pattern.
+ * - This bean is registered as `@Component` so it is auto-injected into
+ *   [LeaderScheduledJobService] via `List<LeaderGuardedJob>`.
+ *
+ * ## Usage
+ * In production, pair a long-running job with `LockExtender.extendActiveLock()` calls
+ * after each major phase, using the remaining estimated runtime as the extension delta.
+ */
+@Component
+class LockExtenderJob : LeaderGuardedJob {
+
+    override val lockName = "leader:lock-extender-demo"
+
+    init {
+        lockName.requireNotBlank("lockName")
+    }
+
+    override fun execute() {
+        log.info { "[LockExtenderJob] Starting — simulating a long-running leader job" }
+
+        // Phase 1: first unit of work
+        Thread.sleep(50)
+        log.debug { "[LockExtenderJob] Phase 1 complete" }
+
+        // Extend lease before Phase 2 to avoid expiry mid-execution.
+        // extendActiveLock uses the current thread's LeaderLockHandle captured by the aspect.
+        val extended = LockExtender.extendActiveLock(EXTENSION_DURATION)
+        if (extended) {
+            log.info { "[LockExtenderJob] Lease extended by $EXTENSION_DURATION — continuing Phase 2" }
+        } else {
+            log.warn { "[LockExtenderJob] Lease extension failed (lock not held or lost) — proceeding anyway for demo" }
+        }
+
+        // Phase 2: second unit of work
+        Thread.sleep(50)
+        log.info { "[LockExtenderJob] Phase 2 complete — job finished" }
+    }
+
+    companion object : KLogging() {
+        /** Extension duration added to the active lease between work phases. */
+        val EXTENSION_DURATION: Duration = Duration.ofSeconds(30)
+    }
+}

--- a/leader/leader-election/src/main/kotlin/io/bluetape4k/workshop/leader/service/LeaderEventListenerService.kt
+++ b/leader/leader-election/src/main/kotlin/io/bluetape4k/workshop/leader/service/LeaderEventListenerService.kt
@@ -8,6 +8,7 @@ import io.bluetape4k.logging.info
 import io.bluetape4k.logging.warn
 import jakarta.annotation.PostConstruct
 import jakarta.annotation.PreDestroy
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -83,6 +84,8 @@ class LeaderEventListenerService(
                             log.info { "[EventFlow] Skipped '${event.lockName}'" }
                     }
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 log.warn(e) { "[EventFlow] Event flow collection stopped unexpectedly" }
             }

--- a/leader/leader-election/src/main/kotlin/io/bluetape4k/workshop/leader/service/LeaderEventListenerService.kt
+++ b/leader/leader-election/src/main/kotlin/io/bluetape4k/workshop/leader/service/LeaderEventListenerService.kt
@@ -1,0 +1,100 @@
+package io.bluetape4k.workshop.leader.service
+
+import io.bluetape4k.leader.LeaderElectionEvent
+import io.bluetape4k.leader.LeaderElectionListener
+import io.bluetape4k.leader.ListeningLeaderElector
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.info
+import io.bluetape4k.logging.warn
+import jakarta.annotation.PostConstruct
+import jakarta.annotation.PreDestroy
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import org.springframework.stereotype.Service
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Service that observes leader election events emitted by [ListeningLeaderElector].
+ *
+ * Demonstrates two complementary event consumption patterns:
+ * 1. **[LeaderElectionListener]** — callback interface added via [ListeningLeaderElector.addListener].
+ *    Runs synchronously on the thread that calls `runIfLeader`; suitable for lightweight side effects
+ *    such as metrics updates or state flags.
+ * 2. **[ListeningLeaderElector.events] Flow** — cold-to-hot shared flow collected in a background
+ *    coroutine. Suitable for async fan-out, reactive pipelines, or SSE streams.
+ *
+ * ## Behavior / Contract
+ * - The [LeaderElectionListener] is registered in [init] and removed in [close].
+ * - The Flow collection coroutine is started in [init] and cancelled in [close].
+ * - [electedCount], [revokedCount], and [skippedCount] are exposed for testing.
+ * - Errors in the Flow collector are logged and do not propagate to the elector.
+ */
+@Service
+class LeaderEventListenerService(
+    private val listeningLeaderElector: ListeningLeaderElector,
+) {
+    val electedCount = AtomicInteger(0)
+    val revokedCount = AtomicInteger(0)
+    val skippedCount = AtomicInteger(0)
+
+    private val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+    private var listenerHandle: AutoCloseable? = null
+
+    companion object : KLogging()
+
+    /**
+     * Registers the callback listener and starts the Flow collector after bean construction.
+     */
+    @PostConstruct
+    fun init() {
+        // Pattern 1: LeaderElectionListener callback — synchronous, lightweight
+        listenerHandle = listeningLeaderElector.addListener(object : LeaderElectionListener {
+            override fun onElected(lockName: String) {
+                electedCount.incrementAndGet()
+                log.info { "[EventListener] ELECTED for '$lockName' — total elected=${electedCount.get()}" }
+            }
+
+            override fun onRevoked(lockName: String) {
+                revokedCount.incrementAndGet()
+                log.info { "[EventListener] REVOKED for '$lockName' — total revoked=${revokedCount.get()}" }
+            }
+
+            override fun onSkipped(lockName: String) {
+                skippedCount.incrementAndGet()
+                log.info { "[EventListener] SKIPPED '$lockName' — not elected this round" }
+            }
+        })
+
+        // Pattern 2: Flow collection — async, fan-out capable
+        scope.launch {
+            try {
+                listeningLeaderElector.events.collect { event ->
+                    when (event) {
+                        is LeaderElectionEvent.Elected ->
+                            log.info { "[EventFlow] Elected for '${event.lockName}' leaderId=${event.leaderId}" }
+
+                        is LeaderElectionEvent.Revoked ->
+                            log.info { "[EventFlow] Revoked for '${event.lockName}'" }
+
+                        is LeaderElectionEvent.Skipped ->
+                            log.info { "[EventFlow] Skipped '${event.lockName}'" }
+                    }
+                }
+            } catch (e: Exception) {
+                log.warn(e) { "[EventFlow] Event flow collection stopped unexpectedly" }
+            }
+        }
+    }
+
+    /**
+     * Removes the listener and cancels the Flow collector on Spring context close.
+     */
+    @PreDestroy
+    fun close() {
+        runCatching { listenerHandle?.close() }
+        runCatching { scope.cancel() }
+    }
+}

--- a/leader/leader-election/src/main/kotlin/io/bluetape4k/workshop/leader/service/SuspendLeaderService.kt
+++ b/leader/leader-election/src/main/kotlin/io/bluetape4k/workshop/leader/service/SuspendLeaderService.kt
@@ -1,0 +1,71 @@
+package io.bluetape4k.workshop.leader.service
+
+import io.bluetape4k.leader.lettuce.LettuceSuspendLeaderElector
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import io.bluetape4k.logging.info
+import kotlinx.coroutines.delay
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Service
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Leader election service demonstrating coroutine-first leadership using [LettuceSuspendLeaderElector].
+ *
+ * In multi-instance deployments, `suspend` leader jobs eliminate blocking while waiting
+ * for lock acquisition. Only the elected leader instance executes the work body;
+ * all others receive `null` from `runIfLeader` and skip silently.
+ *
+ * ## Behavior / Contract
+ * - [runIfLeader] returns `null` when this instance did not win the lock (skipped).
+ * - [runIfLeader] suspends the caller during lock-acquisition wait without blocking a thread.
+ * - The `@Scheduled` method wraps the coroutine call with `kotlinx.coroutines.runBlocking`
+ *   at the Spring scheduler boundary (blocking is acceptable here because the scheduler
+ *   thread is dedicated to this invocation).
+ * - [executionCount] is exposed for testing; not for production use.
+ */
+@Service
+class SuspendLeaderService(
+    private val suspendLeaderElector: LettuceSuspendLeaderElector,
+) {
+    /** Number of times this instance was elected and executed the leader action. */
+    val executionCount = AtomicInteger(0)
+
+    companion object : KLogging() {
+        const val LOCK_NAME = "leader:suspend-demo"
+    }
+
+    /**
+     * Executes a coroutine leader action.
+     *
+     * Returns the action result when this instance is elected, or `null` when skipped.
+     * Suitable for direct use in tests with `runTest {}`.
+     */
+    suspend fun runLeaderWork(): String? =
+        suspendLeaderElector.runIfLeader(LOCK_NAME) {
+            log.info { "[SuspendLeaderService] Coroutine leader work started" }
+            delay(20) // simulate async I/O without blocking a thread
+            executionCount.incrementAndGet()
+            log.info { "[SuspendLeaderService] Coroutine leader work complete (total=${executionCount.get()})" }
+            "done"
+        }
+
+    /**
+     * Scheduled entry point — bridges the blocking Spring scheduler thread into a coroutine.
+     *
+     * Uses `kotlinx.coroutines.runBlocking` at the scheduler boundary only.
+     * All actual leader work runs as a suspend function via [runLeaderWork].
+     */
+    @Scheduled(fixedDelayString = "\${leader.suspend-job-fixed-delay:PT15S}")
+    fun runScheduled() {
+        log.debug { "[SuspendLeaderService] Scheduled trigger — entering coroutine" }
+        kotlinx.coroutines.runBlocking {
+            val result = runLeaderWork()
+            if (result != null) {
+                log.info { "[SuspendLeaderService] [LEADER] Scheduled coroutine job executed: result=$result" }
+            } else {
+                log.debug { "[SuspendLeaderService] [SKIPPED] Not the elected leader this round" }
+            }
+        }
+    }
+}

--- a/leader/leader-election/src/test/kotlin/io/bluetape4k/workshop/leader/AbstractLeaderElectionTest.kt
+++ b/leader/leader-election/src/test/kotlin/io/bluetape4k/workshop/leader/AbstractLeaderElectionTest.kt
@@ -1,7 +1,9 @@
 package io.bluetape4k.workshop.leader
 
-import io.bluetape4k.leader.lettuce.LettuceLeaderElector
 import io.bluetape4k.leader.LeaderElectionOptions
+import io.bluetape4k.leader.ListeningLeaderElector
+import io.bluetape4k.leader.lettuce.LettuceLeaderElector
+import io.bluetape4k.leader.lettuce.LettuceSuspendLeaderElector
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.testcontainers.storage.RedisServer
 import io.lettuce.core.RedisClient
@@ -48,4 +50,14 @@ abstract class AbstractLeaderElectionTest {
     protected fun newElector(
         options: LeaderElectionOptions = defaultOptions,
     ): LettuceLeaderElector = LettuceLeaderElector(newConnection(), options)
+
+    /** Creates a new [LettuceSuspendLeaderElector] with its own connection and the given options. */
+    protected fun newSuspendElector(
+        options: LeaderElectionOptions = defaultOptions,
+    ): LettuceSuspendLeaderElector = LettuceSuspendLeaderElector(newConnection(), options)
+
+    /** Creates a new [ListeningLeaderElector] wrapping a [LettuceLeaderElector]. */
+    protected fun newListeningElector(
+        options: LeaderElectionOptions = defaultOptions,
+    ): ListeningLeaderElector = ListeningLeaderElector(newElector(options))
 }

--- a/leader/leader-election/src/test/kotlin/io/bluetape4k/workshop/leader/LeaderEventListenerTest.kt
+++ b/leader/leader-election/src/test/kotlin/io/bluetape4k/workshop/leader/LeaderEventListenerTest.kt
@@ -1,0 +1,121 @@
+package io.bluetape4k.workshop.leader
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeGreaterOrEqualTo
+import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.leader.LeaderElectionEvent
+import io.bluetape4k.leader.LeaderElectionListener
+import io.bluetape4k.leader.ListeningLeaderElector
+import io.bluetape4k.workshop.leader.service.LeaderEventListenerService
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import java.util.UUID
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Tests for [LeaderEventListenerService] and the [ListeningLeaderElector] event API.
+ *
+ * ## Key behaviours verified
+ * - [LeaderElectionListener.onElected] is called when the lock is acquired.
+ * - [LeaderElectionListener.onSkipped] is called when the lock is not acquired.
+ * - [ListeningLeaderElector.events] Flow emits [LeaderElectionEvent.Elected] on acquisition.
+ * - [LeaderEventListenerService] wires both the listener and the Flow collector correctly.
+ */
+class LeaderEventListenerTest : AbstractLeaderElectionTest() {
+
+    @Test
+    fun `onElected callback is called when lock is acquired`() {
+        val listeningElector = newListeningElector()
+        val electedCount = AtomicInteger(0)
+
+        val handle = listeningElector.addListener(object : LeaderElectionListener {
+            override fun onElected(lockName: String) {
+                electedCount.incrementAndGet()
+            }
+        })
+
+        val lockName = "test:event:elected:${UUID.randomUUID()}"
+        repeat(3) {
+            listeningElector.runIfLeader(lockName) { "work" }
+        }
+
+        handle.close()
+
+        electedCount.get() shouldBeEqualTo 3
+    }
+
+    @Test
+    fun `onSkipped callback is called when lock is held by another elector`() {
+        val lockName = "test:event:skipped:${UUID.randomUUID()}"
+        val followerElector = newListeningElector()
+        val skippedCount = AtomicInteger(0)
+
+        followerElector.addListener(object : LeaderElectionListener {
+            override fun onSkipped(lockName: String) {
+                skippedCount.incrementAndGet()
+            }
+        })
+
+        // Leader holds the lock while follower tries to acquire and gets skipped.
+        val leaderElector = newElector()
+        leaderElector.runIfLeader(lockName) {
+            followerElector.runIfLeader(lockName) { "should-skip" }
+        }
+
+        skippedCount.get() shouldBeGreaterOrEqualTo 1
+    }
+
+    @Test
+    fun `events Flow emits Elected event when lock is acquired`() {
+        val listeningElector = newListeningElector()
+        val lockName = "test:event:flow:${UUID.randomUUID()}"
+        val receivedEvents = Channel<LeaderElectionEvent>(Channel.BUFFERED)
+        val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+
+        scope.launch {
+            listeningElector.events.collect { event ->
+                receivedEvents.trySend(event)
+            }
+        }
+
+        listeningElector.runIfLeader(lockName) { "work" }
+
+        // Allow the shared flow emission to propagate to the collector.
+        val received = runBlocking {
+            withTimeoutOrNull(2_000) { receivedEvents.receive() }
+        }
+
+        received.shouldNotBeNull()
+        (received is LeaderElectionEvent.Elected) shouldBeEqualTo true
+
+        scope.cancel()
+        receivedEvents.close()
+    }
+
+    @Test
+    fun `LeaderEventListenerService counts events from ListeningLeaderElector`() {
+        val listeningElector = newListeningElector()
+        val service = LeaderEventListenerService(listeningElector)
+        service.init()
+
+        val lockName = "test:event:service:${UUID.randomUUID()}"
+        repeat(3) {
+            listeningElector.runIfLeader(lockName) { "work" }
+        }
+
+        // Small delay to allow the background Flow collector to process events.
+        Thread.sleep(200)
+
+        service.electedCount.get() shouldBeEqualTo 3
+        service.skippedCount.get() shouldBeEqualTo 0
+
+        service.close()
+    }
+}

--- a/leader/leader-election/src/test/kotlin/io/bluetape4k/workshop/leader/LeaderEventListenerTest.kt
+++ b/leader/leader-election/src/test/kotlin/io/bluetape4k/workshop/leader/LeaderEventListenerTest.kt
@@ -85,6 +85,10 @@ class LeaderEventListenerTest : AbstractLeaderElectionTest() {
             }
         }
 
+        // Allow the SharedFlow collector to subscribe before emitting.
+        // SharedFlow has replay=0; events emitted before subscription are lost.
+        Thread.sleep(100)
+
         listeningElector.runIfLeader(lockName) { "work" }
 
         // Allow the shared flow emission to propagate to the collector.

--- a/leader/leader-election/src/test/kotlin/io/bluetape4k/workshop/leader/LockAssertTest.kt
+++ b/leader/leader-election/src/test/kotlin/io/bluetape4k/workshop/leader/LockAssertTest.kt
@@ -1,0 +1,72 @@
+package io.bluetape4k.workshop.leader
+
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.leader.LockAssert
+import io.bluetape4k.workshop.leader.job.LockAssertJob
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.util.UUID
+
+/**
+ * Tests for [LockAssertJob] and the [LockAssert] API.
+ *
+ * ## Key behaviours verified
+ * - [LockAssert.assertLocked] passes silently inside `runIfLeader`.
+ * - [LockAssert.assertLocked] throws [IllegalStateException] outside any leader scope.
+ * - [LockAssert.isLocked] returns `true` inside scope and `false` outside.
+ * - [LockAssertJob.execute] completes without error when running as leader.
+ */
+class LockAssertTest : AbstractLeaderElectionTest() {
+
+    @Test
+    fun `assertLocked passes silently inside runIfLeader`() {
+        val lockName = "test:assert:${UUID.randomUUID()}"
+        val elector = newElector()
+
+        val result = elector.runIfLeader(lockName) {
+            LockAssert.assertLocked()          // must not throw
+            LockAssert.assertLocked(lockName)  // named variant must not throw
+            "ok"
+        }
+
+        result.shouldNotBeNull()
+    }
+
+    @Test
+    fun `assertLocked throws IllegalStateException outside runIfLeader`() {
+        assertThrows<IllegalStateException> {
+            LockAssert.assertLocked()
+        }
+    }
+
+    @Test
+    fun `isLocked returns true inside runIfLeader`() {
+        val lockName = "test:assert:locked:${UUID.randomUUID()}"
+        val elector = newElector()
+
+        val isLocked = elector.runIfLeader(lockName) {
+            LockAssert.isLocked()
+        }
+
+        isLocked.shouldNotBeNull()
+        isLocked.shouldBeTrue()
+    }
+
+    @Test
+    fun `isLocked returns false outside runIfLeader`() {
+        LockAssert.isLocked().shouldBeFalse()
+    }
+
+    @Test
+    fun `LockAssertJob executes successfully as leader`() {
+        val lockName = LockAssertJob().lockName
+        val elector = newElector()
+        val job = LockAssertJob()
+
+        val result = elector.runIfLeader(lockName) { job.execute() }
+
+        result.shouldNotBeNull()
+    }
+}

--- a/leader/leader-election/src/test/kotlin/io/bluetape4k/workshop/leader/LockAssertTest.kt
+++ b/leader/leader-election/src/test/kotlin/io/bluetape4k/workshop/leader/LockAssertTest.kt
@@ -5,8 +5,8 @@ import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldNotBeNull
 import io.bluetape4k.leader.LockAssert
 import io.bluetape4k.workshop.leader.job.LockAssertJob
+import kotlin.test.assertFailsWith
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import java.util.UUID
 
 /**
@@ -36,7 +36,7 @@ class LockAssertTest : AbstractLeaderElectionTest() {
 
     @Test
     fun `assertLocked throws IllegalStateException outside runIfLeader`() {
-        assertThrows<IllegalStateException> {
+        assertFailsWith<IllegalStateException> {
             LockAssert.assertLocked()
         }
     }

--- a/leader/leader-election/src/test/kotlin/io/bluetape4k/workshop/leader/LockExtenderTest.kt
+++ b/leader/leader-election/src/test/kotlin/io/bluetape4k/workshop/leader/LockExtenderTest.kt
@@ -1,0 +1,51 @@
+package io.bluetape4k.workshop.leader
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.leader.LockExtender
+import io.bluetape4k.workshop.leader.job.LockExtenderJob
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+/**
+ * Tests for [LockExtenderJob] and the [LockExtender] API.
+ *
+ * ## Key behaviours verified
+ * - [LockExtender.extendActiveLock] returns `true` when called inside `runIfLeader`.
+ * - [LockExtender.extendActiveLock] returns `false` when called outside any leader scope.
+ * - [LockExtenderJob.execute] completes without error when the elector is in scope.
+ */
+class LockExtenderTest : AbstractLeaderElectionTest() {
+
+    @Test
+    fun `extendActiveLock returns true inside runIfLeader`() {
+        val lockName = "test:extend:${UUID.randomUUID()}"
+        val elector = newElector()
+
+        val extended = elector.runIfLeader(lockName) {
+            LockExtender.extendActiveLock(LockExtenderJob.EXTENSION_DURATION)
+        }
+
+        extended.shouldNotBeNull()
+        extended.shouldBeTrue()
+    }
+
+    @Test
+    fun `extendActiveLock returns false outside any leader scope`() {
+        // LockExtender has no active handle when called outside runIfLeader.
+        val extended = LockExtender.extendActiveLock(LockExtenderJob.EXTENSION_DURATION)
+        extended shouldBeEqualTo false
+    }
+
+    @Test
+    fun `LockExtenderJob executes successfully as leader`() {
+        val lockName = LockExtenderJob().lockName
+        val elector = newElector()
+        val job = LockExtenderJob()
+
+        val result = elector.runIfLeader(lockName) { job.execute() }
+
+        result.shouldNotBeNull()
+    }
+}

--- a/leader/leader-election/src/test/kotlin/io/bluetape4k/workshop/leader/SuspendLeaderServiceTest.kt
+++ b/leader/leader-election/src/test/kotlin/io/bluetape4k/workshop/leader/SuspendLeaderServiceTest.kt
@@ -1,0 +1,80 @@
+package io.bluetape4k.workshop.leader
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.junit5.coroutines.SuspendedJobTester
+import io.bluetape4k.leader.LeaderElectionOptions
+import io.bluetape4k.workshop.leader.service.SuspendLeaderService
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import java.util.UUID
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Tests for [SuspendLeaderService] and [io.bluetape4k.leader.lettuce.LettuceSuspendLeaderElector].
+ *
+ * ## Key behaviours verified
+ * - Single coroutine acquires leadership and executes the suspend action.
+ * - Second elector receives `null` when the lock is held by the first elector.
+ * - [SuspendedJobTester] concurrency: exactly one worker wins per lock round.
+ */
+class SuspendLeaderServiceTest : AbstractLeaderElectionTest() {
+
+    @Test
+    fun `single coroutine acquires leadership and executes action`() = runTest {
+        val elector = newSuspendElector()
+        val service = SuspendLeaderService(elector)
+
+        val result = service.runLeaderWork()
+
+        result.shouldNotBeNull() shouldBeEqualTo "done"
+        service.executionCount.get() shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `second elector receives null while first holds the lock`() = runBlocking {
+        val lockName = "test:suspend:contention:${UUID.randomUUID()}"
+        val shortWait = LeaderElectionOptions(waitTime = 50.milliseconds, leaseTime = 5.seconds)
+        val elector1 = newSuspendElector(shortWait)
+        val elector2 = newSuspendElector(shortWait)
+
+        // Elector2 tries while elector1 holds the lock — elector2 times out (waitTime=50ms).
+        var result2: String? = "not-set"
+        val result1 = elector1.runIfLeader(lockName) {
+            result2 = elector2.runIfLeader(lockName) { "follower" }
+            "leader"
+        }
+
+        result1.shouldNotBeNull() shouldBeEqualTo "leader"
+        result2.shouldBeNull()
+    }
+
+    @Test
+    fun `exactly one coroutine wins among concurrent suspend attempts`() = runBlocking {
+        val lockName = "test:suspend:concurrent:${UUID.randomUUID()}"
+        val winCount = AtomicInteger(0)
+
+        // SuspendedJobTester — coroutine concurrency harness from bluetape4k-junit5.
+        // waitTime = 50ms so non-winners time out while the winner holds for 200ms.
+        val opts = LeaderElectionOptions(waitTime = 50.milliseconds, leaseTime = 5.seconds)
+
+        SuspendedJobTester()
+            .workers(4)
+            .rounds(1)
+            .add {
+                val elector = newSuspendElector(opts)
+                elector.runIfLeader(lockName) {
+                    winCount.incrementAndGet()
+                    delay(300) // hold longer than waitTime so others time out
+                }
+            }
+            .run()
+
+        winCount.get() shouldBeEqualTo 1
+    }
+}


### PR DESCRIPTION
## Summary

Extends the existing `leader/leader-election` module with advanced `bluetape4k-leader` v0.2.1 API examples. Closes issue #10 (partial — PR-A of A→B→C).

## Changes

### New source files

| File | Purpose |
|------|---------|
| `job/LockExtenderJob.kt` | Demonstrates `LockExtender.extendActiveLock(Duration)` between work phases |
| `job/LockAssertJob.kt` | Demonstrates `LockAssert.assertLocked()` / `isLocked()` runtime lock ownership guards |
| `service/SuspendLeaderService.kt` | Coroutine-based leader election via `LettuceSuspendLeaderElector` |
| `service/LeaderEventListenerService.kt` | Both `LeaderElectionListener` callback and `events: Flow<LeaderElectionEvent>` patterns |

### Modified files

| File | Change |
|------|--------|
| `config/LeaderElectionConfig.kt` | Add `lettuceSuspendConnection` bean; `@Qualifier` on both connection params; promote `leaderElector` return type to `ListeningLeaderElector` |
| `build.gradle.kts` | Add `bluetape4k-coroutines` + `kotlinx-coroutines-test` test deps |
| `AbstractLeaderElectionTest.kt` | Add `newSuspendElector()` and `newListeningElector()` factory helpers |

### New test files

| File | Coverage |
|------|---------|
| `LockExtenderTest.kt` | Returns true/false inside/outside `runIfLeader` |
| `LockAssertTest.kt` | `assertLocked` passes inside, throws outside; `isLocked` true/false |
| `SuspendLeaderServiceTest.kt` | Single acquisition, contention (nested pattern), concurrent SuspendedJobTester |
| `LeaderEventListenerTest.kt` | onElected/onSkipped callbacks, events Flow emission, service counter integration |

## Test Results

```
Module : :leader-leader-election
Result : 26 passing, 0 failed, 0 skipped
Command: ./gradlew :leader-leader-election:test --no-daemon
```

## Code Review (Tier 4) — All HIGH/CRITICAL resolved

| Severity | Finding | Fix |
|----------|---------|-----|
| HIGH | `CancellationException` swallowed in Flow collector | Added rethrow before broad catch |
| HIGH | Banned `assertThrows` in LockAssertTest | Replaced with `assertFailsWith<T>` |
| HIGH | SharedFlow replay=0 race (collector not subscribed before emit) | Added Thread.sleep(100) before runIfLeader |
| MEDIUM | suspendLeaderElector missing explicit `@Qualifier` | Added `@Qualifier("lettuceSuspendConnection")` |

## Checklist

- [x] All tests passing (26/26)
- [x] Tier 4 code review — CRITICAL/HIGH = 0
- [x] CancellationException rethrow pattern applied
- [x] English KDoc on all new public APIs
- [x] Lessons committed: `docs/lessons/2026-05-25-leader-election-advanced-patterns.md`
- [x] PR title/body in English

## Related

- Issue #10: bluetape4k-leader 예제 제작
- PR-B: `leader/leader-zookeeper/` (deferred, Type-A Full Design)
- PR-C: `leader/leader-k8s/` (deferred, Type-A Full Design)