### PR TITLE
feat: add graph/abuser-detection module (Epic #9, Issue #12)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,6 +35,7 @@ val rootLibs = libs
 
 allprojects {
     repositories {
+        mavenLocal()   // required for bluetape4k-graph until published to Maven Central
         mavenCentral()
         maven {
             name = "central-snapshots"

--- a/docs/lessons/2026-05-25-graph-abuser-detection.md
+++ b/docs/lessons/2026-05-25-graph-abuser-detection.md
@@ -1,0 +1,215 @@
+# 교훈: graph/abuser-detection 모듈 구현
+
+**날짜**: 2026-05-25  
+**작업자**: debop  
+**브랜치**: `feat/graph-abuser-detection`  
+**모듈**: `graph/abuser-detection`
+
+---
+
+## 작업 요약
+
+bluetape4k-graph 라이브러리(Neo4j, TinkerGraph 백엔드)를 활용한 어뷰저 탐지 그래프 서비스 구현.  
+PageRank 기반 의심 사용자 순위, 사기 링(fraud ring) 탐지, 추천 루프(referral loop) 탐지를 블로킹 및 코루틴(Flow) 이중 서비스로 제공.
+
+---
+
+## 발견된 버그 및 기술 결정
+
+### B1. `log.warn { }` / `log.debug { }` 람다 구문 컴파일 에러
+
+**원인**: `KLogging`의 `log`는 `org.slf4j.Logger` 로우 타입.  
+SLF4J 표준 Logger는 람다 형식을 받지 않으므로 `log.warn { "..." }` 구문이 컴파일 실패.
+
+**수정**: bluetape4k 확장 임포트를 명시 추가.
+```kotlin
+import io.bluetape4k.logging.warn
+import io.bluetape4k.logging.debug
+```
+
+**교훈**: `log.warn { }` / `log.debug { }` 등 람다 로깅 구문을 사용할 때는  
+반드시 `io.bluetape4k.logging.*` 확장 import를 추가해야 함.  
+IDE가 자동 import를 제안하지 않을 수 있으므로 수동 확인 필요.
+
+---
+
+### B2. `neo4j.boltUrl` 미해결 — `neo4j.url` 사용
+
+**원인**: `Neo4jContainer`에 `boltUrl` 프로퍼티가 정의되어 있으나, 해당 클래스가 컴파일 클래스패스에 없어 `Neo4jServer.Launcher`에서 `boltUrl`이 unresolved.  
+`Neo4jServer`가 `url`을 override로 노출하며, 이 값이 Bolt URL을 포함함.
+
+**수정**: `neo4j.boltUrl` → `neo4j.url` 사용.
+```kotlin
+// 잘못된 접근
+val driver = GraphDatabase.driver(neo4j.boltUrl, ...)
+
+// 올바른 접근
+val driver = GraphDatabase.driver(neo4j.url, ...)
+```
+
+**교훈**: bluetape4k Testcontainers 래퍼(`XxxServer`)는 `url`을 표준 접근자로 제공.  
+원래 Testcontainers 컨테이너 클래스의 프로퍼티에 직접 접근하기 전에  
+`XxxServer`의 공개 API를 먼저 확인할 것.
+
+---
+
+### B3. Testcontainers 2.x Neo4j 모듈명 변경
+
+**원인**: Testcontainers 2.x에서 Neo4j 아티팩트가 `org.testcontainers:neo4j`에서  
+`org.testcontainers:testcontainers-neo4j`로 변경됨.
+
+**수정**:
+```kotlin
+// Testcontainers 1.x (구버전)
+testImplementation("org.testcontainers:neo4j")
+
+// Testcontainers 2.x (현재)
+testImplementation("org.testcontainers:testcontainers-neo4j")
+```
+
+**교훈**: Testcontainers 2.x 마이그레이션 시 기존 모듈명이 달라질 수 있음.  
+`bluetape4k-testcontainers`의 `libs.versions.toml`에 등록된 alias를 우선 사용하고,  
+직접 좌표를 쓸 경우 Testcontainers 2.x 아티팩트명을 확인.
+
+---
+
+### B4. PageRank `vertexLabel` 필터 미적용 시 identifier 버텍스가 상위 점령
+
+**원인**: PageRank를 전체 그래프에 실행하면 User가 아닌 Device, IP 등 식별자(identifier) 버텍스가  
+다수의 User와 연결되어 높은 PageRank 점수를 받아 상위를 차지함.  
+`limit` 파라미터가 User 버텍스가 아닌 모든 버텍스에 적용됨.
+
+**수정**: `PageRankOptions`에 `vertexLabel` 필터 지정.
+```kotlin
+val options = PageRankOptions(
+    vertexLabel = UserLabel.label,  // User 버텍스에만 limit 적용
+    topK = limit
+)
+val rankings = graphService.pageRank(options)
+```
+
+**교훈**: 멀티-레이블 그래프에서 PageRank/중심성 지표를 특정 엔티티 타입에 적용할 때는  
+`vertexLabel` 필터를 반드시 지정할 것.  
+미지정 시 허브 역할의 보조 노드(Device, IP)가 상위를 독점.
+
+---
+
+### B5. `shouldNotBeEmpty()` / `shouldBeEmpty()` — infix가 아닌 dot 표기
+
+**원인**: Kluent/bluetape4k-assertions의 `shouldNotBeEmpty()`는 infix 함수가 아님.  
+`result shouldNotBeEmpty` 형식으로 작성하면 컴파일 에러 발생.
+
+**수정**:
+```kotlin
+// 잘못된 표기 (컴파일 에러)
+result shouldNotBeEmpty
+
+// 올바른 표기
+result.shouldNotBeEmpty()
+result.shouldBeEmpty()
+```
+
+**교훈**: assertions 라이브러리 함수를 처음 사용할 때 infix 여부를 IDE 자동완성으로 확인.  
+`shouldXxx()` 형식 함수는 대부분 dot 방식이며, infix는 `shouldBe`, `shouldEqual` 등 일부에 한정.
+
+---
+
+### B6. Flow API에 `mapIndexed` 미존재
+
+**원인**: `kotlinx.coroutines.flow`에는 `List.mapIndexed()`와 동일한 `Flow.mapIndexed()`가 없음.  
+직접 사용하면 컴파일 에러.
+
+**수정**: `withIndex().map { }` 패턴으로 대체.
+```kotlin
+// 컴파일 에러
+flow.mapIndexed { index, value -> ... }
+
+// 올바른 패턴
+flow.withIndex().map { (index, value) ->
+    // index, value 사용
+}
+```
+
+**교훈**: Flow API는 Collection API의 모든 확장 함수를 제공하지 않음.  
+`mapIndexed`, `forEachIndexed` 등 인덱스가 필요한 연산은 `.withIndex().map { (i, v) -> }` 패턴 사용.
+
+---
+
+## 설계 결정
+
+### D1. 블로킹 + 코루틴 이중 서비스 구조
+
+`AbuserDetectionService` (블로킹 API)와 `AbuserDetectionSuspendService` (코루틴/Flow API)를 병렬 제공.
+
+**이유**:
+- 블로킹 서비스: 스프링 MVC 통합 및 Java 코드와의 상호운용성 보장
+- 코루틴 서비스: WebFlux / 비동기 파이프라인에서 backpressure와 Flow 스트리밍 지원
+- 같은 비즈니스 로직을 두 API 스타일로 시연하는 워크샵 목적에도 부합
+
+**적용 기준**: 인프라 드라이버가 코루틴 지원 여부에 따라 구분.  
+Neo4j Kotlin 드라이버는 suspend 함수를 지원하므로 코루틴 서비스에 자연스럽게 매핑.
+
+---
+
+### D2. 그래프 격리 — 테스트별 고유 그래프 이름
+
+통합 테스트에서 각 테스트 클래스는 고유한 그래프/데이터베이스 이름을 사용.
+
+**이유**: 테스트 간 데이터 오염 방지. 병렬 실행 시 충돌 방지.  
+TinkerGraph는 인메모리 그래프를 독립적으로 생성; Neo4j는 별도 데이터베이스 또는 고유 라벨 prefix 사용.
+
+---
+
+### D3. 테스트 계층화 — TinkerGraph vs Neo4j/Memgraph
+
+| 계층 | 백엔드 | 태그 | Gradle 태스크 |
+|------|--------|------|---------------|
+| 기본 | TinkerGraph (인메모리) | 없음 | `:test` |
+| 통합 | Neo4j / Memgraph | `@Tag("integration")` | `integrationTest` |
+
+**이유**: TinkerGraph는 Docker 없이 동작하여 CI 기본 태스크에서 빠르게 실행 가능.  
+Neo4j/Memgraph는 실제 Bolt 프로토콜 동작을 검증하지만 컨테이너 의존성 있음.
+
+---
+
+## 코드 리뷰 결과 (6-R 리뷰)
+
+| 심각도 | 항목 | 조치 |
+|--------|------|------|
+| P1/HIGH | `runCatching { driver.close() }` 실패 시 로그 없음 | `.onFailure { log.warn(it) { "드라이버 종료 실패" } }` 추가 |
+| P1/HIGH | `rankSuspiciousUsers respects limit` 테스트가 크기 미검증 | `shouldHaveSize(2)` assertion 추가 |
+| P2/MEDIUM | `detectReferralLoops` 파라미터 검증 누락 | `requirePositiveNumber(maxDepth, "maxDepth")` 추가 |
+| P3/LOW | missing seed vertex 로그 레벨이 DEBUG | WARN으로 승격 |
+| P3/LOW | unknown label silent skip (로그 없음) | WARN 로깅 추가 |
+
+**핵심 교훈**:
+- `runCatching {}` 블록은 반드시 `.onFailure { log.warn(it) { ... } }` 체인으로 실패를 가시화
+- limit/size 제약 테스트는 컬렉션 크기를 직접 assertion으로 검증 (`shouldHaveSize`)
+- 공개 API의 숫자 파라미터는 `requirePositiveNumber` / `requireNotBlank` 등으로 입구 검증
+
+---
+
+## 최종 테스트 결과
+
+```
+TinkerGraph 기준 (기본 :test 태스크):
+37 tests, 0 failures, 0 errors
+```
+
+Neo4j/Memgraph 통합 테스트는 `integrationTest` Gradle 태스크로 별도 실행.
+
+---
+
+## 미래 참고 사항
+
+| 상황 | 적용 패턴 |
+|------|-----------|
+| bluetape4k 람다 로깅 | `import io.bluetape4k.logging.warn` 등 확장 import 필수 |
+| Testcontainers 래퍼 URL | `XxxServer.url` 사용; 원본 컨테이너 프로퍼티 직접 접근 지양 |
+| Testcontainers 2.x Neo4j | `org.testcontainers:testcontainers-neo4j` 아티팩트명 확인 |
+| 멀티-레이블 그래프 PageRank | `PageRankOptions(vertexLabel = TargetLabel.label, topK = limit)` 필터 지정 |
+| Flow 인덱스 순회 | `.withIndex().map { (index, value) -> }` 패턴 사용 |
+| Kluent assertions dot 표기 | `result.shouldNotBeEmpty()` (infix 아님) |
+| `runCatching {}` 실패 처리 | `.onFailure { log.warn(it) { ... } }` 체인 필수 |
+| limit 제약 테스트 | `shouldHaveSize(N)` assertion으로 직접 크기 검증 |
+| 공개 API 파라미터 검증 | `requirePositiveNumber` / `requireNotBlank` 입구 검증 |

--- a/docs/superpowers/plans/2026-05-25-graph-abuser-detection-plan.md
+++ b/docs/superpowers/plans/2026-05-25-graph-abuser-detection-plan.md
@@ -32,6 +32,13 @@
 18. **seed 전략**: `AbuserDetectionSeed` 는 composable helpers (`seedSharedIdentifiers()`, `seedReferralCycle()`, `seedIsolatedUser()`) 로 분리. 각 test 는 `@BeforeEach cleanGraph` 후 필요한 helper 만 호출.
 19. **suspend seeder**: T6-1 이 `suspend fun seedAll(service: AbuserDetectionSuspendService): SeedResult` 도 제공.
 20. **version resolution**: `bluetape4k-graph 0.4.2` 는 Maven Central 미발행. T1-2 에서 mavenLocal 발행 여부 확인 후 버전 결정.
+21. **[P0-Impl-1/P1-Impl-3] Neo4j/Memgraph ops 생성자 database ≠ graphName**: `Neo4jGraphOperations(driver)` — 2번째 인자에 graphName 전달 금지. 생성자 2번째 인자는 Bolt database 이름 (`"neo4j"` / `"memgraph"`). graphName 은 서비스 생성자(`AbuserDetectionService(ops, graphName)`)에만 전달. 모든 4개 integration 테스트(T10-1~T10-4) 동일.
+22. **[P0-Impl-2] suspend `findAbuseCluster` + `explainSuspicion` — Flow API 차이**: `ops.neighbors()` / `ops.findEdgesByStartId()` suspend 변형은 `Flow` 반환. `flatMap { Flow }` 는 compile error. `neighbors().toList()` 로 collect 후 flatMap; `explainSuspicion` 는 `flow { ... .collect { emit(...) } }` 로 작성.
+23. **[P1-Test-1] suspend `@BeforeEach cleanGraph()` 패턴**: `runCatching {}` 안에 suspend 호출 금지. `@BeforeEach fun cleanGraph() = runTest { try { ... } catch (e: CancellationException) { throw e } catch (e: Exception) { log.warn } }` 형식.
+24. **[P1-Test-2] test 16 Flow cancellation**: seed data 필수 + slow consumer (`.onEach { delay(10) }`) 필수. empty graph 에서는 Flow 즉시 완료 → silent pass.
+25. **[P1-Test-4] tests 3/4/5/14 구체 assertion**: paths 에 USES_DEVICE/USES_IP edgeLabel 포함; loops 에 cycle 멤버 IDs 포함; ranks.first() 가 seed user1; sharedIdentifiers 에 PhoneNumber + PaymentMethod labels 포함.
+26. **[P1-Arch-3] `configurations {}` `.get()` 필수**: `testImplementation.get().extendsFrom(compileOnly.get(), runtimeOnly.get())`. 없으면 Kotlin DSL compile error.
+27. **[P1-Deliv-1] `seedIsolatedUser` 는 cluster + isolated user 모두 생성**: user1/user2/user3 공유 deviceA + unrelatedUser 고립. user1.id NPE 방지.
 
 ---
 
@@ -74,6 +81,24 @@
 - **파일**: `graph/abuser-detection/build.gradle.kts`
 - **작업**: spec §8 의 build.gradle.kts — BOM platform, core/tinkerpop impl, neo4j/memgraph `compileOnly` (NOT testImplementation — extendsFrom 이 테스트 classpath 로 전파), integrationTest task, `excludeTags("integration")` on default test task
 - **⚠️ 중복 의존성 금지**: `compileOnly(libs.bluetape4k.graph.neo4j)` + `testImplementation(libs.bluetape4k.graph.neo4j)` 동시 선언 금지. `compileOnly` + `extendsFrom` 으로 충분.
+- **⚠️ [P1-Arch-3] BOM platform import 가 반드시 첫 번째 dependency 여야 함** — version-less alias 들은 BOM 에서 버전을 받으므로 BOM import 가 먼저 선언되어야 한다:
+  ```kotlin
+  dependencies {
+      implementation(platform(libs.bluetape4k.graph.bom))  // ← 반드시 첫 번째
+      implementation(libs.bluetape4k.graph.core)
+      implementation(libs.bluetape4k.graph.tinkerpop)
+      compileOnly(libs.bluetape4k.graph.neo4j)
+      compileOnly(libs.bluetape4k.graph.memgraph)
+      // ...
+  }
+  ```
+- **⚠️ [P1-Arch-3] Kotlin DSL `configurations {}` 에서 `.get()` 필수** — `NamedDomainObjectProvider<Configuration>` 는 `.extendsFrom()` 메서드가 없으므로 `.get()` 없이는 **compile error**. 반드시 아래 형식 사용:
+  ```kotlin
+  configurations {
+      testImplementation.get().extendsFrom(compileOnly.get(), runtimeOnly.get())
+  }
+  ```
+  참조: `redis/redisson-examples/build.gradle.kts:6`, `kotlin/coroutines/build.gradle.kts:6` — 동일 패턴.
 
 ### T1-4: 테스트 리소스 생성
 - **complexity**: low
@@ -81,7 +106,17 @@
   - `graph/abuser-detection/src/test/resources/junit-platform.properties`
   - `graph/abuser-detection/src/test/resources/logback-test.xml`
 - **작업**:
-  - `junit-platform.properties`: `junit.jupiter.execution.parallel.enabled=false` 만 — **`junit.jupiter.tags.exclude=integration` 절대 포함 금지** (JUnit 엔진 레벨 제외가 Gradle `integrationTest` 태스크도 막음; tag exclusion 은 `build.gradle.kts tasks.test { excludeTags }` 에서만)
+  - `junit-platform.properties`: **⚠️ [P2-Arch-4] workshop 표준 6줄 전체 복사** — `junit.jupiter.execution.parallel.enabled=false` 만으로는 부족; 아래 전체 사용:
+    ```properties
+    junit.jupiter.extensions.autodetection.enabled=true
+    junit.jupiter.testinstance.lifecycle.default=per_class
+
+    junit.jupiter.execution.parallel.enabled=false
+    junit.jupiter.execution.parallel.mode.default=same_thread
+    junit.jupiter.execution.parallel.mode.classes.default=concurrent
+    ```
+    참조: `redis/redisson-examples/src/test/resources/junit-platform.properties`, `kotlin/coroutines` — 동일 6줄.  
+    **`junit.jupiter.tags.exclude=integration` 절대 포함 금지** (JUnit 엔진 레벨 제외가 Gradle `integrationTest` 태스크도 막음; tag exclusion 은 `build.gradle.kts tasks.test { excludeTags }` 에서만)
   - `logback-test.xml`: 기존 workshop 모듈 logback-test.xml 복사
 
 ---
@@ -223,6 +258,33 @@
     }
     ```
   - `VERTEX_LABEL_TO_EDGE_LABEL` — companion object 에 선언 (T4-1b 동일)
+  - **⚠️ [P0-Impl-2] `findAbuseCluster` suspend — `ops.neighbors()` 는 `Flow<GraphVertex>` 반환 (List 아님)**:
+    `List.flatMap { Flow }` 는 compile error. `.toList()` 로 수집 후 flatMap 해야 함:
+    ```kotlin
+    suspend fun findAbuseCluster(seedUserId: GraphElementId): AbuseCluster {
+        if (ops.findVertexById(seedUserId) == null) return AbuseCluster(seedUserId, emptyList(), emptyList())
+        val seedIdentifiers: List<GraphVertex> = IdentifierEdgeLabel.all.flatMap { edgeLabel ->
+            ops.neighbors(seedUserId, NeighborOptions(edgeLabel.value, OUTGOING, 1))
+                .toList()   // import kotlinx.coroutines.flow.toList ← REQUIRED
+        }
+        // 이하 blocking 버전과 동일한 label-dispatch BFS 로직
+    }
+    ```
+    **필수 imports**: `kotlinx.coroutines.flow.firstOrNull`, `kotlinx.coroutines.flow.toList`
+  - **⚠️ [P1-Impl-1] `explainSuspicion` suspend — `ops.findEdgesByStartId()` 는 `Flow<GraphEdge>` 반환 (List 아님)**:
+    `List` 방식 iteration 은 compile error. `flow { }` 빌더로 작성:
+    ```kotlin
+    fun explainSuspicion(userId: GraphElementId): Flow<AbusePath> = flow {
+        userId.requireNotBlank("userId")    // ← validation inside flow{} — runs at collection time
+        IdentifierEdgeLabel.all.forEach { lbl ->
+            ops.findEdgesByStartId(userId, lbl.value).collect { edge ->
+                emit(AbusePath(edge.endVertexId, lbl))
+            }
+        }
+    }
+    ```
+    이 함수는 `suspend` 가 아닌 Flow-반환 함수. validation 은 collect 시 발생.
+    테스트 패턴: `assertFailsWith<IllegalArgumentException> { service.explainSuspicion("").toList() }`
   - `rankSuspiciousUsers` — **`Flow.mapIndexed` 없음** — `.withIndex().map { (idx, s) -> SuspiciousUserScore(s.vertex, s.score, idx + 1) }` 사용.
     **`flow { }` 빌더 + `Flow.forEach` 패턴 금지 — `Flow.forEach` 는 존재하지 않음 (compile error).**
     Direct pipeline 으로 작성:
@@ -246,9 +308,14 @@
 - **파일**: `graph/abuser-detection/src/main/kotlin/io/bluetape4k/workshop/graph/abuser/seed/AbuserDetectionSeed.kt`
 - **선행**: T4-1a, T4-1b, T5-1 완료
 - **설계 전략**: `seedAll` 대신 **composable helpers** — 각 테스트가 `@BeforeEach cleanGraph` 후 필요한 helper 만 호출
-  - `seedSharedIdentifiers(service): SeedResult` — 3 users × shared device+IP (test 2, 3, 5, 14)
+  - `seedSharedIdentifiers(service): SeedResult` — 3 users × shared device+IP (test 2, 3, 5, 14); `unrelatedUser` 포함 (cluster 와 무관한 4번째 user 생성)
   - `seedReferralCycle(service): SeedResult` — A→B→C→A cycle (test 4)
-  - `seedIsolatedUser(service): SeedResult` — 독립 사용자 (test 7)
+  - `seedIsolatedUser(service): SeedResult` — **⚠️ [P1-Deliv-1] 반드시 cluster + isolated user 모두 생성해야 함**:
+    - `user1`, `user2`, `user3` 는 `deviceA` 를 공유 (cluster 형성)
+    - `unrelatedUser` 는 graph edge 없음 (완전 고립)
+    - 이 구조가 없으면 test 7 에서 `seed.user1.id` NPE 발생
+    - `phoneA`, `paymentA`, `referralUser*` = null
+    - Test 7 assertions: `findAbuseCluster(seed.user1.id).users` 에 user2/user3 포함, `unrelatedUser` 미포함; `findAbuseCluster(seed.unrelatedUser.id).users.isEmpty()`
   - `seedAll(service): SeedResult` — 모두 포함 (backward compat, test 5)
 - **suspend variant 필수**: blocking 버전과 동일한 suspend helpers:
   - `suspend fun seedSharedIdentifiers(service: AbuserDetectionSuspendService): SeedResult`
@@ -288,9 +355,20 @@
   - **15개 테스트 케이스** (happy 7 + failure 5 + additional 3):
     1. `creates user and links device` — `service.initialize()` 후 직접 addUser/addDevice/linkDevice (seed 없음)
     2. `finds shared-device abuse cluster — returns 2 other users (seed excluded)` — `seedSharedIdentifiers(service)` 호출; assert `findAbuseCluster(seed.user1.id).users shouldContainExactlyInAnyOrder listOf(seed.user2, seed.user3)`
-    3. `explains suspicion by shared device and IP` — `seedSharedIdentifiers(service)` 사용
-    4. `detects referral loops (A→B→C→A)` — `seedReferralCycle(service)` 호출
-    5. `ranks user at center of identifier sharing as most suspicious` — `seedSharedIdentifiers(service)` 사용
+    3. `explains suspicion by shared device and IP` — `seedSharedIdentifiers(service)` 사용:
+       - **⚠️ [P1-Test-4] 구체 assertion 필수**: `service.explainSuspicion(seed.user1.id)` 결과에 대해:
+         - `paths.shouldNotBeEmpty()`
+         - `paths.map { it.edgeLabel }.toSet() shouldContainAll setOf(IdentifierEdgeLabel.USES_DEVICE, IdentifierEdgeLabel.USES_IP)`
+    4. `detects referral loops (A→B→C→A)` — `seedReferralCycle(service)` 호출:
+       - **⚠️ [P1-Test-4] 구체 assertion 필수**:
+         - `val loops = service.detectReferralLoops()`
+         - `loops.shouldNotBeEmpty()`
+         - `loops.any { cycle -> cycle.vertices.map { it.id }.containsAll(listOf(seed.referralUserA!!.id, seed.referralUserB!!.id, seed.referralUserC!!.id)) } shouldBe true`
+    5. `ranks user at center of identifier sharing as most suspicious` — `seedSharedIdentifiers(service)` 사용:
+       - **⚠️ [P1-Test-4] 구체 assertion 필수**:
+         - `val ranks = service.rankSuspiciousUsers()`
+         - `ranks.shouldNotBeEmpty()`
+         - `ranks.first().user.id shouldBeEqualTo seed.user1.id` — user1 이 device+IP 를 2명과 공유하므로 최고 score
     6. `empty graph returns empty cluster` — seed 없음; `findAbuseCluster(nonExistentId).users.isEmpty()`
     7. `cluster excludes unrelated users` — `seedIsolatedUser(service)` 호출 후:
        - `findAbuseCluster(seed.user1.id).users` 에 `seed.unrelatedUser` 포함 안 됨 확인
@@ -301,7 +379,12 @@
     11. `rankSuspiciousUsers returns empty list on empty graph`
     12. `detectReferralLoops returns empty list when no REFERRED_BY edges exist`
     13. `addDevice called twice with same deviceId returns the same vertex id` — `service.addDevice("device-X", "ios").id == service.addDevice("device-X", "ios").id`; `ops.findVerticesByLabel(DeviceLabel.label).count { it.properties["deviceId"] == "device-X" } == 1`
-    14. `shared phone and payment method detection` — seed two users sharing phone + payment; assert `findAbuseCluster` returns both with PhoneNumber + PaymentMethod in sharedIdentifiers
+    14. `shared phone and payment method detection` — seed two users sharing phone + payment:
+        - **⚠️ [P1-Test-4] 구체 assertion 필수**:
+          - `val cluster = service.findAbuseCluster(seed.user1.id)`
+          - `cluster.users.size shouldBeGreaterThanOrEqual 1`
+          - `cluster.sharedIdentifiers.map { it.label } shouldContainAll listOf(PhoneNumberLabel.label, PaymentMethodLabel.label)`
+          - PhoneNumber + PaymentMethod 양쪽 label 이 모두 포함되어야 `HAS_PHONE`/`USES_PAYMENT` dispatch 분기 검증 완료
     15. `cluster excludes REFERRED_BY-only reachable users` — link userA→userB via USES_DEVICE + REFERRED_BY; link userC→userA via REFERRED_BY only; assert userB in cluster, userC NOT in cluster
   - Exception tests: `assertFailsWith<IllegalArgumentException> { }`
   - Assertion: `shouldBe`, `shouldContainExactlyInAnyOrder` (bluetape4k-assertions)
@@ -317,6 +400,23 @@
 - **선행**: T7-1 완료 (동일 15개 테스트 구조 참조)
 - **작업**:
   - `@TestInstance(TestInstance.Lifecycle.PER_CLASS)` 필수
+  - **⚠️ [P1-Test-1] `@BeforeEach cleanGraph()` — suspend call 은 `runCatching {}` 금지**:
+    `runCatching {}` 안에서 suspend 함수 호출 시 `CancellationException` 삼킴 (CLAUDE.md 규칙 위반).
+    올바른 패턴:
+    ```kotlin
+    @BeforeEach
+    fun cleanGraph() = runTest {
+        try {
+            if (ops.graphExists(graphName)) ops.dropGraph(graphName)
+        } catch (e: CancellationException) {
+            throw e   // ← 반드시 재throw
+        } catch (e: Exception) {
+            log.warn(e) { "dropGraph failed; continuing with initialize()" }
+        }
+        suspendService.initialize()
+    }
+    ```
+    `@BeforeEach fun cleanGraph() = runTest { ... }` 형식 사용 — JUnit 5 가 `runTest` 의 반환값 무시함으로 정상 동작.
   - 동일 15개 테스트를 `runTest { }` 로 래핑
   - **suspend seeder 사용**: `seedSharedIdentifiers(suspendService)`, `seedReferralCycle(suspendService)`, `seedIsolatedUser(suspendService)` (T6-1 suspend 버전)
   - Flow 테스트: `explainSuspicion(...).toList()`, `rankSuspiciousUsers(...).toList()`
@@ -333,11 +433,16 @@
     ```
   - **suspend `fun` exception 테스트**: `coInvoking { service.addDevice("", "ios") } shouldThrow IllegalArgumentException::class`
   - **Flow 취소 검증 테스트** (test 16): `rankSuspiciousUsers` Flow 를 collect 중인 Job 을 cancel 하고 취소 전파 확인
+    - **⚠️ [P1-Test-2] empty graph 에서는 Flow 가 즉시 완료 → cancel 이 도달하기 전에 정상 종료 → silent pass**
+      반드시 seed data 를 넣고 slow consumer 사용해야 cancellation 이 in-flight 중에 도달함:
     ```kotlin
-    // ✅ Option A — async + deferred.await() (CancellationException 전파 검증)
+    // ✅ Option A — seed data 필수 + slow consumer + async/deferred.await()
     runTest {
+        seedSharedIdentifiers(suspendService)   // graph data 필수 — PageRank 가 실제 emit 해야 함
         val deferred = async {
-            service.rankSuspiciousUsers().collect { }
+            service.rankSuspiciousUsers()
+                .onEach { delay(10) }           // slow consumer — cancel 이 in-flight 중에 도달하도록
+                .collect { }
         }
         deferred.cancel()
         assertFailsWith<CancellationException> { deferred.await() }
@@ -345,8 +450,9 @@
 
     // ✅ Option B — backgroundScope (isCancelled 상태 검증)
     runTest {
+        seedSharedIdentifiers(suspendService)
         val job = backgroundScope.launch {
-            service.rankSuspiciousUsers().collect { }
+            service.rankSuspiciousUsers().onEach { delay(10) }.collect { }
         }
         job.cancel()
         job.join()
@@ -398,7 +504,11 @@
     // ⚠️ graphName MUST be declared before ops — Kotlin initializes properties in declaration order.
     // Declaring ops first would read graphName before it is initialized (null → NPE or wrong value).
     override val graphName = "abuser_neo4j"
-    override val ops: GraphOperations = Neo4jGraphOperations(driver, graphName)
+    // ⚠️ [P0-Impl-1] Neo4jGraphOperations 생성자 2번째 인자는 `database: String = "neo4j"` (Bolt database 이름).
+    // graphName ("abuser_neo4j") 를 여기 전달하면 존재하지 않는 database 에 연결 → ClientException: Database does not exist.
+    // graphName 은 서비스 생성자 (abstract base 에서 AbuserDetectionService(ops, graphName)) 에 전달되어
+    // createGraph(graphName) / dropGraph(graphName) 에서만 사용됨 — 생성자에는 전달하지 않음.
+    override val ops: GraphOperations = Neo4jGraphOperations(driver)   // default database = "neo4j"
     ```
   - `@AfterAll fun teardown()`: `runCatching { if (ops.graphExists(graphName)) ops.dropGraph(graphName) }.onFailure { log.warn }` + `driver.close()`
 
@@ -419,7 +529,9 @@
         }
         // ⚠️ graphName MUST be declared before ops (same initialization order rule as T10-1)
         override val graphName = "abuser_memgraph"
-        override val ops: GraphOperations = MemgraphGraphOperations(driver, graphName)
+        // ⚠️ [P0-Impl-1] MemgraphGraphOperations 생성자 2번째 인자는 `database: String = "memgraph"`.
+        // graphName 전달 금지 — default database "memgraph" 사용.
+        override val ops: GraphOperations = MemgraphGraphOperations(driver)   // default database = "memgraph"
 
         @AfterAll
         fun teardown() {
@@ -456,7 +568,9 @@
             val driver: Driver = GraphDatabase.driver(neo4j.boltUrl, AuthTokens.none())
         }
         override val graphName = "abuser_suspend_neo4j"
-        override val ops: GraphSuspendOperations = Neo4jGraphSuspendOperations(driver, graphName)
+        // ⚠️ [P1-Impl-3] Neo4jGraphSuspendOperations 생성자 2번째 인자는 `database: String = "neo4j"`.
+        // graphName 전달 금지 — default database "neo4j" 사용.
+        override val ops: GraphSuspendOperations = Neo4jGraphSuspendOperations(driver)   // default database = "neo4j"
 
         @AfterAll
         fun teardown() {
@@ -484,7 +598,9 @@
             val driver: Driver = GraphDatabase.driver(memgraph.boltUrl, AuthTokens.none())
         }
         override val graphName = "abuser_suspend_memgraph"
-        override val ops: GraphSuspendOperations = MemgraphGraphSuspendOperations(driver, graphName)
+        // ⚠️ [P1-Impl-3] MemgraphGraphSuspendOperations 생성자 2번째 인자는 `database: String = "memgraph"`.
+        // graphName 전달 금지 — default database "memgraph" 사용.
+        override val ops: GraphSuspendOperations = MemgraphGraphSuspendOperations(driver)   // default database = "memgraph"
 
         @AfterAll
         fun teardown() {

--- a/docs/superpowers/plans/2026-05-25-graph-abuser-detection-plan.md
+++ b/docs/superpowers/plans/2026-05-25-graph-abuser-detection-plan.md
@@ -1,0 +1,334 @@
+# Plan: graph/abuser-detection 워크샵 모듈
+
+**날짜**: 2026-05-25  
+**브랜치**: `feat/graph-abuser-detection`  
+**Issue**: bluetape4k-workshop#12  
+**Spec**: `docs/superpowers/specs/2026-05-25-graph-abuser-detection-design.md`  
+**모듈**: `graph/abuser-detection` → Gradle 모듈명: `graph-abuser-detection`  
+**참조 구현**: `/Users/debop/work/bluetape4k/bluetape4k-graph/examples/fraud-detection-examples/`  
+**스택**: Kotlin 2.3, Java 25, bluetape4k 1.5.0-Beta2, bluetape4k-graph 0.4.2
+
+---
+
+## 핵심 Spec 결정 사항 (task 에 인코딩됨)
+
+1. **§6 label-dispatch**: `vertexLabelToEdgeLabel: Map<String, IdentifierEdgeLabel>` literal map 사용 (`"Device"→USES_DEVICE` 등). `.uppercase()` 비교 절대 금지.
+2. **§5.1 findOrCreate**: `ops.findVerticesByLabel(label).firstOrNull { it.properties["key"] == value }` — 먼저 조회 후 없으면 생성.
+3. **§9 @TestInstance(PER_CLASS)**: 두 abstract base (`AbstractAbuserDetectionTest`, `AbstractAbuserDetectionSuspendTest`) 모두 필수.
+4. **§9 cleanGraph**: `@BeforeEach` 에서 `runCatching { dropGraph }.onFailure { log.warn }` 래핑.
+5. **§9 driver ownership**: integration 구상 클래스 `@AfterAll` 이 `driver.close()` 단독 호출; abstract base 는 close 금지.
+6. **§9 unique graphName**: `"abuser_neo4j"` / `"abuser_memgraph"` per backend.
+7. **§8 integrationTest task**: `tasks.test { excludeTags("integration") }` + `tasks.register<Test>("integrationTest") { includeTags("integration") }`.
+8. **Testcontainers**: `Neo4jServer.Launcher.neo4j`, `MemgraphServer.Launcher.memgraph` singleton 사용 — `GenericContainer` 직접 생성 금지.
+9. **§10 validation**: 모든 identifier mutator 가 `requireNotBlank` 를 findOrCreate 전에 호출.
+
+---
+
+## Phase 1 — Module Scaffolding (복잡도: low)
+
+### T1-1: `settings.gradle.kts` 에 graph 도메인 등록
+- **complexity**: low
+- **파일**: `settings.gradle.kts`
+- **작업**:
+  - `includeModules("graph", false, true)` 삽입 (`gatling` 과 `image-processing` 사이, 알파벳 순)
+  - 결과 모듈명: `:graph-abuser-detection`
+
+### T1-2: `gradle/libs.versions.toml` 에 bluetape4k-graph 추가
+- **complexity**: low
+- **파일**: `gradle/libs.versions.toml`
+- **작업**:
+  ```toml
+  [versions]
+  # TODO: bluetape4k-dependencies BOM 이 bluetape4k-graph 를 govern 하면 pin 제거.
+  bluetape4k-graph = "0.4.2"
+  
+  [libraries]
+  bluetape4k-graph-bom       = { module = "io.github.bluetape4k.graph:bluetape4k-graph-bom", version.ref = "bluetape4k-graph" }
+  bluetape4k-graph-core      = { module = "io.github.bluetape4k.graph:bluetape4k-graph-core" }
+  bluetape4k-graph-tinkerpop = { module = "io.github.bluetape4k.graph:bluetape4k-graph-tinkerpop" }
+  bluetape4k-graph-neo4j     = { module = "io.github.bluetape4k.graph:bluetape4k-graph-neo4j" }
+  bluetape4k-graph-memgraph  = { module = "io.github.bluetape4k.graph:bluetape4k-graph-memgraph" }
+  neo4j-java-driver          = { module = "org.neo4j.driver:neo4j-java-driver" }
+  ```
+
+### T1-3: `graph/abuser-detection/build.gradle.kts` 생성
+- **complexity**: low
+- **파일**: `graph/abuser-detection/build.gradle.kts`
+- **작업**: spec §8 의 build.gradle.kts 내용 그대로 — BOM platform, core/tinkerpop impl, neo4j/memgraph compileOnly, integrationTest task, `excludeTags("integration")` on default test task
+
+### T1-4: 테스트 리소스 생성
+- **complexity**: low
+- **파일**:
+  - `graph/abuser-detection/src/test/resources/junit-platform.properties`
+  - `graph/abuser-detection/src/test/resources/logback-test.xml`
+- **작업**:
+  - `junit-platform.properties`: `junit.jupiter.execution.parallel.enabled=false`, `junit.jupiter.tags.exclude=integration`
+  - `logback-test.xml`: 기존 workshop 모듈 logback-test.xml 복사
+
+---
+
+## Phase 2 — Schema (복잡도: low)
+
+### T2-1: `AbuserDetectionSchema.kt` — 5 vertex label objects + 5 edge label objects
+- **complexity**: low
+- **파일**: `graph/abuser-detection/src/main/kotlin/io/bluetape4k/workshop/graph/abuser/schema/AbuserDetectionSchema.kt`
+- **작업**:
+  - `fraud-detection-examples/FraudDetectionSchema.kt` 패턴 그대로 따름
+  - Vertex labels: `UserLabel`, `DeviceLabel`, `IpAddressLabel`, `PhoneNumberLabel`, `PaymentMethodLabel`
+  - Edge labels: `UsesDeviceLabel`, `UsesIpLabel`, `HasPhoneLabel`, `UsesPaymentLabel`, `ReferredByLabel`
+  - 각 object 는 `VertexLabel` / `EdgeLabel` interface 구현 (bluetape4k-graph-core API 확인 후)
+  - 영문 KDoc 필수
+
+---
+
+## Phase 3 — Model Types (복잡도: low)
+
+### T3-1: `IdentifierEdgeLabel.kt` — value class + companion constants
+- **complexity**: low
+- **파일**: `graph/abuser-detection/src/main/kotlin/io/bluetape4k/workshop/graph/abuser/model/IdentifierEdgeLabel.kt`
+- **작업**:
+  ```kotlin
+  @JvmInline
+  value class IdentifierEdgeLabel(val value: String) {
+      companion object {
+          val USES_DEVICE  = IdentifierEdgeLabel("USES_DEVICE")
+          val USES_IP      = IdentifierEdgeLabel("USES_IP")
+          val HAS_PHONE    = IdentifierEdgeLabel("HAS_PHONE")
+          val USES_PAYMENT = IdentifierEdgeLabel("USES_PAYMENT")
+          val all: List<IdentifierEdgeLabel> = listOf(USES_DEVICE, USES_IP, HAS_PHONE, USES_PAYMENT)
+      }
+  }
+  ```
+  - 영문 KDoc 필수
+
+### T3-2: `AbuseCluster.kt`, `AbusePath.kt`, `SuspiciousUserScore.kt`
+- **complexity**: low
+- **파일**:
+  - `.../model/AbuseCluster.kt`
+  - `.../model/AbusePath.kt`
+  - `.../model/SuspiciousUserScore.kt`
+- **작업**: spec §5.3 그대로 — `Serializable`, `serialVersionUID = 1L`, `edgeLabel: IdentifierEdgeLabel`, 영문 KDoc
+
+---
+
+## Phase 4 — Blocking Service (복잡도: high)
+
+### T4-1: `AbuserDetectionService.kt` — 전체 구현
+- **complexity**: high
+- **파일**: `graph/abuser-detection/src/main/kotlin/io/bluetape4k/workshop/graph/abuser/service/AbuserDetectionService.kt`
+- **작업**:
+  - `initialize()`: `ops.graphExists` 체크 후 `ops.createGraph`
+  - **findOrCreate mutators** (각 identifier):
+    ```kotlin
+    fun addDevice(deviceId: String, platform: String): GraphVertex {
+        deviceId.requireNotBlank("deviceId")
+        return ops.findVerticesByLabel(DeviceLabel.label)
+            .firstOrNull { it.properties["deviceId"] == deviceId }
+            ?: ops.createVertex(DeviceLabel.label, mapOf("deviceId" to deviceId, "platform" to platform))
+    }
+    ```
+  - **`findAbuseCluster(seedUserId)`** — spec §6 label-dispatch 알고리즘 전체:
+    ```kotlin
+    val vertexLabelToEdgeLabel = mapOf(
+        "Device"        to IdentifierEdgeLabel.USES_DEVICE,
+        "IpAddress"     to IdentifierEdgeLabel.USES_IP,
+        "PhoneNumber"   to IdentifierEdgeLabel.HAS_PHONE,
+        "PaymentMethod" to IdentifierEdgeLabel.USES_PAYMENT,
+    )
+    ```
+  - **`explainSuspicion(userId)`**: `IdentifierEdgeLabel.all` 순회, `edgeLabel.value` String 전달
+  - **`detectReferralLoops`**: `ops.detectCycles(CycleOptions(...))`
+  - **`rankSuspiciousUsers`**: `ops.pageRank(PageRankOptions(...))` → User 필터 → limit → SuspiciousUserScore
+  - 영문 KDoc 필수
+
+---
+
+## Phase 5 — Suspend Service (복잡도: medium)
+
+### T5-1: `AbuserDetectionSuspendService.kt` — suspend + Flow variants
+- **complexity**: medium
+- **파일**: `graph/abuser-detection/src/main/kotlin/io/bluetape4k/workshop/graph/abuser/service/AbuserDetectionSuspendService.kt`
+- **작업**:
+  - T4-1 과 동일한 로직; `ops: GraphSuspendOperations` 사용
+  - mutators: `suspend fun`
+  - `findAbuseCluster`: `suspend fun` returning `AbuseCluster`
+  - `explainSuspicion`, `detectReferralLoops`, `rankSuspiciousUsers`: `Flow<T>` (cold flow)
+  - Flow 수집 시 `CancellationException` 전파 (runCatching 내 suspend 호출 금지)
+  - 영문 KDoc + @param Flow 수집 방법 설명
+
+---
+
+## Phase 6 — Seed Data (복잡도: medium)
+
+### T6-1: `AbuserDetectionSeed.kt` — 결정론적 테스트 픽스처
+- **complexity**: medium
+- **파일**: `graph/abuser-detection/src/main/kotlin/io/bluetape4k/workshop/graph/abuser/seed/AbuserDetectionSeed.kt`
+- **작업**:
+  - 고정 3-user × 2-device 공유 시나리오 (테스트 케이스 2, 3 커버)
+  - referral cycle A→B→C→A (테스트 케이스 4 커버)
+  - 독립 사용자 (테스트 케이스 7 커버)
+  - 모든 timestamp 고정 (`"2026-01-01T00:00:00Z"`)
+  - 모든 identifier 는 placeholder hash (`"device-hash-a1b2c3"` 등)
+  - `fun seedAll(service: AbuserDetectionService): SeedResult` 반환 (user/identifier GraphVertex map)
+  - `data class SeedResult(...)` — 테스트에서 seedUserId 등 참조용
+
+---
+
+## Phase 7 — Abstract Test Base Blocking (복잡도: medium)
+
+### T7-1: `AbstractAbuserDetectionTest.kt`
+- **complexity**: medium
+- **파일**: `graph/abuser-detection/src/test/kotlin/io/bluetape4k/workshop/graph/abuser/AbstractAbuserDetectionTest.kt`
+- **작업**:
+  - `@TestInstance(TestInstance.Lifecycle.PER_CLASS)` 필수
+  - `@BeforeEach cleanGraph()`: `runCatching { dropGraph }.onFailure { log.warn }` + `service.initialize()`
+  - 12개 테스트 케이스 (happy 7 + failure 5):
+    1. creates user and links device
+    2. finds shared-device abuse cluster — returns 2 other users (seed excluded)
+    3. explains suspicion by shared device and IP
+    4. detects referral loops (A→B→C→A)
+    5. ranks user at center of identifier sharing as most suspicious
+    6. empty graph returns empty cluster
+    7. cluster excludes unrelated users
+    8. `addDevice with blank deviceId throws IllegalArgumentException`
+    9. `addUser with blank userId throws IllegalArgumentException`
+    10. `findAbuseCluster with non-existent seedUserId returns empty cluster`
+    11. `rankSuspiciousUsers returns empty list on empty graph`
+    12. `detectReferralLoops returns empty list when no REFERRED_BY edges exist`
+  - Exception tests: `assertFailsWith<IllegalArgumentException> { }`
+  - Assertion: `shouldBe`, `shouldContainExactlyInAnyOrder` etc. (bluetape4k-assertions)
+  - 백틱 테스트 이름 사용
+
+---
+
+## Phase 8 — Abstract Test Base Suspend (복잡도: medium)
+
+### T8-1: `AbstractAbuserDetectionSuspendTest.kt`
+- **complexity**: medium
+- **파일**: `graph/abuser-detection/src/test/kotlin/io/bluetape4k/workshop/graph/abuser/AbstractAbuserDetectionSuspendTest.kt`
+- **작업**:
+  - `@TestInstance(TestInstance.Lifecycle.PER_CLASS)` 필수 (T7-1 과 동일)
+  - 동일 12개 테스트를 `runTest { }` 로 래핑
+  - Flow 테스트: `explainSuspicion(...).toList()`, `rankSuspiciousUsers(...).toList()`
+  - suspend exception: `coInvoking { suspendCall } shouldThrow IllegalArgumentException::class`
+  - `CancellationException` 재throw — suspend 본문에서 `runCatching` 사용 금지
+
+---
+
+## Phase 9 — TinkerGraph Concrete Tests (복잡도: low)
+
+### T9-1: `AbuserDetectionTinkerGraphTest.kt` + `AbuserDetectionSuspendTinkerGraphTest.kt`
+- **complexity**: low
+- **파일**:
+  - `.../AbuserDetectionTinkerGraphTest.kt`
+  - `.../AbuserDetectionSuspendTinkerGraphTest.kt`
+- **작업**:
+  - `@Tag` 없음 (default run 대상)
+  - TinkerGraph `GraphOperations` / `GraphSuspendOperations` 인스턴스 생성 (bluetape4k-graph-tinkerpop API 참조)
+  - `graphName = "abuser_tinkergraph"`
+  - `AbuserDetectionService(ops, graphName)` / `AbuserDetectionSuspendService(ops, graphName)` 생성
+  - `AbstractAbuserDetectionTest` / `AbstractAbuserDetectionSuspendTest` 확장
+
+---
+
+## Phase 10 — Integration Tests (복잡도: medium)
+
+### T10-1: `AbuserDetectionNeo4jTest.kt`
+- **complexity**: medium
+- **파일**: `.../AbuserDetectionNeo4jTest.kt`
+- **작업**:
+  - `@Tag("integration")`
+  - `@TestInstance(TestInstance.Lifecycle.PER_CLASS)` (상속으로 충분하나 명시 권장)
+  - companion object: `val neo4j = Neo4jServer.Launcher.neo4j` (bluetape4k-testcontainers)
+  - `graphName = "abuser_neo4j"`
+  - `@AfterAll fun teardown()`: `runCatching { dropGraph }.onFailure { log.warn }` + `driver.close()`
+  - abstract base 에서 close 호출 없음
+
+### T10-2: `AbuserDetectionMemgraphTest.kt`
+- **complexity**: medium
+- **파일**: `.../AbuserDetectionMemgraphTest.kt`
+- **작업**:
+  - T10-1 과 동일 패턴, `MemgraphServer.Launcher.memgraph`
+  - `graphName = "abuser_memgraph"`
+
+---
+
+## Phase 11 — README (복잡도: low)
+
+### T11-1: `README.md` + `README.ko.md`
+- **complexity**: low
+- **파일**:
+  - `graph/abuser-detection/README.md`
+  - `graph/abuser-detection/README.ko.md`
+- **작업**:
+  - Architecture diagram 포함 (spec §2 참조)
+  - `Skill("bluetape4k-diagram")` 호출하여 SVG+PNG 생성 — 직접 SVG 작성 금지
+  - 다이어그램 저장: `docs/images/readme-diagrams/abuser-detection-architecture.{svg,png}`
+  - 구조: Architecture → Core Features → Usage Examples → Build/Test
+
+---
+
+## Phase 12 — Final Wiring + Verification (복잡도: low)
+
+### T12-1: 모듈 등록 검증 + TinkerGraph 테스트 실행
+- **complexity**: low
+- **작업**:
+  ```bash
+  cd /Users/debop/work/bluetape4k/bluetape4k-workshop/.worktrees/feat/graph-abuser-detection
+  ./gradlew :graph-abuser-detection:build -x test --no-daemon   # compile check
+  ./gradlew :graph-abuser-detection:test --no-daemon            # TinkerGraph tests (no Docker)
+  ```
+  - 결과 기록: pass count, elapsed time
+  - 실패 시 → `bugfix-workflow` 호출
+
+### T12-2: CI workflow 확인
+- **complexity**: low
+- **작업**:
+  ```bash
+  rg "graph-abuser-detection|graph-abuser" .github/workflows/
+  ```
+  - 신규 모듈 CI 추가 누락 여부 확인
+  - 필요 시 CI path filter 및 job matrix 추가
+
+### T12-3: Lessons 문서 작성 + 커밋 (PR 생성 전 필수)
+- **complexity**: low
+- **파일**: `docs/lessons/2026-05-25-graph-abuser-detection.md`
+- **작업**: root cause, decision, outcome, review misses, future guidance
+
+---
+
+## 실행 순서 (병렬 가능 그룹)
+
+```
+P1 (T1-1 ~ T1-4)  → 순차 (서로 의존)
+P2 (T2-1)          → P1 완료 후
+P3 (T3-1, T3-2)    → P2 완료 후 (병렬 가능)
+P4 (T4-1)          → P3 완료 후 (high complexity — Opus)
+P5 (T5-1)          → P3 완료 후 (P4 와 병렬 가능)
+P6 (T6-1)          → P4, P5 완료 후
+P7 (T7-1)          → P6 완료 후 (high complexity — Opus)
+P8 (T8-1)          → P6 완료 후 (P7 과 병렬 가능)
+P9 (T9-1)          → P7, P8 완료 후
+P10 (T10-1, T10-2) → P7, P8 완료 후 (P9 와 병렬 가능)
+P11 (T11-1)        → 코드 완성 후 (P9 이후)
+P12 (T12-1~3)      → 전체 완료 후
+```
+
+---
+
+## DoD 체크리스트
+
+- [ ] T1-1~T1-4: 모듈 스캐폴딩 완료
+- [ ] T2-1: AbuserDetectionSchema.kt — 5 vertex + 5 edge labels
+- [ ] T3-1~T3-2: 모델 타입 4종 (IdentifierEdgeLabel, AbuseCluster, AbusePath, SuspiciousUserScore)
+- [ ] T4-1: AbuserDetectionService — label-dispatch + findOrCreate 구현
+- [ ] T5-1: AbuserDetectionSuspendService — Flow variants
+- [ ] T6-1: AbuserDetectionSeed — 결정론적 픽스처
+- [ ] T7-1: AbstractAbuserDetectionTest — 12 test cases
+- [ ] T8-1: AbstractAbuserDetectionSuspendTest — 12 test cases (runTest)
+- [ ] T9-1: TinkerGraph 구상 테스트 2종
+- [ ] T10-1~T10-2: Neo4j + Memgraph integration 테스트
+- [ ] T11-1: README.md + README.ko.md + diagram
+- [ ] T12-1: `./gradlew :graph-abuser-detection:test` 전체 통과
+- [ ] T12-2: CI workflow 누락 없음
+- [ ] T12-3: Lessons 문서 커밋 (PR 전)

--- a/docs/superpowers/plans/2026-05-25-graph-abuser-detection-plan.md
+++ b/docs/superpowers/plans/2026-05-25-graph-abuser-detection-plan.md
@@ -97,6 +97,26 @@
   - Edge labels: `UsesDeviceLabel`, `UsesIpLabel`, `HasPhoneLabel`, `UsesPaymentLabel`, `ReferredByLabel`
   - 각 object 는 `VertexLabel` / `EdgeLabel` interface 구현 (bluetape4k-graph-core API 확인 후)
   - 영문 KDoc 필수
+  - **⚠️ Security KDoc 필수** — 민감 속성에 반드시 보안 주석 명기:
+    ```kotlin
+    /**
+     * Vertex label for phone number identifiers.
+     *
+     * **Security**: `phone` property stores an **E.164-format hash** (SHA-256 hex or equivalent).
+     * Raw phone numbers MUST NOT be persisted in the graph. Callers are responsible for hashing
+     * before calling [AbuserDetectionService.addPhoneNumber].
+     */
+    object PhoneNumberLabel : VertexLabel { ... }
+
+    /**
+     * Vertex label for payment method identifiers.
+     *
+     * **Security**: `paymentToken` stores a **PCI-safe processor token** (e.g., Stripe/Braintree token),
+     * never a raw PAN or CVV. Callers must obtain a tokenised reference from the payment processor
+     * before calling [AbuserDetectionService.addPaymentMethod].
+     */
+    object PaymentMethodLabel : VertexLabel { ... }
+    ```
 
 ---
 
@@ -272,7 +292,9 @@
     4. `detects referral loops (A→B→C→A)` — `seedReferralCycle(service)` 호출
     5. `ranks user at center of identifier sharing as most suspicious` — `seedSharedIdentifiers(service)` 사용
     6. `empty graph returns empty cluster` — seed 없음; `findAbuseCluster(nonExistentId).users.isEmpty()`
-    7. `cluster excludes unrelated users` — `seedIsolatedUser(service)` 호출 후 `findAbuseCluster` 결과에 unrelatedUser 없음 확인
+    7. `cluster excludes unrelated users` — `seedIsolatedUser(service)` 호출 후:
+       - `findAbuseCluster(seed.user1.id).users` 에 `seed.unrelatedUser` 포함 안 됨 확인
+       - `findAbuseCluster(seed.unrelatedUser.id).users.isEmpty()` 확인 (isolated user 시드 시 cluster 비어 있어야 함)
     8. `addDevice with blank deviceId throws IllegalArgumentException`
     9. `addUser with blank userId throws IllegalArgumentException`
     10. `findAbuseCluster with non-existent seedUserId returns empty cluster`
@@ -310,16 +332,35 @@
     // coInvoking { service.explainSuspicion(GraphElementId("")) } shouldThrow IllegalArgumentException::class
     ```
   - **suspend `fun` exception 테스트**: `coInvoking { service.addDevice("", "ios") } shouldThrow IllegalArgumentException::class`
-  - **Flow 취소 검증 테스트** (test 16): `rankSuspiciousUsers` Flow 를 collect 중인 Job 을 cancel 하고 `CancellationException` 전파 확인
+  - **Flow 취소 검증 테스트** (test 16): `rankSuspiciousUsers` Flow 를 collect 중인 Job 을 cancel 하고 취소 전파 확인
     ```kotlin
+    // ✅ Option A — async + deferred.await() (CancellationException 전파 검증)
     runTest {
-        val scope = CoroutineScope(Job())
-        val job = scope.launch {
+        val deferred = async {
+            service.rankSuspiciousUsers().collect { }
+        }
+        deferred.cancel()
+        assertFailsWith<CancellationException> { deferred.await() }
+    }
+
+    // ✅ Option B — backgroundScope (isCancelled 상태 검증)
+    runTest {
+        val job = backgroundScope.launch {
             service.rankSuspiciousUsers().collect { }
         }
         job.cancel()
-        assertFailsWith<CancellationException> { job.join() }
+        job.join()
+        job.isCancelled shouldBe true
     }
+    ```
+    **⚠️ 금지 패턴 — compile 통과하나 런타임 오류**:
+    ```kotlin
+    // ❌ WRONG — job.join() 은 취소된 Job 에서 CancellationException 를 throw 하지 않음
+    assertFailsWith<CancellationException> { job.join() }
+
+    // ❌ WRONG — CoroutineScope(Job()) 은 runTest dispatcher 외부 scope; 테스트 종료 후에도 살아있는 coroutine leak
+    val scope = CoroutineScope(Job())
+    scope.launch { ... }
     ```
   - `CancellationException` 재throw 필수 (runCatching 내 suspend 호출 금지)
 
@@ -365,17 +406,27 @@
 - **complexity**: medium
 - **파일**: `.../AbuserDetectionMemgraphTest.kt`
 - **작업**:
+  - **`@Tag("integration")` 필수** — default `test` task 에서 제외, `integrationTest` task 에서만 실행
   - T10-1 과 동일 패턴, `MemgraphServer.Launcher.memgraph`
   - `graphName = "abuser_memgraph"`
   - **Driver wiring skeleton**:
     ```kotlin
-    companion object : KLogging() {
-        val memgraph = MemgraphServer.Launcher.memgraph
-        val driver: Driver = GraphDatabase.driver(memgraph.boltUrl, AuthTokens.none())
+    @Tag("integration")
+    class AbuserDetectionMemgraphTest : AbstractAbuserDetectionTest() {
+        companion object : KLogging() {
+            val memgraph = MemgraphServer.Launcher.memgraph
+            val driver: Driver = GraphDatabase.driver(memgraph.boltUrl, AuthTokens.none())
+        }
+        // ⚠️ graphName MUST be declared before ops (same initialization order rule as T10-1)
+        override val graphName = "abuser_memgraph"
+        override val ops: GraphOperations = MemgraphGraphOperations(driver, graphName)
+
+        @AfterAll
+        fun teardown() {
+            runCatching { if (ops.graphExists(graphName)) ops.dropGraph(graphName) }.onFailure { log.warn(it) { "dropGraph failed" } }
+            driver.close()
+        }
     }
-    // ⚠️ graphName MUST be declared before ops (same initialization order rule as T10-1)
-    override val graphName = "abuser_memgraph"
-    override val ops: GraphOperations = MemgraphGraphOperations(driver, graphName)
     ```
 
 ### T10-3: `AbuserDetectionSuspendNeo4jTest.kt`
@@ -388,14 +439,60 @@
   - `override val ops: GraphSuspendOperations = Neo4jGraphSuspendOperations(driver, graphName)`
   - `graphName = "abuser_suspend_neo4j"` (T10-1 와 다른 unique name — DB 충돌 방지)
   - `AbstractAbuserDetectionSuspendTest` 확장
+  - **`@AfterAll fun teardown()` 필수** — driver 반납:
+    ```kotlin
+    @AfterAll
+    fun teardown() {
+        runCatching { if (ops.graphExists(graphName)) ops.dropGraph(graphName) }.onFailure { log.warn(it) { "dropGraph failed" } }
+        driver.close()
+    }
+    ```
+  - **Driver wiring skeleton**:
+    ```kotlin
+    @Tag("integration")
+    class AbuserDetectionSuspendNeo4jTest : AbstractAbuserDetectionSuspendTest() {
+        companion object : KLogging() {
+            val neo4j = Neo4jServer.Launcher.neo4j
+            val driver: Driver = GraphDatabase.driver(neo4j.boltUrl, AuthTokens.none())
+        }
+        override val graphName = "abuser_suspend_neo4j"
+        override val ops: GraphSuspendOperations = Neo4jGraphSuspendOperations(driver, graphName)
+
+        @AfterAll
+        fun teardown() {
+            runCatching { if (ops.graphExists(graphName)) ops.dropGraph(graphName) }.onFailure { log.warn(it) { "dropGraph failed" } }
+            driver.close()
+        }
+    }
+    ```
 
 ### T10-4: `AbuserDetectionSuspendMemgraphTest.kt`
 - **complexity**: medium
 - **파일**: `.../AbuserDetectionSuspendMemgraphTest.kt`
 - **작업**:
+  - **`@Tag("integration")` 필수** — default `test` task 에서 제외, `integrationTest` task 에서만 실행
   - T10-3 패턴, `MemgraphServer.Launcher.memgraph`
   - **⚠️ 초기화 순서**: `override val graphName = "abuser_suspend_memgraph"` 를 `override val ops` **앞에** 선언
   - `graphName = "abuser_suspend_memgraph"`
+  - **`@AfterAll fun teardown()` 필수** — driver 반납:
+  - **Driver wiring skeleton**:
+    ```kotlin
+    @Tag("integration")
+    class AbuserDetectionSuspendMemgraphTest : AbstractAbuserDetectionSuspendTest() {
+        companion object : KLogging() {
+            val memgraph = MemgraphServer.Launcher.memgraph
+            val driver: Driver = GraphDatabase.driver(memgraph.boltUrl, AuthTokens.none())
+        }
+        override val graphName = "abuser_suspend_memgraph"
+        override val ops: GraphSuspendOperations = MemgraphGraphSuspendOperations(driver, graphName)
+
+        @AfterAll
+        fun teardown() {
+            runCatching { if (ops.graphExists(graphName)) ops.dropGraph(graphName) }.onFailure { log.warn(it) { "dropGraph failed" } }
+            driver.close()
+        }
+    }
+    ```
 
 ---
 

--- a/docs/superpowers/plans/2026-05-25-graph-abuser-detection-plan.md
+++ b/docs/superpowers/plans/2026-05-25-graph-abuser-detection-plan.md
@@ -6,21 +6,32 @@
 **Spec**: `docs/superpowers/specs/2026-05-25-graph-abuser-detection-design.md`  
 **모듈**: `graph/abuser-detection` → Gradle 모듈명: `graph-abuser-detection`  
 **참조 구현**: `/Users/debop/work/bluetape4k/bluetape4k-graph/examples/fraud-detection-examples/`  
-**스택**: Kotlin 2.3, Java 25, bluetape4k 1.5.0-Beta2, bluetape4k-graph 0.4.2
+**스택**: Kotlin 2.3, Java 25, bluetape4k 1.5.0-Beta2, bluetape4k-graph 0.4.1 (또는 mavenLocal 0.4.2)
 
 ---
 
 ## 핵심 Spec 결정 사항 (task 에 인코딩됨)
 
-1. **§6 label-dispatch**: `vertexLabelToEdgeLabel: Map<String, IdentifierEdgeLabel>` literal map 사용 (`"Device"→USES_DEVICE` 등). `.uppercase()` 비교 절대 금지.
-2. **§5.1 findOrCreate**: `ops.findVerticesByLabel(label).firstOrNull { it.properties["key"] == value }` — 먼저 조회 후 없으면 생성.
-3. **§9 @TestInstance(PER_CLASS)**: 두 abstract base (`AbstractAbuserDetectionTest`, `AbstractAbuserDetectionSuspendTest`) 모두 필수.
-4. **§9 cleanGraph**: `@BeforeEach` 에서 `runCatching { dropGraph }.onFailure { log.warn }` 래핑.
-5. **§9 driver ownership**: integration 구상 클래스 `@AfterAll` 이 `driver.close()` 단독 호출; abstract base 는 close 금지.
-6. **§9 unique graphName**: `"abuser_neo4j"` / `"abuser_memgraph"` per backend.
-7. **§8 integrationTest task**: `tasks.test { excludeTags("integration") }` + `tasks.register<Test>("integrationTest") { includeTags("integration") }`.
-8. **Testcontainers**: `Neo4jServer.Launcher.neo4j`, `MemgraphServer.Launcher.memgraph` singleton 사용 — `GenericContainer` 직접 생성 금지.
-9. **§10 validation**: 모든 identifier mutator 가 `requireNotBlank` 를 findOrCreate 전에 호출.
+1. **§6 label-dispatch**: `VERTEX_LABEL_TO_EDGE_LABEL` companion object `private val` 에 선언 — 함수 body 에 `val` 로 선언 금지 (매 호출마다 Map 재생성 방지 + 프로젝트 규칙 준수).
+2. **§5.1 findOrCreate — server-side filter 사용**: `ops.findVerticesByLabel(label, mapOf("deviceId" to deviceId)).firstOrNull()` — client-side 전체 스캔 금지.
+3. **§5.1 findOrCreate idempotency**: 두 번 호출 시 동일 vertex ID 반환 + 중복 vertex 미생성. test case 13 으로 검증.
+4. **§5.2 suspend Flow API 차이**: `GraphSuspendVertexRepository.findVerticesByLabel` 는 `Flow<GraphVertex>` 반환 — `List` 아님. `import kotlinx.coroutines.flow.firstOrNull` 필수.
+5. **§5.2 `Flow.mapIndexed` 없음**: `rankSuspiciousUsers` suspend 구현은 `.withIndex().map { (idx, s) -> SuspiciousUserScore(s.vertex, s.score, idx + 1) }` 사용.
+6. **§9 @TestInstance(PER_CLASS)**: 두 abstract base 모두 필수.
+7. **§9 cleanGraph**: `@BeforeEach` 에서 `runCatching { dropGraph }.onFailure { log.warn }` + `service.initialize()` 래핑.
+8. **§9 driver ownership**: integration 구상 클래스 `@AfterAll` 이 `driver.close()` 단독 호출; abstract base 는 close 금지.
+9. **§9 unique graphName**: `"abuser_neo4j"` / `"abuser_memgraph"` per backend.
+10. **§8 integrationTest task**: `tasks.test { excludeTags("integration") }` + `tasks.register<Test>("integrationTest") { includeTags("integration") }`.
+11. **Testcontainers**: `Neo4jServer.Launcher.neo4j`, `MemgraphServer.Launcher.memgraph` singleton — `GenericContainer` 직접 생성 금지.
+12. **§9 `junit-platform.properties`**: `tags.exclude=integration` 포함 금지 — Gradle `tasks.test { excludeTags }` 만 사용. properties 는 병렬화 설정 전용.
+13. **§9 validation**: `requireNotBlank` 를 findOrCreate 전에 호출.
+14. **§9 Flow exception 테스트**: `explainSuspicion`, `detectReferralLoops` 는 non-suspend Flow 반환 — validation 은 collect 시 발생. `assertFailsWith<T> { service.explainSuspicion("").toList() }` 사용; `coInvoking { ... } shouldThrow` 사용 금지.
+15. **§9 test case 13**: `addDevice` 동일 deviceId 2회 → 동일 vertex ID, duplicate 없음.
+16. **§9 test cases 14–15**: Phone/PaymentMethod 분기 + REFERRED_BY 제외 음성 테스트.
+17. **REFERRED_BY exclusion 검증**: `findAbuseCluster` 가 REFERRED_BY 만으로 연결된 user 를 결과에서 제외하는 것을 명시적 음성 테스트로 검증 (test case 15).
+18. **seed 전략**: `AbuserDetectionSeed` 는 composable helpers (`seedSharedIdentifiers()`, `seedReferralCycle()`, `seedIsolatedUser()`) 로 분리. 각 test 는 `@BeforeEach cleanGraph` 후 필요한 helper 만 호출.
+19. **suspend seeder**: T6-1 이 `suspend fun seedAll(service: AbuserDetectionSuspendService): SeedResult` 도 제공.
+20. **version resolution**: `bluetape4k-graph 0.4.2` 는 Maven Central 미발행. T1-2 에서 mavenLocal 발행 여부 확인 후 버전 결정.
 
 ---
 
@@ -30,18 +41,25 @@
 - **complexity**: low
 - **파일**: `settings.gradle.kts`
 - **작업**:
-  - `includeModules("graph", false, true)` 삽입 (`gatling` 과 `image-processing` 사이, 알파벳 순)
+  - `includeModules("graph", false, true)` 삽입 (`graalvm` 과 `image-processing` 사이, 알파벳 순)
+  - **실제 파일 확인**: `settings.gradle.kts` lines 26–27: `graalvm → image-processing` 순서; `graph` 는 `graalvm` 뒤에 삽입
   - 결과 모듈명: `:graph-abuser-detection`
 
 ### T1-2: `gradle/libs.versions.toml` 에 bluetape4k-graph 추가
 - **complexity**: low
 - **파일**: `gradle/libs.versions.toml`
+- **⚠️ version resolution 주의**: `bluetape4k-graph 0.4.2` 는 Maven Central 미발행 (확인: `baseVersion=0.4.2, snapshotVersion=` in bluetape4k-graph/gradle.properties). 구현 전 아래 순서로 확인:
+  1. `./gradlew -p /Users/debop/work/bluetape4k/bluetape4k-graph publishAllPublicationsToMavenLocalRepository` 로 0.4.2 로컬 발행 여부 확인
+  2. 발행된 경우: `settings.gradle.kts` 에 `mavenLocal()` 추가 + `bluetape4k-graph = "0.4.2"` 사용
+  3. 미발행인 경우: `bluetape4k-graph = "0.4.1"` 사용 (Maven Central 최신 확인 버전)
+  4. 어느 경우든 TODO 주석 필수
 - **작업**:
   ```toml
   [versions]
   # TODO: bluetape4k-dependencies BOM 이 bluetape4k-graph 를 govern 하면 pin 제거.
-  bluetape4k-graph = "0.4.2"
-  
+  # Version resolution: 0.4.2 로컬 빌드 발행 시 mavenLocal() 필요; 아니면 0.4.1 (last Maven Central).
+  bluetape4k-graph = "0.4.1"   # or "0.4.2" if published to mavenLocal
+
   [libraries]
   bluetape4k-graph-bom       = { module = "io.github.bluetape4k.graph:bluetape4k-graph-bom", version.ref = "bluetape4k-graph" }
   bluetape4k-graph-core      = { module = "io.github.bluetape4k.graph:bluetape4k-graph-core" }
@@ -54,7 +72,8 @@
 ### T1-3: `graph/abuser-detection/build.gradle.kts` 생성
 - **complexity**: low
 - **파일**: `graph/abuser-detection/build.gradle.kts`
-- **작업**: spec §8 의 build.gradle.kts 내용 그대로 — BOM platform, core/tinkerpop impl, neo4j/memgraph compileOnly, integrationTest task, `excludeTags("integration")` on default test task
+- **작업**: spec §8 의 build.gradle.kts — BOM platform, core/tinkerpop impl, neo4j/memgraph `compileOnly` (NOT testImplementation — extendsFrom 이 테스트 classpath 로 전파), integrationTest task, `excludeTags("integration")` on default test task
+- **⚠️ 중복 의존성 금지**: `compileOnly(libs.bluetape4k.graph.neo4j)` + `testImplementation(libs.bluetape4k.graph.neo4j)` 동시 선언 금지. `compileOnly` + `extendsFrom` 으로 충분.
 
 ### T1-4: 테스트 리소스 생성
 - **complexity**: low
@@ -62,7 +81,7 @@
   - `graph/abuser-detection/src/test/resources/junit-platform.properties`
   - `graph/abuser-detection/src/test/resources/logback-test.xml`
 - **작업**:
-  - `junit-platform.properties`: `junit.jupiter.execution.parallel.enabled=false`, `junit.jupiter.tags.exclude=integration`
+  - `junit-platform.properties`: `junit.jupiter.execution.parallel.enabled=false` 만 — **`junit.jupiter.tags.exclude=integration` 절대 포함 금지** (JUnit 엔진 레벨 제외가 Gradle `integrationTest` 태스크도 막음; tag exclusion 은 `build.gradle.kts tasks.test { excludeTags }` 에서만)
   - `logback-test.xml`: 기존 workshop 모듈 logback-test.xml 복사
 
 ---
@@ -86,6 +105,7 @@
 ### T3-1: `IdentifierEdgeLabel.kt` — value class + companion constants
 - **complexity**: low
 - **파일**: `graph/abuser-detection/src/main/kotlin/io/bluetape4k/workshop/graph/abuser/model/IdentifierEdgeLabel.kt`
+- **주의**: `model/` 디렉토리에 배치 (schema/ 아님) — `IdentifierEdgeLabel` 은 DB 스키마 선언이 아닌 도메인 수준 dispatch enum
 - **작업**:
   ```kotlin
   @JvmInline
@@ -111,34 +131,56 @@
 
 ---
 
-## Phase 4 — Blocking Service (복잡도: high)
+## Phase 4 — Blocking Service (복잡도: high → 2개 sub-task로 분할)
 
-### T4-1: `AbuserDetectionService.kt` — 전체 구현
-- **complexity**: high
+### T4-1a: `AbuserDetectionService.kt` — mutators 구현 (CRUD operations)
+- **complexity**: medium
 - **파일**: `graph/abuser-detection/src/main/kotlin/io/bluetape4k/workshop/graph/abuser/service/AbuserDetectionService.kt`
 - **작업**:
-  - `initialize()`: `ops.graphExists` 체크 후 `ops.createGraph`
-  - **findOrCreate mutators** (각 identifier):
+  - `initialize()`: `ops.graphExists` 체크 후 `ops.createGraph`; idempotent; safe to call multiple times
+  - **findOrCreate mutators** — server-side filter 사용 (전체 스캔 금지):
     ```kotlin
     fun addDevice(deviceId: String, platform: String): GraphVertex {
         deviceId.requireNotBlank("deviceId")
-        return ops.findVerticesByLabel(DeviceLabel.label)
-            .firstOrNull { it.properties["deviceId"] == deviceId }
+        return ops.findVerticesByLabel(DeviceLabel.label, mapOf("deviceId" to deviceId))
+            .firstOrNull()
             ?: ops.createVertex(DeviceLabel.label, mapOf("deviceId" to deviceId, "platform" to platform))
     }
     ```
-  - **`findAbuseCluster(seedUserId)`** — spec §6 label-dispatch 알고리즘 전체:
+  - `addUser`, `addIpAddress`, `addPhoneNumber`, `addPaymentMethod` 동일 패턴 (각 key 속성으로 서버 필터)
+  - `linkDevice`, `linkIp`, `linkPhone`, `linkPayment`, `linkReferral` — `ops.createEdge` 호출
+  - **KDoc 주의사항 (각 mutator)**: "Not safe for concurrent invocation; findOrCreate is not atomic. For atomic upsert, use mergeVertex."
+  - 영문 KDoc 필수
+
+### T4-1b: `AbuserDetectionService.kt` — query 알고리즘 구현
+- **complexity**: high
+- **파일**: 동일 파일 (T4-1a 와 같은 클래스)
+- **선행**: T4-1a 완료 후 진행
+- **작업**:
+  - **`VERTEX_LABEL_TO_EDGE_LABEL` — companion object 에 선언** (함수 body 에 val 금지):
     ```kotlin
-    val vertexLabelToEdgeLabel = mapOf(
-        "Device"        to IdentifierEdgeLabel.USES_DEVICE,
-        "IpAddress"     to IdentifierEdgeLabel.USES_IP,
-        "PhoneNumber"   to IdentifierEdgeLabel.HAS_PHONE,
-        "PaymentMethod" to IdentifierEdgeLabel.USES_PAYMENT,
-    )
+    companion object : KLogging() {
+        private val VERTEX_LABEL_TO_EDGE_LABEL: Map<String, IdentifierEdgeLabel> = mapOf(
+            "Device"        to IdentifierEdgeLabel.USES_DEVICE,
+            "IpAddress"     to IdentifierEdgeLabel.USES_IP,
+            "PhoneNumber"   to IdentifierEdgeLabel.HAS_PHONE,
+            "PaymentMethod" to IdentifierEdgeLabel.USES_PAYMENT,
+        )
+    }
     ```
+  - **`findAbuseCluster(seedUserId)`** — spec §6 label-dispatch 알고리즘:
+    1. `ops.findVertexById(seedUserId) ?: return AbuseCluster(seedUserId, emptyList(), emptyList())` — 존재 여부 가드
+    2. `IdentifierEdgeLabel.all.flatMap { edgeLabel -> ops.neighbors(seedUserId, NeighborOptions(edgeLabel.value, OUTGOING, 1)) }` → seedIdentifiers
+    3. `seedIdentifiers.forEach { identifierVertex -> val matchingLabel = VERTEX_LABEL_TO_EDGE_LABEL[identifierVertex.label] ?: return@forEach ... }` → clusterUsers
   - **`explainSuspicion(userId)`**: `IdentifierEdgeLabel.all` 순회, `edgeLabel.value` String 전달
   - **`detectReferralLoops`**: `ops.detectCycles(CycleOptions(...))`
-  - **`rankSuspiciousUsers`**: `ops.pageRank(PageRankOptions(...))` → User 필터 → limit → SuspiciousUserScore
+  - **`rankSuspiciousUsers`** (List 반환 — `mapIndexed` 사용 가능):
+    ```kotlin
+    ops.pageRank(PageRankOptions(...))
+        .filter { it.vertex.label == UserLabel.label }
+        .take(limit)
+        .mapIndexed { idx, s -> SuspiciousUserScore(s.vertex, s.score, idx + 1) }
+    ```
   - 영문 KDoc 필수
 
 ---
@@ -148,13 +190,31 @@
 ### T5-1: `AbuserDetectionSuspendService.kt` — suspend + Flow variants
 - **complexity**: medium
 - **파일**: `graph/abuser-detection/src/main/kotlin/io/bluetape4k/workshop/graph/abuser/service/AbuserDetectionSuspendService.kt`
+- **선행**: T3-1, T3-2 완료
 - **작업**:
-  - T4-1 과 동일한 로직; `ops: GraphSuspendOperations` 사용
-  - mutators: `suspend fun`
-  - `findAbuseCluster`: `suspend fun` returning `AbuseCluster`
-  - `explainSuspicion`, `detectReferralLoops`, `rankSuspiciousUsers`: `Flow<T>` (cold flow)
+  - `ops: GraphSuspendOperations` 사용
+  - **findOrCreate — `Flow<GraphVertex>` 주의**: `GraphSuspendVertexRepository.findVerticesByLabel` 는 `Flow<GraphVertex>` 반환 (List 아님).
+    ```kotlin
+    suspend fun addDevice(deviceId: String, platform: String): GraphVertex {
+        deviceId.requireNotBlank("deviceId")
+        return ops.findVerticesByLabel(DeviceLabel.label, mapOf("deviceId" to deviceId))
+            .firstOrNull()   // import kotlinx.coroutines.flow.firstOrNull  ← REQUIRED
+            ?: ops.createVertex(DeviceLabel.label, mapOf("deviceId" to deviceId, "platform" to platform))
+    }
+    ```
+  - `VERTEX_LABEL_TO_EDGE_LABEL` — companion object 에 선언 (T4-1b 동일)
+  - `rankSuspiciousUsers` — **`Flow.mapIndexed` 없음** — `.withIndex().map { (idx, s) -> SuspiciousUserScore(s.vertex, s.score, idx + 1) }` 사용:
+    ```kotlin
+    fun rankSuspiciousUsers(limit: Int = 10): Flow<SuspiciousUserScore> = flow {
+        ops.pageRank(PageRankOptions(...))
+            .filter { it.vertex.label == UserLabel.label }
+            .take(limit)
+            .withIndex()
+            .forEach { (idx, s) -> emit(SuspiciousUserScore(s.vertex, s.score, idx + 1)) }
+    }
+    ```
   - Flow 수집 시 `CancellationException` 전파 (runCatching 내 suspend 호출 금지)
-  - 영문 KDoc + @param Flow 수집 방법 설명
+  - 영문 KDoc + Flow 수집 방법 설명 필수
 
 ---
 
@@ -163,40 +223,65 @@
 ### T6-1: `AbuserDetectionSeed.kt` — 결정론적 테스트 픽스처
 - **complexity**: medium
 - **파일**: `graph/abuser-detection/src/main/kotlin/io/bluetape4k/workshop/graph/abuser/seed/AbuserDetectionSeed.kt`
-- **작업**:
-  - 고정 3-user × 2-device 공유 시나리오 (테스트 케이스 2, 3 커버)
-  - referral cycle A→B→C→A (테스트 케이스 4 커버)
-  - 독립 사용자 (테스트 케이스 7 커버)
-  - 모든 timestamp 고정 (`"2026-01-01T00:00:00Z"`)
-  - 모든 identifier 는 placeholder hash (`"device-hash-a1b2c3"` 등)
-  - `fun seedAll(service: AbuserDetectionService): SeedResult` 반환 (user/identifier GraphVertex map)
-  - `data class SeedResult(...)` — 테스트에서 seedUserId 등 참조용
+- **선행**: T4-1a, T4-1b, T5-1 완료
+- **설계 전략**: `seedAll` 대신 **composable helpers** — 각 테스트가 `@BeforeEach cleanGraph` 후 필요한 helper 만 호출
+  - `seedSharedIdentifiers(service): SeedResult` — 3 users × shared device+IP (test 2, 3, 5, 14)
+  - `seedReferralCycle(service): SeedResult` — A→B→C→A cycle (test 4)
+  - `seedIsolatedUser(service): SeedResult` — 독립 사용자 (test 7)
+  - `seedAll(service): SeedResult` — 모두 포함 (backward compat, test 5)
+- **suspend variant 필수**: blocking 버전과 동일한 suspend helpers:
+  - `suspend fun seedSharedIdentifiers(service: AbuserDetectionSuspendService): SeedResult`
+  - `suspend fun seedReferralCycle(service: AbuserDetectionSuspendService): SeedResult`
+  - `suspend fun seedIsolatedUser(service: AbuserDetectionSuspendService): SeedResult`
+  - `suspend fun seedAll(service: AbuserDetectionSuspendService): SeedResult`
+- **`data class SeedResult` — 명시적 필드**:
+  ```kotlin
+  data class SeedResult(
+      val user1: GraphVertex,    // test 2, 3, 5: seed user
+      val user2: GraphVertex,    // test 2, 3, 5: shares device with user1
+      val user3: GraphVertex,    // test 2, 3, 5: shares device with user1 and user2
+      val unrelatedUser: GraphVertex,   // test 7: isolated user
+      val deviceA: GraphVertex,  // shared device
+      val ipA: GraphVertex,      // shared IP
+      val phoneA: GraphVertex?,  // test 14: shared phone number (null if not seeded)
+      val paymentA: GraphVertex?, // test 14: shared payment method (null if not seeded)
+      val referralUserA: GraphVertex?, // test 4: cycle node A
+      val referralUserB: GraphVertex?, // test 4: cycle node B
+      val referralUserC: GraphVertex?, // test 4: cycle node C
+  )
+  ```
+- 모든 timestamp 고정 (`"2026-01-01T00:00:00Z"`)
+- 모든 identifier 는 placeholder hash
 
 ---
 
-## Phase 7 — Abstract Test Base Blocking (복잡도: medium)
+## Phase 7 — Abstract Test Base Blocking (복잡도: high)
 
 ### T7-1: `AbstractAbuserDetectionTest.kt`
-- **complexity**: medium
+- **complexity**: high
 - **파일**: `graph/abuser-detection/src/test/kotlin/io/bluetape4k/workshop/graph/abuser/AbstractAbuserDetectionTest.kt`
 - **작업**:
   - `@TestInstance(TestInstance.Lifecycle.PER_CLASS)` 필수
   - `@BeforeEach cleanGraph()`: `runCatching { dropGraph }.onFailure { log.warn }` + `service.initialize()`
-  - 12개 테스트 케이스 (happy 7 + failure 5):
-    1. creates user and links device
-    2. finds shared-device abuse cluster — returns 2 other users (seed excluded)
-    3. explains suspicion by shared device and IP
-    4. detects referral loops (A→B→C→A)
-    5. ranks user at center of identifier sharing as most suspicious
-    6. empty graph returns empty cluster
-    7. cluster excludes unrelated users
+  - **각 테스트가 필요한 seed helper 직접 호출** (seedAll 를 @BeforeEach 에서 전역 호출 금지 — 일부 테스트는 빈 그래프 필요)
+  - **15개 테스트 케이스** (happy 7 + failure 5 + additional 3):
+    1. `creates user and links device` — `service.initialize()` 후 직접 addUser/addDevice/linkDevice (seed 없음)
+    2. `finds shared-device abuse cluster — returns 2 other users (seed excluded)` — `seedSharedIdentifiers(service)` 호출; assert `findAbuseCluster(seed.user1.id).users shouldContainExactlyInAnyOrder listOf(seed.user2, seed.user3)`
+    3. `explains suspicion by shared device and IP` — `seedSharedIdentifiers(service)` 사용
+    4. `detects referral loops (A→B→C→A)` — `seedReferralCycle(service)` 호출
+    5. `ranks user at center of identifier sharing as most suspicious` — `seedSharedIdentifiers(service)` 사용
+    6. `empty graph returns empty cluster` — seed 없음; `findAbuseCluster(nonExistentId).users.isEmpty()`
+    7. `cluster excludes unrelated users` — `seedIsolatedUser(service)` 호출 후 `findAbuseCluster` 결과에 unrelatedUser 없음 확인
     8. `addDevice with blank deviceId throws IllegalArgumentException`
     9. `addUser with blank userId throws IllegalArgumentException`
     10. `findAbuseCluster with non-existent seedUserId returns empty cluster`
     11. `rankSuspiciousUsers returns empty list on empty graph`
     12. `detectReferralLoops returns empty list when no REFERRED_BY edges exist`
+    13. `addDevice called twice with same deviceId returns the same vertex id` — `service.addDevice("device-X", "ios").id == service.addDevice("device-X", "ios").id`; `ops.findVerticesByLabel(DeviceLabel.label).count { it.properties["deviceId"] == "device-X" } == 1`
+    14. `shared phone and payment method detection` — seed two users sharing phone + payment; assert `findAbuseCluster` returns both with PhoneNumber + PaymentMethod in sharedIdentifiers
+    15. `cluster excludes REFERRED_BY-only reachable users` — link userA→userB via USES_DEVICE + REFERRED_BY; link userC→userA via REFERRED_BY only; assert userB in cluster, userC NOT in cluster
   - Exception tests: `assertFailsWith<IllegalArgumentException> { }`
-  - Assertion: `shouldBe`, `shouldContainExactlyInAnyOrder` etc. (bluetape4k-assertions)
+  - Assertion: `shouldBe`, `shouldContainExactlyInAnyOrder` (bluetape4k-assertions)
   - 백틱 테스트 이름 사용
 
 ---
@@ -206,12 +291,36 @@
 ### T8-1: `AbstractAbuserDetectionSuspendTest.kt`
 - **complexity**: medium
 - **파일**: `graph/abuser-detection/src/test/kotlin/io/bluetape4k/workshop/graph/abuser/AbstractAbuserDetectionSuspendTest.kt`
+- **선행**: T7-1 완료 (동일 15개 테스트 구조 참조)
 - **작업**:
-  - `@TestInstance(TestInstance.Lifecycle.PER_CLASS)` 필수 (T7-1 과 동일)
-  - 동일 12개 테스트를 `runTest { }` 로 래핑
+  - `@TestInstance(TestInstance.Lifecycle.PER_CLASS)` 필수
+  - 동일 15개 테스트를 `runTest { }` 로 래핑
+  - **suspend seeder 사용**: `seedSharedIdentifiers(suspendService)`, `seedReferralCycle(suspendService)`, `seedIsolatedUser(suspendService)` (T6-1 suspend 버전)
   - Flow 테스트: `explainSuspicion(...).toList()`, `rankSuspiciousUsers(...).toList()`
-  - suspend exception: `coInvoking { suspendCall } shouldThrow IllegalArgumentException::class`
-  - `CancellationException` 재throw — suspend 본문에서 `runCatching` 사용 금지
+  - **Flow exception 테스트 패턴 주의**: `explainSuspicion` 는 non-suspend Flow — validation 은 collect 시 발생
+    ```kotlin
+    // ✅ CORRECT
+    runTest {
+        assertFailsWith<IllegalArgumentException> {
+            service.explainSuspicion(GraphElementId("")).toList()
+        }
+    }
+    // ❌ WRONG (validation not triggered — flow not collected)
+    // coInvoking { service.explainSuspicion(GraphElementId("")) } shouldThrow IllegalArgumentException::class
+    ```
+  - **suspend `fun` exception 테스트**: `coInvoking { service.addDevice("", "ios") } shouldThrow IllegalArgumentException::class`
+  - **Flow 취소 검증 테스트** (test 16): `rankSuspiciousUsers` Flow 를 collect 중인 Job 을 cancel 하고 `CancellationException` 전파 확인
+    ```kotlin
+    runTest {
+        val scope = CoroutineScope(Job())
+        val job = scope.launch {
+            service.rankSuspiciousUsers().collect { }
+        }
+        job.cancel()
+        assertFailsWith<CancellationException> { job.join() }
+    }
+    ```
+  - `CancellationException` 재throw 필수 (runCatching 내 suspend 호출 금지)
 
 ---
 
@@ -225,7 +334,7 @@
 - **작업**:
   - `@Tag` 없음 (default run 대상)
   - TinkerGraph `GraphOperations` / `GraphSuspendOperations` 인스턴스 생성 (bluetape4k-graph-tinkerpop API 참조)
-  - `graphName = "abuser_tinkergraph"`
+  - `graphName = "abuser_tinkergraph"` — TinkerGraph 에서는 graphName 이 cosmetic (실제 graph 분리 없음; `dropGraph` 는 단일 in-memory graph 전체 초기화)
   - `AbuserDetectionService(ops, graphName)` / `AbuserDetectionSuspendService(ops, graphName)` 생성
   - `AbstractAbuserDetectionTest` / `AbstractAbuserDetectionSuspendTest` 확장
 
@@ -238,11 +347,16 @@
 - **파일**: `.../AbuserDetectionNeo4jTest.kt`
 - **작업**:
   - `@Tag("integration")`
-  - `@TestInstance(TestInstance.Lifecycle.PER_CLASS)` (상속으로 충분하나 명시 권장)
-  - companion object: `val neo4j = Neo4jServer.Launcher.neo4j` (bluetape4k-testcontainers)
-  - `graphName = "abuser_neo4j"`
-  - `@AfterAll fun teardown()`: `runCatching { dropGraph }.onFailure { log.warn }` + `driver.close()`
-  - abstract base 에서 close 호출 없음
+  - **Driver wiring skeleton**:
+    ```kotlin
+    companion object : KLogging() {
+        val neo4j = Neo4jServer.Launcher.neo4j  // bluetape4k-testcontainers launcher
+        val driver: Driver = GraphDatabase.driver(neo4j.boltUrl, AuthTokens.none())
+    }
+    override val ops: GraphOperations = Neo4jGraphOperations(driver, graphName)
+    override val graphName = "abuser_neo4j"
+    ```
+  - `@AfterAll fun teardown()`: `runCatching { if (ops.graphExists(graphName)) ops.dropGraph(graphName) }.onFailure { log.warn }` + `driver.close()`
 
 ### T10-2: `AbuserDetectionMemgraphTest.kt`
 - **complexity**: medium
@@ -250,19 +364,52 @@
 - **작업**:
   - T10-1 과 동일 패턴, `MemgraphServer.Launcher.memgraph`
   - `graphName = "abuser_memgraph"`
+  - **Driver wiring skeleton**:
+    ```kotlin
+    companion object : KLogging() {
+        val memgraph = MemgraphServer.Launcher.memgraph
+        val driver: Driver = GraphDatabase.driver(memgraph.boltUrl, AuthTokens.none())
+    }
+    override val ops: GraphOperations = MemgraphGraphOperations(driver, graphName)
+    override val graphName = "abuser_memgraph"
+    ```
+
+### T10-3: `AbuserDetectionSuspendNeo4jTest.kt`
+- **complexity**: medium
+- **파일**: `.../AbuserDetectionSuspendNeo4jTest.kt`
+- **작업**:
+  - `@Tag("integration")`
+  - T10-1 와 동일 container + driver wiring
+  - `override val ops: GraphSuspendOperations = Neo4jGraphSuspendOperations(driver, graphName)`
+  - `graphName = "abuser_suspend_neo4j"` (T10-1 와 다른 unique name)
+  - `AbstractAbuserDetectionSuspendTest` 확장
+
+### T10-4: `AbuserDetectionSuspendMemgraphTest.kt`
+- **complexity**: medium
+- **파일**: `.../AbuserDetectionSuspendMemgraphTest.kt`
+- **작업**:
+  - T10-3 패턴, `MemgraphServer.Launcher.memgraph`
+  - `graphName = "abuser_suspend_memgraph"`
 
 ---
 
 ## Phase 11 — README (복잡도: low)
+
+### T11-0: `Skill("bluetape4k-diagram")` 명시적 호출 (README 작성 전 필수)
+- **complexity**: low
+- **작업**:
+  - `Skill("bluetape4k-diagram")` 를 **T11-1 시작 전** 반드시 호출
+  - skill 미사용 시 raw SVG/Mermaid 작성 금지 — 오케스트레이터에 escalate
+  - skill 호출 후 diagram 가이드라인에 따라 아키텍처 다이어그램 준비
 
 ### T11-1: `README.md` + `README.ko.md`
 - **complexity**: low
 - **파일**:
   - `graph/abuser-detection/README.md`
   - `graph/abuser-detection/README.ko.md`
+- **선행**: T11-0 (`Skill("bluetape4k-diagram")`) 완료 후
 - **작업**:
   - Architecture diagram 포함 (spec §2 참조)
-  - `Skill("bluetape4k-diagram")` 호출하여 SVG+PNG 생성 — 직접 SVG 작성 금지
   - 다이어그램 저장: `docs/images/readme-diagrams/abuser-detection-architecture.{svg,png}`
   - 구조: Architecture → Core Features → Usage Examples → Build/Test
 
@@ -290,45 +437,73 @@
   - 신규 모듈 CI 추가 누락 여부 확인
   - 필요 시 CI path filter 및 job matrix 추가
 
-### T12-3: Lessons 문서 작성 + 커밋 (PR 생성 전 필수)
+### T12-3: Lessons 문서 작성 + 커밋 (**PR 생성 전 반드시 커밋 완료**)
 - **complexity**: low
 - **파일**: `docs/lessons/2026-05-25-graph-abuser-detection.md`
-- **작업**: root cause, decision, outcome, review misses, future guidance
+- **타이밍**: Step 7-P (PR 생성) 전에 이 파일을 반드시 feature branch 에 커밋; merge 후 작성하면 별도 PR 필요
+- **작업**: root cause, decision, outcome, review misses (label-dispatch bug, Flow API 차이, findOrCreate 전략), future guidance
+
+### T12-4: bluetape4k-patterns checklist 검증
+- **complexity**: low
+- **작업**:
+  - `Skill("bluetape4k-patterns")` 호출하여 패턴 체크리스트 실행
+  - Kotlin 패턴: `requireNotBlank`, `CancellationException`, `@TestInstance`, KDoc
+  - 테스트 패턴: `assertFailsWith`, `runTest`, Flow 취소, idempotency
+  - Testcontainers: launcher singleton 사용 확인
 
 ---
 
 ## 실행 순서 (병렬 가능 그룹)
 
 ```
-P1 (T1-1 ~ T1-4)  → 순차 (서로 의존)
-P2 (T2-1)          → P1 완료 후
-P3 (T3-1, T3-2)    → P2 완료 후 (병렬 가능)
-P4 (T4-1)          → P3 완료 후 (high complexity — Opus)
-P5 (T5-1)          → P3 완료 후 (P4 와 병렬 가능)
-P6 (T6-1)          → P4, P5 완료 후
-P7 (T7-1)          → P6 완료 후 (high complexity — Opus)
-P8 (T8-1)          → P6 완료 후 (P7 과 병렬 가능)
-P9 (T9-1)          → P7, P8 완료 후
-P10 (T10-1, T10-2) → P7, P8 완료 후 (P9 와 병렬 가능)
-P11 (T11-1)        → 코드 완성 후 (P9 이후)
-P12 (T12-1~3)      → 전체 완료 후
+P1 (T1-1 ~ T1-4)    → 순차 (서로 의존)
+P2 (T2-1)            → P1 완료 후
+P3 (T3-1, T3-2)      → P2 완료 후 (병렬 가능)
+P4a (T4-1a)          → P3 완료 후 (medium complexity)
+P4b (T4-1b)          → T4-1a 완료 후 (high complexity — Opus)
+P5 (T5-1)            → P3 완료 후 (P4a 와 병렬 가능; P4b 완료 전에 진행)
+P6 (T6-1)            → P4b, P5 완료 후 (blocking + suspend seeders 모두 필요)
+P7 (T7-1)            → P6 완료 후 (high complexity — Opus)
+P8 (T8-1)            → P6 완료 후 (P7 과 병렬 가능)
+P9 (T9-1)            → P7, P8 완료 후
+P10 (T10-1~T10-4)    → P7, P8 완료 후 (P9 와 병렬 가능)
+P11 (T11-0, T11-1)   → 코드 완성 후 (P9 이후); T11-0 먼저
+P12 (T12-1~T12-4)    → 전체 완료 후
 ```
 
 ---
 
 ## DoD 체크리스트
 
-- [ ] T1-1~T1-4: 모듈 스캐폴딩 완료
+- [ ] T1-1: `settings.gradle.kts` — `graph` 모듈 `graalvm` 뒤에 삽입
+- [ ] T1-2: `libs.versions.toml` — version resolution 완료 (mavenLocal/0.4.1/0.4.2 결정)
+- [ ] T1-3: `build.gradle.kts` — BOM + compileOnly + integrationTest task (중복 testImplementation 없음)
+- [ ] T1-4: `junit-platform.properties` — tags.exclude 없음; `logback-test.xml`
 - [ ] T2-1: AbuserDetectionSchema.kt — 5 vertex + 5 edge labels
 - [ ] T3-1~T3-2: 모델 타입 4종 (IdentifierEdgeLabel, AbuseCluster, AbusePath, SuspiciousUserScore)
-- [ ] T4-1: AbuserDetectionService — label-dispatch + findOrCreate 구현
-- [ ] T5-1: AbuserDetectionSuspendService — Flow variants
-- [ ] T6-1: AbuserDetectionSeed — 결정론적 픽스처
-- [ ] T7-1: AbstractAbuserDetectionTest — 12 test cases
-- [ ] T8-1: AbstractAbuserDetectionSuspendTest — 12 test cases (runTest)
+- [ ] T4-1a: AbuserDetectionService mutators — server-side filter findOrCreate
+- [ ] T4-1b: AbuserDetectionService queries — VERTEX_LABEL_TO_EDGE_LABEL companion + findVertexById guard + label-dispatch BFS
+- [ ] T5-1: AbuserDetectionSuspendService — Flow.firstOrNull + withIndex rank + Flow cancellation safe
+- [ ] T6-1: AbuserDetectionSeed — composable helpers + blocking + suspend variants + SeedResult 명시 필드
+- [ ] T7-1: AbstractAbuserDetectionTest — 15 test cases (7 happy + 5 failure + 3 additional)
+- [ ] T8-1: AbstractAbuserDetectionSuspendTest — 16 test cases (15 + Flow cancellation) + Flow exception 패턴 정확
 - [ ] T9-1: TinkerGraph 구상 테스트 2종
-- [ ] T10-1~T10-2: Neo4j + Memgraph integration 테스트
+- [ ] T10-1~T10-4: Neo4j + Memgraph integration 테스트 4종 (blocking + suspend per backend)
+- [ ] T11-0: `Skill("bluetape4k-diagram")` 호출 완료
 - [ ] T11-1: README.md + README.ko.md + diagram
 - [ ] T12-1: `./gradlew :graph-abuser-detection:test` 전체 통과
 - [ ] T12-2: CI workflow 누락 없음
-- [ ] T12-3: Lessons 문서 커밋 (PR 전)
+- [ ] T12-3: Lessons 문서 커밋 (PR 생성 전)
+- [ ] T12-4: bluetape4k-patterns checklist 통과
+
+---
+
+## Plan Review Iteration Log
+
+| Round | Reviewer | P0 | P1 | P2 | P3 | Applied |
+|-------|----------|----|----|----|----|---------|
+| Round 1 (Step 3-R) | 3r-delivery (haiku) | 0 | 3 | 0 | 0 | v2: T12-3 timing, T11-0 추가, T12-4 추가 |
+| Round 1 (Step 3-R) | 3r-tester (sonnet) | 0 | 7 | 3 | 0 | v2: test 13/14/15 추가; Flow exception 패턴; T10-3/T10-4 추가; T1-4 tags.exclude 제거; DoD count 수정 |
+| Round 1 (Step 3-R) | 3r-implementer (sonnet) | 0 | 3 | 3 | 3 | v2: T4-1a/b 분할; suspend seeder 추가; version 주의사항; T1-1 삽입 위치 수정 |
+| Round 1 (Step 3-R) | 3r-architect (sonnet) | 0 | 6 | 3 | 0 | v2: Flow firstOrNull; withIndex; server-side filter; seedAll composable; companion hoist; driver wiring; TOCTOU note; findVertexById guard |
+| **Round 1 total** | **all 4 agents** | **0** | **19** | **9** | **3** | **plan v2 반영 중** |

--- a/docs/superpowers/plans/2026-05-25-graph-abuser-detection-plan.md
+++ b/docs/superpowers/plans/2026-05-25-graph-abuser-detection-plan.md
@@ -203,15 +203,16 @@
     }
     ```
   - `VERTEX_LABEL_TO_EDGE_LABEL` — companion object 에 선언 (T4-1b 동일)
-  - `rankSuspiciousUsers` — **`Flow.mapIndexed` 없음** — `.withIndex().map { (idx, s) -> SuspiciousUserScore(s.vertex, s.score, idx + 1) }` 사용:
+  - `rankSuspiciousUsers` — **`Flow.mapIndexed` 없음** — `.withIndex().map { (idx, s) -> SuspiciousUserScore(s.vertex, s.score, idx + 1) }` 사용.
+    **`flow { }` 빌더 + `Flow.forEach` 패턴 금지 — `Flow.forEach` 는 존재하지 않음 (compile error).**
+    Direct pipeline 으로 작성:
     ```kotlin
-    fun rankSuspiciousUsers(limit: Int = 10): Flow<SuspiciousUserScore> = flow {
-        ops.pageRank(PageRankOptions(...))
+    fun rankSuspiciousUsers(limit: Int = 10): Flow<SuspiciousUserScore> =
+        ops.pageRank(PageRankOptions(vertexLabel = null, edgeLabel = null, topK = Int.MAX_VALUE))
             .filter { it.vertex.label == UserLabel.label }
             .take(limit)
             .withIndex()
-            .forEach { (idx, s) -> emit(SuspiciousUserScore(s.vertex, s.score, idx + 1)) }
-    }
+            .map { (idx, s) -> SuspiciousUserScore(s.vertex, s.score, idx + 1) }
     ```
   - Flow 수집 시 `CancellationException` 전파 (runCatching 내 suspend 호출 금지)
   - 영문 KDoc + Flow 수집 방법 설명 필수
@@ -353,8 +354,10 @@
         val neo4j = Neo4jServer.Launcher.neo4j  // bluetape4k-testcontainers launcher
         val driver: Driver = GraphDatabase.driver(neo4j.boltUrl, AuthTokens.none())
     }
-    override val ops: GraphOperations = Neo4jGraphOperations(driver, graphName)
+    // ⚠️ graphName MUST be declared before ops — Kotlin initializes properties in declaration order.
+    // Declaring ops first would read graphName before it is initialized (null → NPE or wrong value).
     override val graphName = "abuser_neo4j"
+    override val ops: GraphOperations = Neo4jGraphOperations(driver, graphName)
     ```
   - `@AfterAll fun teardown()`: `runCatching { if (ops.graphExists(graphName)) ops.dropGraph(graphName) }.onFailure { log.warn }` + `driver.close()`
 
@@ -370,8 +373,9 @@
         val memgraph = MemgraphServer.Launcher.memgraph
         val driver: Driver = GraphDatabase.driver(memgraph.boltUrl, AuthTokens.none())
     }
-    override val ops: GraphOperations = MemgraphGraphOperations(driver, graphName)
+    // ⚠️ graphName MUST be declared before ops (same initialization order rule as T10-1)
     override val graphName = "abuser_memgraph"
+    override val ops: GraphOperations = MemgraphGraphOperations(driver, graphName)
     ```
 
 ### T10-3: `AbuserDetectionSuspendNeo4jTest.kt`
@@ -380,8 +384,9 @@
 - **작업**:
   - `@Tag("integration")`
   - T10-1 와 동일 container + driver wiring
+  - **⚠️ 초기화 순서**: `override val graphName = "abuser_suspend_neo4j"` 를 `override val ops` **앞에** 선언
   - `override val ops: GraphSuspendOperations = Neo4jGraphSuspendOperations(driver, graphName)`
-  - `graphName = "abuser_suspend_neo4j"` (T10-1 와 다른 unique name)
+  - `graphName = "abuser_suspend_neo4j"` (T10-1 와 다른 unique name — DB 충돌 방지)
   - `AbstractAbuserDetectionSuspendTest` 확장
 
 ### T10-4: `AbuserDetectionSuspendMemgraphTest.kt`
@@ -389,6 +394,7 @@
 - **파일**: `.../AbuserDetectionSuspendMemgraphTest.kt`
 - **작업**:
   - T10-3 패턴, `MemgraphServer.Launcher.memgraph`
+  - **⚠️ 초기화 순서**: `override val graphName = "abuser_suspend_memgraph"` 를 `override val ops` **앞에** 선언
   - `graphName = "abuser_suspend_memgraph"`
 
 ---

--- a/docs/superpowers/specs/2026-05-25-graph-abuser-detection-design.md
+++ b/docs/superpowers/specs/2026-05-25-graph-abuser-detection-design.md
@@ -523,6 +523,13 @@ fun teardown() {
 > - `AbuserDetectionNeo4jTest`: `graphName = "abuser_neo4j"`
 > - `AbuserDetectionMemgraphTest`: `graphName = "abuser_memgraph"`
 > This prevents `dropGraph` in one class from racing with graph setup in another class.
+>
+> **⚠️ [P0-Impl-1] `graphName` is NOT the Bolt database name** — `Neo4jGraphOperations(driver, database)` and
+> `MemgraphGraphOperations(driver, database)` accept a `database: String` (Bolt database selector,
+> default `"neo4j"` / `"memgraph"`). Passing `"abuser_neo4j"` as the `database` argument will fail at
+> runtime with `ClientException: Database does not exist` on Community Edition containers.
+> The correct wiring: `Neo4jGraphOperations(driver)` (drop the second arg); `graphName` flows only to
+> `AbuserDetectionService(ops, graphName)` and then into `createGraph(graphName)` / `dropGraph(graphName)`.
 
 > **`AbstractAbuserDetectionSuspendTest`**: The `@TestInstance(TestInstance.Lifecycle.PER_CLASS)` requirement applies equally. Declare the annotation on the suspend abstract base class for the same reason.
 
@@ -668,3 +675,5 @@ the expected format (e.g., `@param phone E.164 SHA-256 hex hash, not plaintext`)
 | **Step 3-R Pre-Round 2 fixes** | inline advisor | 0 | 3 | 0 | 0 | spec v6 (§13 DoD 12→15/16) + plan v3 (T5-1 Flow.forEach→direct pipeline; T10-1~4 graphName init order; API class names verified) |
 | **Step 3-R Round 2** | 4-perspective (implementer/tester/architect/delivery) + 6-tier advisor | 0 | 7 | 5 | 2 | — |
 | **Step 3-R Round 2 applied** | inline triage | 0 | 7→0 | 1 MEDIUM | 0 | spec v7 + plan v4: §8 contradictory testImpl line fixed; §5.1 findOrCreate "first-create wins" contract; §5.1 linkDevice param rename (userVertexId/deviceVertexId); T2-1 security KDoc; T8-1 Flow cancel pattern (async+deferred/backgroundScope); T10-2/T10-4 @Tag("integration"); T10-3/T10-4 @AfterAll driver.close(); T7-1 test7 sub-assertion |
+| **Step 3-R Round 3** | implementer(Opus) P0=2,P1=3; tester(Opus) P0=0,P1=4; architect(Sonnet) P0=0,P1=3; delivery(Sonnet) P0=0,P1=3 | raw P0=2, P1=13 | strict triage P0=2, P1=7 | 8 | 0 | — |
+| **Step 3-R Round 3 applied** | inline triage (strict: compile error / runtime crash / silent test bypass) | P0=2→0, P1=7→0 | 0 | 8 | 0 | spec v8 + plan v5: [P0-1] ops constructor database≠graphName (§9 + T10-1~4); [P0-2] suspend findAbuseCluster Flow.toList (T5-1); [P1-1] explainSuspicion Flow composition (T5-1); [P1-3] T10-3/4 suspend ops constructor fix; [P1-Arch-3] configurations{}.get() T1-3; [P1-Deliv-1] seedIsolatedUser creates cluster+isolated (T6-1+T7-1); [P1-Test-1] @BeforeEach cleanGraph() runTest+try/catch pattern (T8-1); [P1-Test-2] test16 seed+delay (T8-1); [P1-Test-4] tests 3/4/5/14 concrete assertions (T7-1) |

--- a/docs/superpowers/specs/2026-05-25-graph-abuser-detection-design.md
+++ b/docs/superpowers/specs/2026-05-25-graph-abuser-detection-design.md
@@ -625,8 +625,8 @@ the expected format (e.g., `@param phone E.164 SHA-256 hex hash, not plaintext`)
 - [ ] `settings.gradle.kts` and `gradle/libs.versions.toml` updated
 - [ ] `AbuserDetectionSchema.kt` with all 5 vertex labels and 5 edge labels
 - [ ] `AbuserDetectionService` + `AbuserDetectionSuspendService` implement all methods
-- [ ] `AbstractAbuserDetectionTest` covers all 12 test cases (7 happy-path + 5 failure-path)
-- [ ] `AbstractAbuserDetectionSuspendTest` covers same 12 test cases with `runTest`
+- [ ] `AbstractAbuserDetectionTest` covers all 15 test cases (7 happy-path + 5 failure-path + 3 additional: idempotency, phone/payment dispatch, REFERRED_BY exclusion)
+- [ ] `AbstractAbuserDetectionSuspendTest` covers same 15 test cases with `runTest` + 1 Flow cancellation test = 16 total
 - [ ] TinkerGraph tests pass without Docker: `./gradlew :graph-abuser-detection:test`
 - [ ] Neo4j and Memgraph integration tests tagged and skipped by default
 - [ ] `README.md` + `README.ko.md` written with architecture diagram
@@ -655,3 +655,4 @@ the expected format (e.g., `@param phone E.164 SHA-256 hex hash, not plaintext`)
 | Round 3 | Ops/SRE (Sonnet) | 0 | 0 | 2 | 0 | in spec v4: M1 @AfterAll .onFailure log added; M2 AbstractAbuserDetectionSuspendTest @TestInstance mention added |
 | **Round 3 final** | **All reviewers** | **0** | **0** | polish | low | **CONVERGED ✅** |
 | **Step 3-R Plan Review** | 3r-delivery, 3r-tester, 3r-implementer, 3r-architect | **0** | **19** | 9 | 3 | v5: §6 mapIndexed→withIndex fix; §13 DoD 7→12 tests; §8 build script duplicate dep removed + positions fixed; test cases 13–15 added; Flow exception test pattern clarified; §9 integrationTest note; spec v5 applied |
+| **Step 3-R Pre-Round 2 fixes** | inline advisor | 0 | 3 | 0 | 0 | spec v6 (§13 DoD 12→15/16) + plan v3 (T5-1 Flow.forEach→direct pipeline; T10-1~4 graphName init order; API class names verified) |

--- a/docs/superpowers/specs/2026-05-25-graph-abuser-detection-design.md
+++ b/docs/superpowers/specs/2026-05-25-graph-abuser-detection-design.md
@@ -302,8 +302,14 @@ ops.detectCycles(CycleOptions(
 ops.pageRank(PageRankOptions(vertexLabel = null, edgeLabel = null, topK = Int.MAX_VALUE))
   → filter { it.vertex.label == UserLabel.label }
   → take(limit)
-  → mapIndexed { idx, s -> SuspiciousUserScore(s.vertex, s.score, idx + 1) }
+  → withIndex().map { (idx, s) -> SuspiciousUserScore(s.vertex, s.score, idx + 1) }
 ```
+
+> **`Flow.mapIndexed` does not exist** in `kotlinx.coroutines.flow`. In `AbuserDetectionSuspendService`,
+> the suspend `rankSuspiciousUsers` returns `Flow<SuspiciousUserScore>`. Use `.withIndex().map { (idx, s) -> ... }`
+> (Flow analogue of `mapIndexed`) or accumulate with a `var rank = 1` counter.
+> The blocking `AbuserDetectionService.rankSuspiciousUsers` returns `List<SuspiciousUserScore>` and
+> may use `mapIndexed` directly.
 
 ---
 
@@ -339,7 +345,7 @@ bluetape4k-workshop/
                 │   ├── AbuserDetectionNeo4jTest.kt             (@Tag("integration"))
                 │   └── AbuserDetectionMemgraphTest.kt          (@Tag("integration"))
                 └── resources/
-                    ├── junit-platform.properties               (excludes "integration" tag by default)
+                    ├── junit-platform.properties               (parallelism settings ONLY — do NOT add tags.exclude here)
                     └── logback-test.xml
 ```
 
@@ -374,7 +380,7 @@ neo4j-java-driver          = { module = "org.neo4j.driver:neo4j-java-driver" }
 includeModules("graph", false, true)   // produces project :graph-abuser-detection
 ```
 
-Place alphabetically between `gatling` and `image-processing`.
+Place alphabetically between `graalvm` and `image-processing` (verified: `settings.gradle.kts` order is `gatling → graalvm → image-processing`; `graph` sorts after `graalvm`).
 
 ### `graph/abuser-detection/build.gradle.kts`
 
@@ -421,9 +427,10 @@ dependencies {
     testImplementation(libs.kotlinx.coroutines.test.lib)
     testImplementation(libs.mockk)
 
-    // Integration backends (testImplementation so drivers resolve at test classpath)
-    testImplementation(libs.bluetape4k.graph.neo4j)
-    testImplementation(libs.bluetape4k.graph.memgraph)
+    // Integration backends — declared as compileOnly above.
+    // `configurations { testImplementation.extendsFrom(compileOnly, runtimeOnly) }` already
+    // pulls them into the test classpath; do NOT add explicit testImplementation entries here
+    // (duplicate-dependency warning + redundant resolution).
     testImplementation(libs.neo4j.java.driver)
 }
 ```
@@ -527,14 +534,33 @@ fun teardown() {
 8. `addDevice with blank deviceId throws IllegalArgumentException` — `assertFailsWith<IllegalArgumentException> { service.addDevice("", "ios") }`
 9. `addUser with blank userId throws IllegalArgumentException` — `assertFailsWith<IllegalArgumentException> { service.addUser("", "KR") }`
 10. `findAbuseCluster with non-existent seedUserId returns empty cluster` — seed ID not in graph; result has `users.isEmpty() && sharedIdentifiers.isEmpty()`
+    Implementation guard: `if (ops.findVertexById(seedUserId) == null) return AbuseCluster(seedUserId, emptyList(), emptyList())`
+    (TinkerGraph returns empty, but Neo4j/Memgraph may throw on unknown vertex ID — guard required for uniform behavior.)
 11. `rankSuspiciousUsers returns empty list on empty graph` — boundary: no vertices
 12. `detectReferralLoops returns empty list when no REFERRED_BY edges exist`
+
+**Additional MANDATORY test cases:**
+13. `addDevice called twice with same deviceId returns the same vertex id` — findOrCreate idempotency: assert `addDevice("device-X", "ios").id == addDevice("device-X", "ios").id`; verify only one Device vertex exists for `"device-X"`.
+14. `shared phone and payment method detection` — seed two users sharing `PhoneNumber` + `PaymentMethod`; assert `findAbuseCluster` returns both via `sharedIdentifiers` containing both vertex types (exercises `HAS_PHONE` and `USES_PAYMENT` dispatch paths).
+15. `cluster excludes REFERRED_BY-only reachable users` — link `userA → userB` via `USES_DEVICE` AND `REFERRED_BY`; link `userC → userA` via `REFERRED_BY` only; assert `findAbuseCluster(userA).users` contains `userB` but NOT `userC`.
+
+> **Test 13–15 are required** to prevent silent failures in findOrCreate idempotency and label-dispatch correctness (the Round 3 regression fix area).
 
 ### Validation rules
 
 - `addUser`, `addDevice`, etc. call `requireNotBlank` per bluetape4k conventions.
-- Suspend tests use `runTest { ... }` and `coInvoking { } shouldThrow T::class` for expected exceptions.
 - Blocking exception tests use `assertFailsWith<T> { }`.
+- Suspend `suspend fun` exception tests: `coInvoking { suspendCall } shouldThrow T::class`.
+- **Flow-returning function exception tests**: `explainSuspicion` and `detectReferralLoops` are NOT `suspend` — they return a cold `Flow`. Validation inside `flow { }` runs at collection time, NOT at call time. Use:
+  ```kotlin
+  runTest {
+      assertFailsWith<IllegalArgumentException> {
+          service.explainSuspicion(GraphElementId("")).toList()
+      }
+  }
+  ```
+  Do NOT use `coInvoking { service.explainSuspicion(GraphElementId("")) } shouldThrow ...` — this does NOT collect the flow and will not trigger the validation.
+- Flow cancellation: add one test that cancels a `Job` collecting `rankSuspiciousUsers(...)` and asserts `CancellationException` propagates cleanly (use `runTest` with `cancel()`).
 - `findAbuseCluster` does NOT validate seedUserId format — a non-existent vertex returns an empty cluster.
 
 ---
@@ -599,8 +625,8 @@ the expected format (e.g., `@param phone E.164 SHA-256 hex hash, not plaintext`)
 - [ ] `settings.gradle.kts` and `gradle/libs.versions.toml` updated
 - [ ] `AbuserDetectionSchema.kt` with all 5 vertex labels and 5 edge labels
 - [ ] `AbuserDetectionService` + `AbuserDetectionSuspendService` implement all methods
-- [ ] `AbstractAbuserDetectionTest` covers all 7 test cases
-- [ ] `AbstractAbuserDetectionSuspendTest` covers same 7 cases with `runTest`
+- [ ] `AbstractAbuserDetectionTest` covers all 12 test cases (7 happy-path + 5 failure-path)
+- [ ] `AbstractAbuserDetectionSuspendTest` covers same 12 test cases with `runTest`
 - [ ] TinkerGraph tests pass without Docker: `./gradlew :graph-abuser-detection:test`
 - [ ] Neo4j and Memgraph integration tests tagged and skipped by default
 - [ ] `README.md` + `README.ko.md` written with architecture diagram
@@ -628,3 +654,4 @@ the expected format (e.g., `@param phone E.164 SHA-256 hex hash, not plaintext`)
 | Round 3 | Developer (Sonnet) | 0 | 1→0 | 2 | 0 | in spec v4: NEW H1 label-dispatch bug (vertex label vs edge label string mismatch → always false) fixed with explicit Map lookup |
 | Round 3 | Ops/SRE (Sonnet) | 0 | 0 | 2 | 0 | in spec v4: M1 @AfterAll .onFailure log added; M2 AbstractAbuserDetectionSuspendTest @TestInstance mention added |
 | **Round 3 final** | **All reviewers** | **0** | **0** | polish | low | **CONVERGED ✅** |
+| **Step 3-R Plan Review** | 3r-delivery, 3r-tester, 3r-implementer, 3r-architect | **0** | **19** | 9 | 3 | v5: §6 mapIndexed→withIndex fix; §13 DoD 7→12 tests; §8 build script duplicate dep removed + positions fixed; test cases 13–15 added; Flow exception test pattern clarified; §9 integrationTest note; spec v5 applied |

--- a/docs/superpowers/specs/2026-05-25-graph-abuser-detection-design.md
+++ b/docs/superpowers/specs/2026-05-25-graph-abuser-detection-design.md
@@ -249,11 +249,19 @@ val seedIdentifiers = IdentifierEdgeLabel.all.flatMap { edgeLabel ->
 }
 identifierVertices += seedIdentifiers
 
-// Step 2: for each identifier, find users connected via the SAME identifier edge label.
-// We dispatch by the vertex's own label to avoid querying a DeviceVertex for USES_IP edges.
+// Vertex-label → edge-label mapping (vertex labels are NOT the same strings as edge labels)
+val vertexLabelToEdgeLabel: Map<String, IdentifierEdgeLabel> = mapOf(
+    "Device"        to IdentifierEdgeLabel.USES_DEVICE,
+    "IpAddress"     to IdentifierEdgeLabel.USES_IP,
+    "PhoneNumber"   to IdentifierEdgeLabel.HAS_PHONE,
+    "PaymentMethod" to IdentifierEdgeLabel.USES_PAYMENT,
+)
+
+// Step 2: for each identifier vertex, find users connected via its corresponding edge label.
+// Do NOT compare identifierVertex.label.uppercase() to edge label strings — they differ
+// (e.g. "Device" vs "USES_DEVICE"). Use the explicit map above.
 seedIdentifiers.forEach { identifierVertex ->
-    // Determine the matching outgoing edge label for this identifier type
-    val matchingLabel = IdentifierEdgeLabel.all.firstOrNull { it.value == identifierVertex.label.uppercase() }
+    val matchingLabel = vertexLabelToEdgeLabel[identifierVertex.label]
         ?: return@forEach  // skip unrecognized vertex types
 
     val connectedUsers = ops.neighbors(
@@ -483,6 +491,7 @@ fun teardown() {
     // driver is owned by this test class (created in companion object / @BeforeAll).
     // Call driver.close() exactly once; do not delegate to a parent teardown that also closes it.
     runCatching { if (ops.graphExists(graphName)) ops.dropGraph(graphName) }
+        .onFailure { log.warn(it) { "dropGraph failed in @AfterAll; container may be in dirty state" } }
     driver.close()
 }
 ```
@@ -497,6 +506,8 @@ fun teardown() {
 > - `AbuserDetectionNeo4jTest`: `graphName = "abuser_neo4j"`
 > - `AbuserDetectionMemgraphTest`: `graphName = "abuser_memgraph"`
 > This prevents `dropGraph` in one class from racing with graph setup in another class.
+
+> **`AbstractAbuserDetectionSuspendTest`**: The `@TestInstance(TestInstance.Lifecycle.PER_CLASS)` requirement applies equally. Declare the annotation on the suspend abstract base class for the same reason.
 
 > **Stale container note**: If containers use `withReuse(true)`, graph data may persist across JVM sessions.
 > On unexpected test failures, verify with `docker ps | grep neo4j` and remove stale containers before retrying.
@@ -614,3 +625,6 @@ the expected format (e.g., `@param phone E.164 SHA-256 hex hash, not plaintext`)
 | Round 2 | 6-tier advisor (Sonnet) | 0 | 9 | 2 | 0 | in spec v3 (T1-H1 hash validation note, T2-H1/H2 driver+graphName isolation, T3-H1 version governance TODO, T4-H1 timestamp guidance, T4-H2 Flow cancellation contract, T5-H1 failure-path tests, T5-H2 backend fallback, T6-H1 label-dispatch optimization) |
 | Round 2 | Developer (Sonnet) | 0 | 2 | 2 | 0 | in spec v3 (H1 maxDepth removed, H2 ALL_IDENTIFIER_EDGE_LABELS → IdentifierEdgeLabel.all, M1 .value unwrap note, M2 findOrCreate lookup) |
 | Round 2 | Ops/SRE (Sonnet) | 0 | 2 | 1 | 0 | in spec v3 (H1 @TestInstance(PER_CLASS), H2 integrationTest Gradle task, M asymmetric runCatching) |
+| Round 3 | Developer (Sonnet) | 0 | 1→0 | 2 | 0 | in spec v4: NEW H1 label-dispatch bug (vertex label vs edge label string mismatch → always false) fixed with explicit Map lookup |
+| Round 3 | Ops/SRE (Sonnet) | 0 | 0 | 2 | 0 | in spec v4: M1 @AfterAll .onFailure log added; M2 AbstractAbuserDetectionSuspendTest @TestInstance mention added |
+| **Round 3 final** | **All reviewers** | **0** | **0** | polish | low | **CONVERGED ✅** |

--- a/docs/superpowers/specs/2026-05-25-graph-abuser-detection-design.md
+++ b/docs/superpowers/specs/2026-05-25-graph-abuser-detection-design.md
@@ -56,10 +56,12 @@ The existing `bluetape4k-graph/examples/fraud-detection-examples/` models financ
 
 ### 4.3 Abuse Detection Logic
 
-- **Abuse Cluster**: Set of users reachable from a seed user via `BOTH`-direction BFS of depth ≤ 4, crossing shared-identifier vertices as intermediate hops.
+- **Abuse Cluster**: Set of users reachable from a seed user via a **direct shared-identifier hop** (User → Identifier → User, exactly 1 identifier level). `REFERRED_BY` edges are excluded from cluster traversal.
 - **Suspicion Explanation**: For each identifier edge label, find identifiers connected to a user and return other users sharing those identifiers.
 - **Referral Loops**: Cycle detection on `REFERRED_BY` edges (reward farming detection).
 - **Suspicious Ranking**: PageRank over full graph; post-filter to User vertices (identifier-bridge topology amplifies scores of users in dense sharing clusters).
+
+> **Note**: `findAbuseCluster` intentionally implements a fixed 1-hop identifier traversal (User→Identifier→User = 2 edge hops). This is sufficient for direct-sharing detection and avoids unbounded traversal in a workshop setting.
 
 ---
 
@@ -87,6 +89,18 @@ class AbuserDetectionService(
     // If a vertex with the same key property already exists, return the existing vertex.
     // This is critical for shared-identifier detection: two users sharing "device-X"
     // must link to the SAME Device vertex, not two separate vertices.
+    //
+    // findOrCreate lookup: ops.findVerticesByLabel(DeviceLabel.label).firstOrNull { it.properties["deviceId"] == deviceId }
+    // before creating; if found, return existing vertex.
+    //
+    // Timestamp defaults: passing "" for createdAt/firstSeenAt/verifiedAt/firstChargedAt/occurredAt
+    // stores an empty string in the graph. Callers MUST pass a valid ISO-8601 timestamp string
+    // (e.g. Instant.now().toString()) when the field is meaningful.
+    // In tests, use a fixed string like "2026-01-01T00:00:00Z" for determinism.
+    //
+    // Hash validation: deviceId, ip, phone, paymentToken parameters MUST be non-blank.
+    // Callers are responsible for passing hashed/tokenized values (see §10).
+    // Implementation calls requireNotBlank("deviceId") etc. before vertex lookup.
     fun addUser(userId: String, country: String, createdAt: String = ""): GraphVertex
     fun addDevice(deviceId: String, platform: String): GraphVertex          // findOrCreate by deviceId
     fun addIpAddress(ip: String, asn: String = ""): GraphVertex             // findOrCreate by ip
@@ -100,12 +114,20 @@ class AbuserDetectionService(
     fun linkReferral(referrerId: GraphElementId, referredId: GraphElementId, occurredAt: String = "")
 
     // Queries
-    fun findAbuseCluster(seedUserId: GraphElementId, maxDepth: Int = 4): AbuseCluster
+    // findAbuseCluster: fixed 1-hop identifier traversal (User→Identifier→User).
+    // Returns AbuseCluster(users = emptyList(), sharedIdentifiers = emptyList()) when
+    // seedUserId has no identifier links. Never throws for a valid (even non-existent) seedUserId.
+    fun findAbuseCluster(seedUserId: GraphElementId): AbuseCluster
     fun explainSuspicion(userId: GraphElementId): List<AbusePath>
     fun detectReferralLoops(maxDepth: Int = 6, maxCycles: Int = 20): List<GraphCycle>
     fun rankSuspiciousUsers(limit: Int = 10): List<SuspiciousUserScore>
 }
 ```
+
+> **Per-backend graph name isolation**: Each concrete integration test class must supply a unique
+> `graphName` to `AbuserDetectionService` (e.g., `"abuser_neo4j"`, `"abuser_memgraph"`) to
+> prevent `dropGraph` in one class from racing with graph setup in another class running
+> concurrently in the same JVM.
 
 ### 5.2 AbuserDetectionSuspendService (coroutine)
 
@@ -121,8 +143,13 @@ class AbuserDetectionSuspendService(
     suspend fun addUser(userId: String, country: String, createdAt: String = ""): GraphVertex
     // ... same mutator shape as blocking
 
-    // Streaming queries
-    suspend fun findAbuseCluster(seedUserId: GraphElementId, maxDepth: Int = 4): AbuseCluster
+    // Streaming queries — Flow-returning methods produce cold flows.
+    // The caller is responsible for collecting them within an appropriate coroutine scope.
+    // Cancellation: Flow collection honours structured concurrency; cancelling the collecting
+    // coroutine causes the flow to terminate cleanly at the next suspension point.
+    // Callers must NOT use GlobalScope for collection; use viewModelScope, lifecycleScope, or
+    // a test-scoped coroutineScope / runTest block.
+    suspend fun findAbuseCluster(seedUserId: GraphElementId): AbuseCluster
     fun explainSuspicion(userId: GraphElementId): Flow<AbusePath>
     fun detectReferralLoops(maxDepth: Int = 6, maxCycles: Int = 20): Flow<GraphCycle>
     fun rankSuspiciousUsers(limit: Int = 10): Flow<SuspiciousUserScore>
@@ -199,45 +226,57 @@ data class SuspiciousUserScore(
 
 ## 6. Algorithm Implementation Notes
 
-### `findAbuseCluster(seedUserId, maxDepth)`
+### `findAbuseCluster(seedUserId)`
 
 > **Important**: Do NOT use `edgeLabel = null` — this would traverse `REFERRED_BY` edges
 > and pull unrelated users into the cluster. Use identifier edge labels only.
+>
+> **`IdentifierEdgeLabel` vs `String`**: The `ops` API (`NeighborOptions`, `findEdgesByStartId`)
+> expects a raw `String` for `edgeLabel`. Pass `edgeLabel.value` (not the `IdentifierEdgeLabel`
+> object directly) at every call site.
 
-Multi-hop BFS restricted to identifier edges (enforces `User → Identifier → User` pattern):
+Fixed 1-hop identifier traversal (`User → Identifier → User`):
 
 ```kotlin
 val visited = mutableSetOf<GraphElementId>()
 val identifierVertices = mutableListOf<GraphVertex>()
 val clusterUsers = mutableListOf<GraphVertex>()
 
-// Step 1: hop out from seed user to identifier vertices
-val seedIdentifiers = ALL_IDENTIFIER_EDGE_LABELS.flatMap { edgeLabel ->
-    ops.neighbors(seedUserId, NeighborOptions(edgeLabel = edgeLabel, direction = OUTGOING, maxDepth = 1))
+// Step 1: hop out from seed user to identifier vertices (label-dispatched — each label
+// queries only the edges relevant to that identifier type)
+val seedIdentifiers = IdentifierEdgeLabel.all.flatMap { edgeLabel ->
+    ops.neighbors(seedUserId, NeighborOptions(edgeLabel = edgeLabel.value, direction = OUTGOING, maxDepth = 1))
 }
 identifierVertices += seedIdentifiers
 
-// Step 2: for each identifier, find all connected users
+// Step 2: for each identifier, find users connected via the SAME identifier edge label.
+// We dispatch by the vertex's own label to avoid querying a DeviceVertex for USES_IP edges.
 seedIdentifiers.forEach { identifierVertex ->
-    ALL_IDENTIFIER_EDGE_LABELS.forEach { edgeLabel ->
-        val connectedUsers = ops.neighbors(
-            identifierVertex.id,
-            NeighborOptions(edgeLabel = edgeLabel, direction = INCOMING, maxDepth = 1)
-        ).filter { it.id != seedUserId && it.id !in visited && it.label == UserLabel.label }
-        clusterUsers += connectedUsers
-        visited += connectedUsers.map { it.id }
-    }
+    // Determine the matching outgoing edge label for this identifier type
+    val matchingLabel = IdentifierEdgeLabel.all.firstOrNull { it.value == identifierVertex.label.uppercase() }
+        ?: return@forEach  // skip unrecognized vertex types
+
+    val connectedUsers = ops.neighbors(
+        identifierVertex.id,
+        NeighborOptions(edgeLabel = matchingLabel.value, direction = INCOMING, maxDepth = 1)
+    ).filter { it.id != seedUserId && it.id !in visited && it.label == UserLabel.label }
+    clusterUsers += connectedUsers
+    visited += connectedUsers.map { it.id }
 }
 
 → AbuseCluster(seedUserId, users = clusterUsers.distinct(), sharedIdentifiers = identifierVertices.distinct())
 ```
 
-Returns `AbuseCluster(users = emptyList(), sharedIdentifiers = emptyList())` when seed has no identifier links — no exception.
+> **Label-dispatch optimization**: Instead of querying all 4 edge labels per identifier vertex
+> (O(4N) round trips), the algorithm dispatches exactly 1 query per identifier vertex by
+> matching the vertex's own label to its corresponding edge label. This reduces to O(N) queries.
+
+Returns `AbuseCluster(users = emptyList(), sharedIdentifiers = emptyList())` when seed has no identifier links or seedUserId does not exist — no exception.
 
 ### `explainSuspicion(userId)`
-For each `edgeLabel` in `ALL_IDENTIFIER_EDGE_LABELS` (`USES_DEVICE`, `USES_IP`, `HAS_PHONE`, `USES_PAYMENT`):
-1. `ops.findEdgesByStartId(userId, edgeLabel)` → edges to identifier vertices
-2. For each identifier edge: `ops.neighbors(identifierId, NeighborOptions(edgeLabel, INCOMING, maxDepth=1))`
+For each `edgeLabel` in `IdentifierEdgeLabel.all` (`USES_DEVICE`, `USES_IP`, `HAS_PHONE`, `USES_PAYMENT`):
+1. `ops.findEdgesByStartId(userId, edgeLabel.value)` → edges to identifier vertices
+2. For each identifier edge: `ops.neighbors(identifierId, NeighborOptions(edgeLabel.value, INCOMING, maxDepth=1))`
 3. Filter out `userId` itself; emit `AbusePath(userId, otherUserId, identifierVertex, edgeLabel)` per other user found
 
 ### `detectReferralLoops(maxDepth, maxCycles)`
@@ -304,6 +343,9 @@ bluetape4k-workshop/
 
 ```toml
 [versions]
+# bluetape4k-graph version is pinned here until bluetape4k-dependencies BOM includes it.
+# TODO: Once bluetape4k-dependencies governs bluetape4k-graph-bom, remove this pin and
+#       reference the centrally governed alias instead. Track: bluetape4k-dependencies#<issue>.
 bluetape4k-graph = "0.4.2"   # https://mvnrepository.com/artifact/io.github.bluetape4k.graph/bluetape4k-graph-bom
 
 [libraries]
@@ -334,7 +376,19 @@ configurations {
 }
 
 tasks.test {
-    useJUnitPlatform { }
+    useJUnitPlatform {
+        excludeTags("integration")   // default run: TinkerGraph only
+    }
+}
+
+// Dedicated task for integration tests (requires Docker)
+tasks.register<Test>("integrationTest") {
+    group = "verification"
+    description = "Runs Neo4j and Memgraph integration tests (requires Docker)"
+    useJUnitPlatform {
+        includeTags("integration")
+    }
+    shouldRunAfter(tasks.test)
 }
 
 dependencies {
@@ -381,47 +435,75 @@ Exercises: `AbuserDetectionTinkerGraphTest` + `AbuserDetectionSuspendTinkerGraph
 ### Integration run (Neo4j + Memgraph via Testcontainers)
 
 ```bash
-# Run integration-tagged tests only (Docker required)
-./gradlew :graph-abuser-detection:test -Djunit.jupiter.tags="integration"
+# Run integration-tagged tests only (Docker required) via dedicated Gradle task
+./gradlew :graph-abuser-detection:integrationTest
 
-# Run ALL tests including integration (unfiltered)
-./gradlew :graph-abuser-detection:test -Djunit.jupiter.execution.exclude.tags=""
+# Run ALL tests including integration (both tasks)
+./gradlew :graph-abuser-detection:test :graph-abuser-detection:integrationTest
 ```
 
 > ⚠️ **Docker required** for integration tests. Integration test classes must use
-> `org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable` or `Assumptions.assumeTrue(DockerClientFactory.instance().isDockerAvailable)`
-> in `@BeforeAll` to produce a readable skip instead of an initialization error on machines without Docker.
+> **`bluetape4k-testcontainers` singleton launcher patterns** — do NOT instantiate `GenericContainer` directly
+> or call `DockerClientFactory.instance().isDockerAvailable`. Use `Neo4jServer.Launcher.neo4j` and
+> `MemgraphServer.Launcher.memgraph` (or equivalent launchers from `bluetape4k-testcontainers`).
+> The launcher singleton handles Docker availability checks and container lifecycle automatically.
+> See `bluetape4k-patterns` skill for the authoritative Testcontainers usage pattern.
 
 > ⚠️ **testMutex impact**: Integration tests hold the global workshop test mutex while Neo4j/Memgraph containers start
 > (30–90s on cold pull). Do NOT add integration tests to the default CI matrix. Run them only in a dedicated nightly job.
 
 ### Test isolation (MANDATORY)
 
-`AbstractAbuserDetectionTest` **must** include:
+`AbstractAbuserDetectionTest` **must** have `@TestInstance(TestInstance.Lifecycle.PER_CLASS)` so that
+`@BeforeEach` and `@AfterAll` can be declared as instance methods (required by JUnit 5 for Kotlin):
 
 ```kotlin
-@BeforeEach
-fun cleanGraph() {
-    if (ops.graphExists(graphName)) ops.dropGraph(graphName)
-    service.initialize()
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+abstract class AbstractAbuserDetectionTest {
+
+    @BeforeEach
+    fun cleanGraph() {
+        runCatching {
+            if (ops.graphExists(graphName)) ops.dropGraph(graphName)
+        }.onFailure { log.warn(it) { "dropGraph failed before test; continuing with initialize()" } }
+        service.initialize()
+    }
 }
 ```
+
+> Symmetric error handling: `@BeforeEach cleanGraph` wraps `dropGraph` in `runCatching` for the same
+> reason as `@AfterAll` — a backend error on drop must not cascade all tests in the class with the
+> same infrastructure exception.
 
 Integration-backend concrete classes (`AbuserDetectionNeo4jTest`, `AbuserDetectionMemgraphTest`) **must** include:
 
 ```kotlin
 @AfterAll
 fun teardown() {
+    // driver is owned by this test class (created in companion object / @BeforeAll).
+    // Call driver.close() exactly once; do not delegate to a parent teardown that also closes it.
     runCatching { if (ops.graphExists(graphName)) ops.dropGraph(graphName) }
     driver.close()
 }
 ```
 
-> Stale container note: If containers use `withReuse(true)`, graph data may persist across JVM sessions.
+> **Driver ownership**: The `Driver` (Neo4j) / `BoltDriver` (Memgraph) instance is created in the
+> concrete class's companion object or `@BeforeAll`. The `@AfterAll teardown` in the **concrete** class
+> is the sole owner that calls `driver.close()`. The abstract base class must NOT call `close()`.
+> This prevents double-close across the class hierarchy.
+
+> **Unique graph names**: Each concrete integration test class must pass a unique `graphName` when
+> constructing `AbuserDetectionService`:
+> - `AbuserDetectionNeo4jTest`: `graphName = "abuser_neo4j"`
+> - `AbuserDetectionMemgraphTest`: `graphName = "abuser_memgraph"`
+> This prevents `dropGraph` in one class from racing with graph setup in another class.
+
+> **Stale container note**: If containers use `withReuse(true)`, graph data may persist across JVM sessions.
 > On unexpected test failures, verify with `docker ps | grep neo4j` and remove stale containers before retrying.
 
 ### Test cases in `AbstractAbuserDetectionTest`
 
+**Happy-path tests:**
 1. `creates user and links device` — vertex + edge CRUD
 2. `finds shared-device abuse cluster — returns 2 other users (seed excluded)` — seed user1 + 2 others share device; `findAbuseCluster(user1)` returns `[user2, user3]` (NOT user1)
 3. `explains suspicion by shared device and IP` — `explainSuspicion` returns 2 `AbusePath` rows
@@ -430,12 +512,19 @@ fun teardown() {
 6. `empty graph returns empty cluster` — boundary: zero neighbors
 7. `cluster excludes unrelated users` — negative: isolated user absent from cluster
 
+**Failure-path tests (MANDATORY):**
+8. `addDevice with blank deviceId throws IllegalArgumentException` — `assertFailsWith<IllegalArgumentException> { service.addDevice("", "ios") }`
+9. `addUser with blank userId throws IllegalArgumentException` — `assertFailsWith<IllegalArgumentException> { service.addUser("", "KR") }`
+10. `findAbuseCluster with non-existent seedUserId returns empty cluster` — seed ID not in graph; result has `users.isEmpty() && sharedIdentifiers.isEmpty()`
+11. `rankSuspiciousUsers returns empty list on empty graph` — boundary: no vertices
+12. `detectReferralLoops returns empty list when no REFERRED_BY edges exist`
+
 ### Validation rules
 
 - `addUser`, `addDevice`, etc. call `requireNotBlank` per bluetape4k conventions.
-- `findAbuseCluster` validates `maxDepth in 1..10` with `require`.
 - Suspend tests use `runTest { ... }` and `coInvoking { } shouldThrow T::class` for expected exceptions.
 - Blocking exception tests use `assertFailsWith<T> { }`.
+- `findAbuseCluster` does NOT validate seedUserId format — a non-existent vertex returns an empty cluster.
 
 ---
 
@@ -444,7 +533,15 @@ fun teardown() {
 - `PhoneNumberLabel.phone`: store E.164 **hash** only (e.g. SHA-256 hex). KDoc must say "hashed phone number; never store plaintext".
 - `PaymentMethodLabel.paymentToken`: PCI-safe token from payment processor. KDoc must say "payment processor token; never store PAN or CVV".
 - `DeviceLabel.deviceId`: hashed device fingerprint. KDoc must say so.
+- `IpAddressLabel.ip`: may be stored as-is (non-PII in most jurisdictions) but hash if GDPR applies.
 - Seed data uses placeholder values (`"device-hash-a1b2c3"`, not real fingerprints).
+
+**Runtime input validation** (T1-H1): The service must call `requireNotBlank("deviceId")` (and similar)
+for all identifier parameters before calling `findOrCreate`. This prevents accidentally creating
+`""` or whitespace-only vertices that would corrupt the graph's shared-identifier detection.
+The spec does NOT validate hash format (SHA-256 length, base64 encoding, etc.) — that is the
+caller's responsibility and out of scope for a workshop example. KDoc on each mutator must state
+the expected format (e.g., `@param phone E.164 SHA-256 hex hash, not plaintext`).
 
 ---
 
@@ -456,8 +553,17 @@ fun teardown() {
 | `neighbors(BOTH, multi-hop)` | ✅ | ✅ | ✅ | ✅ | ✅ |
 | `findEdgesByStartId` | ✅ | ✅ | ✅ | ✅ | ✅ |
 | `detectCycles(single label)` | ✅ | ✅ | ✅ | ✅ | ✅ |
-| `pageRank(null labels)` | ✅ (in-memory) | ✅ | ✅ | partial | partial |
+| `pageRank(null labels)` | ✅ (in-memory) | ✅ | ✅ | partial ⚠️ | partial ⚠️ |
 | Tested in CI | ✅ | integration | integration | not exercised | not exercised |
+
+> ⚠️ **AGE / FalkorDB partial `pageRank`**: When `GraphAlgorithmRepository.pageRank()` is invoked on
+> an AGE or FalkorDB backend that does not support null vertex/edge label filters, the implementation
+> must either:
+> - Throw `UnsupportedOperationException("pageRank with null labels not supported by this backend")`, OR
+> - Log a `WARN` and return an empty list (fail-open, not silently corrupt).
+>
+> This module does NOT exercise AGE/FalkorDB backends. The behavior above is informational for
+> future integrators. TinkerGraph, Neo4j, and Memgraph all support the required `pageRank` variant.
 
 ---
 
@@ -465,11 +571,14 @@ fun teardown() {
 
 | Risk | Mitigation |
 |------|-----------|
-| testMutex serializes all workshop tests | Tag integration tests `@Tag("integration")`; default run is TinkerGraph-only (< 5s) |
+| testMutex serializes all workshop tests | Tag integration tests `@Tag("integration")`; default `test` task excludes them; use `integrationTest` task for Docker run |
 | TinkerGraph ID quirk (Long internally) | Never fabricate IDs; always reuse from `createVertex` return value |
-| `explainSuspicion` N×M calls per identifier type | Bounded by `ALL_IDENTIFIER_EDGE_LABELS.size = 4`; acceptable for example scope |
+| `explainSuspicion` N×M calls per identifier type | Bounded by `IdentifierEdgeLabel.all.size = 4`; acceptable for example scope |
 | PageRank iterates over all vertex types | Service-layer post-filter to `User`; identifier vertices don't dominate because they have low fan-in |
 | Blueprint neo4j-java-driver version needs pin | Managed by `bluetape4k-graph-bom` platform; no explicit version needed |
+| `bluetape4k-graph` version pin in libs.versions.toml | Temporary until `bluetape4k-dependencies` BOM governs it; TODO comment added |
+| Duplicate identifier vertices (findOrCreate failure) | See §5.1 findOrCreate lookup spec — vertex lookup by key property before create |
+| AGE/FalkorDB partial pageRank | Throw `UnsupportedOperationException` or return empty list with WARN log; see §11 |
 
 ---
 
@@ -501,4 +610,7 @@ fun teardown() {
 | Round 1 | User/Caller (Haiku) | 0 | 3 | 4 | 0 | in spec v2 (U2/U3 downgraded impl phase) |
 | Round 1 | Critic (Opus) | — | — | — | — | C1–C6 HIGH fixed; C7–C15 impl phase |
 | Round 1 | Codex CLI | 0 | 2 | 6 | 2 | HIGH-Codex1 (traversal fix) + HIGH-Codex2 (findOrCreate) fixed in spec v2 |
-| **Round 1 final** | **All reviewers** | **0** | **0** | impl-phase | low | **PROCEED** |
+| **Round 1 final** | **All reviewers** | **0** | **0** | impl-phase | low | spec v2 committed |
+| Round 2 | 6-tier advisor (Sonnet) | 0 | 9 | 2 | 0 | in spec v3 (T1-H1 hash validation note, T2-H1/H2 driver+graphName isolation, T3-H1 version governance TODO, T4-H1 timestamp guidance, T4-H2 Flow cancellation contract, T5-H1 failure-path tests, T5-H2 backend fallback, T6-H1 label-dispatch optimization) |
+| Round 2 | Developer (Sonnet) | 0 | 2 | 2 | 0 | in spec v3 (H1 maxDepth removed, H2 ALL_IDENTIFIER_EDGE_LABELS → IdentifierEdgeLabel.all, M1 .value unwrap note, M2 findOrCreate lookup) |
+| Round 2 | Ops/SRE (Sonnet) | 0 | 2 | 1 | 0 | in spec v3 (H1 @TestInstance(PER_CLASS), H2 integrationTest Gradle task, M asymmetric runCatching) |

--- a/docs/superpowers/specs/2026-05-25-graph-abuser-detection-design.md
+++ b/docs/superpowers/specs/2026-05-25-graph-abuser-detection-design.md
@@ -90,8 +90,18 @@ class AbuserDetectionService(
     // This is critical for shared-identifier detection: two users sharing "device-X"
     // must link to the SAME Device vertex, not two separate vertices.
     //
-    // findOrCreate lookup: ops.findVerticesByLabel(DeviceLabel.label).firstOrNull { it.properties["deviceId"] == deviceId }
+    // findOrCreate lookup: ops.findVerticesByLabel(DeviceLabel.label, mapOf("deviceId" to deviceId)).firstOrNull()
     // before creating; if found, return existing vertex.
+    //
+    // findOrCreate contract — "first-create wins":
+    //   • The KEY property (deviceId / ip / phone / paymentToken) identifies uniqueness.
+    //   • If the vertex already exists (matched by key), the EXISTING vertex is returned as-is.
+    //   • Secondary/mutable properties (platform, asn, brand) from the second call are IGNORED —
+    //     they are NOT merged into the existing vertex.
+    //   • Callers must not assume that repeated calls with different secondary props update the vertex.
+    //   • This is NOT atomic (TOCTOU race under parallel invocation); concurrent callers may
+    //     create duplicate vertices. The service is designed for sequential use (PER_CLASS test instances,
+    //     `junit.jupiter.execution.parallel.enabled=false`).
     //
     // Timestamp defaults: passing "" for createdAt/firstSeenAt/verifiedAt/firstChargedAt/occurredAt
     // stores an empty string in the graph. Callers MUST pass a valid ISO-8601 timestamp string
@@ -107,11 +117,11 @@ class AbuserDetectionService(
     fun addPhoneNumber(phone: String): GraphVertex                          // findOrCreate by phone
     fun addPaymentMethod(paymentToken: String, brand: String): GraphVertex  // findOrCreate by paymentToken
 
-    fun linkDevice(userId: GraphElementId, deviceId: GraphElementId, firstSeenAt: String = "")
-    fun linkIp(userId: GraphElementId, ipId: GraphElementId, firstSeenAt: String = "")
-    fun linkPhone(userId: GraphElementId, phoneId: GraphElementId, verifiedAt: String = "")
-    fun linkPayment(userId: GraphElementId, paymentId: GraphElementId, firstChargedAt: String = "")
-    fun linkReferral(referrerId: GraphElementId, referredId: GraphElementId, occurredAt: String = "")
+    fun linkDevice(userVertexId: GraphElementId, deviceVertexId: GraphElementId, firstSeenAt: String = "")
+    fun linkIp(userVertexId: GraphElementId, ipVertexId: GraphElementId, firstSeenAt: String = "")
+    fun linkPhone(userVertexId: GraphElementId, phoneVertexId: GraphElementId, verifiedAt: String = "")
+    fun linkPayment(userVertexId: GraphElementId, paymentVertexId: GraphElementId, firstChargedAt: String = "")
+    fun linkReferral(referrerVertexId: GraphElementId, referredVertexId: GraphElementId, occurredAt: String = "")
 
     // Queries
     // findAbuseCluster: fixed 1-hop identifier traversal (User→Identifier→User).
@@ -431,7 +441,7 @@ dependencies {
     // `configurations { testImplementation.extendsFrom(compileOnly, runtimeOnly) }` already
     // pulls them into the test classpath; do NOT add explicit testImplementation entries here
     // (duplicate-dependency warning + redundant resolution).
-    testImplementation(libs.neo4j.java.driver)
+    // ❌ DO NOT add: testImplementation(libs.neo4j.java.driver)  — extendsFrom already covers it
 }
 ```
 
@@ -656,3 +666,5 @@ the expected format (e.g., `@param phone E.164 SHA-256 hex hash, not plaintext`)
 | **Round 3 final** | **All reviewers** | **0** | **0** | polish | low | **CONVERGED ✅** |
 | **Step 3-R Plan Review** | 3r-delivery, 3r-tester, 3r-implementer, 3r-architect | **0** | **19** | 9 | 3 | v5: §6 mapIndexed→withIndex fix; §13 DoD 7→12 tests; §8 build script duplicate dep removed + positions fixed; test cases 13–15 added; Flow exception test pattern clarified; §9 integrationTest note; spec v5 applied |
 | **Step 3-R Pre-Round 2 fixes** | inline advisor | 0 | 3 | 0 | 0 | spec v6 (§13 DoD 12→15/16) + plan v3 (T5-1 Flow.forEach→direct pipeline; T10-1~4 graphName init order; API class names verified) |
+| **Step 3-R Round 2** | 4-perspective (implementer/tester/architect/delivery) + 6-tier advisor | 0 | 7 | 5 | 2 | — |
+| **Step 3-R Round 2 applied** | inline triage | 0 | 7→0 | 1 MEDIUM | 0 | spec v7 + plan v4: §8 contradictory testImpl line fixed; §5.1 findOrCreate "first-create wins" contract; §5.1 linkDevice param rename (userVertexId/deviceVertexId); T2-1 security KDoc; T8-1 Flow cancel pattern (async+deferred/backgroundScope); T10-2/T10-4 @Tag("integration"); T10-3/T10-4 @AfterAll driver.close(); T7-1 test7 sub-assertion |

--- a/docs/superpowers/specs/2026-05-25-graph-abuser-detection-design.md
+++ b/docs/superpowers/specs/2026-05-25-graph-abuser-detection-design.md
@@ -1,0 +1,504 @@
+# Design Spec — graph/abuser-detection Workshop Module
+
+**Date**: 2026-05-25  
+**Issue**: [#12](https://github.com/bluetape4k/bluetape4k-workshop/issues/12)  
+**Status**: Draft  
+**Author**: AI-assisted (Claude)
+
+---
+
+## 1. Problem Statement
+
+Issue #12 requires a primary `bluetape4k-graph` workshop example demonstrating **abuser detection** — the process of finding suspicious users who operate multiple accounts by sharing identifiers such as devices, IP addresses, phone numbers, and payment methods.
+
+The existing `bluetape4k-graph/examples/fraud-detection-examples/` models financial fraud (money-flow circular transfers between homogeneous Account vertices). The abuser-detection scenario is architecturally different: it uses a **heterogeneous graph** where `User` vertices connect to multiple identifier vertex types via shared-identifier edges. Abusers are revealed by the **transitive shared-identifier neighborhood** (users who share any identifier reachable within a few hops).
+
+---
+
+## 2. Goals
+
+- Demonstrate why graph modeling is superior to SQL joins for multi-account abuse detection.
+- Show bluetape4k-graph APIs: vertex/edge CRUD, BFS-based cluster traversal, cycle detection, PageRank.
+- Provide an in-memory (TinkerGraph) fast test path and opt-in integration tests for Neo4j and Memgraph.
+- Showcase blocking + suspend service patterns with the same domain.
+
+---
+
+## 3. Non-Goals
+
+- REST API endpoint (no Spring Boot in this module).
+- AGE / FalkorDB integration tests (documented as supported but not exercised in CI).
+- Real PII data (all identifiers are hashed/tokenized placeholders).
+
+---
+
+## 4. Graph Domain Model
+
+### 4.1 Vertex Labels
+
+| Object | Label | Key Properties |
+|--------|-------|----------------|
+| `UserLabel` | `"User"` | `userId`, `createdAt`, `signupCountry` |
+| `DeviceLabel` | `"Device"` | `deviceId`, `platform` |
+| `IpAddressLabel` | `"IpAddress"` | `ip`, `asn` |
+| `PhoneNumberLabel` | `"PhoneNumber"` | `phone` (E.164 hash) |
+| `PaymentMethodLabel` | `"PaymentMethod"` | `paymentToken` (PCI-safe token), `brand` |
+
+### 4.2 Edge Labels
+
+| Object | Label | From → To | Key Properties |
+|--------|-------|-----------|----------------|
+| `UsesDeviceLabel` | `"USES_DEVICE"` | User → Device | `firstSeenAt` |
+| `UsesIpLabel` | `"USES_IP"` | User → IpAddress | `firstSeenAt` |
+| `HasPhoneLabel` | `"HAS_PHONE"` | User → PhoneNumber | `verifiedAt` |
+| `UsesPaymentLabel` | `"USES_PAYMENT"` | User → PaymentMethod | `firstChargedAt` |
+| `ReferredByLabel` | `"REFERRED_BY"` | User → User | `occurredAt` |
+
+### 4.3 Abuse Detection Logic
+
+- **Abuse Cluster**: Set of users reachable from a seed user via `BOTH`-direction BFS of depth ≤ 4, crossing shared-identifier vertices as intermediate hops.
+- **Suspicion Explanation**: For each identifier edge label, find identifiers connected to a user and return other users sharing those identifiers.
+- **Referral Loops**: Cycle detection on `REFERRED_BY` edges (reward farming detection).
+- **Suspicious Ranking**: PageRank over full graph; post-filter to User vertices (identifier-bridge topology amplifies scores of users in dense sharing clusters).
+
+---
+
+## 5. API Design
+
+### 5.1 AbuserDetectionService (blocking)
+
+```kotlin
+class AbuserDetectionService(
+    private val ops: GraphOperations,
+    private val graphName: String = "abuser_detection",
+) {
+    companion object : KLogging()
+
+    /**
+     * Creates the backing graph when it does not already exist. No-op if graph exists.
+     * **Must be called before any mutator.** All mutators throw [IllegalStateException]
+     * if called on an uninitialized service. Safe to call multiple times (idempotent).
+     * Implementation: checks `ops.graphExists(graphName)` before `ops.createGraph(graphName)`.
+     * Under `junit.jupiter.execution.parallel.enabled=false`, concurrent initialization is not a concern.
+     */
+    fun initialize()                              // idempotent; createGraph if absent
+
+    // Mutators — identifier vertex creators use findOrCreate semantics:
+    // If a vertex with the same key property already exists, return the existing vertex.
+    // This is critical for shared-identifier detection: two users sharing "device-X"
+    // must link to the SAME Device vertex, not two separate vertices.
+    fun addUser(userId: String, country: String, createdAt: String = ""): GraphVertex
+    fun addDevice(deviceId: String, platform: String): GraphVertex          // findOrCreate by deviceId
+    fun addIpAddress(ip: String, asn: String = ""): GraphVertex             // findOrCreate by ip
+    fun addPhoneNumber(phone: String): GraphVertex                          // findOrCreate by phone
+    fun addPaymentMethod(paymentToken: String, brand: String): GraphVertex  // findOrCreate by paymentToken
+
+    fun linkDevice(userId: GraphElementId, deviceId: GraphElementId, firstSeenAt: String = "")
+    fun linkIp(userId: GraphElementId, ipId: GraphElementId, firstSeenAt: String = "")
+    fun linkPhone(userId: GraphElementId, phoneId: GraphElementId, verifiedAt: String = "")
+    fun linkPayment(userId: GraphElementId, paymentId: GraphElementId, firstChargedAt: String = "")
+    fun linkReferral(referrerId: GraphElementId, referredId: GraphElementId, occurredAt: String = "")
+
+    // Queries
+    fun findAbuseCluster(seedUserId: GraphElementId, maxDepth: Int = 4): AbuseCluster
+    fun explainSuspicion(userId: GraphElementId): List<AbusePath>
+    fun detectReferralLoops(maxDepth: Int = 6, maxCycles: Int = 20): List<GraphCycle>
+    fun rankSuspiciousUsers(limit: Int = 10): List<SuspiciousUserScore>
+}
+```
+
+### 5.2 AbuserDetectionSuspendService (coroutine)
+
+```kotlin
+class AbuserDetectionSuspendService(
+    private val ops: GraphSuspendOperations,
+    private val graphName: String = "abuser_detection",
+) {
+    companion object : KLoggingChannel()
+
+    // All mutators are suspend
+    suspend fun initialize()
+    suspend fun addUser(userId: String, country: String, createdAt: String = ""): GraphVertex
+    // ... same mutator shape as blocking
+
+    // Streaming queries
+    suspend fun findAbuseCluster(seedUserId: GraphElementId, maxDepth: Int = 4): AbuseCluster
+    fun explainSuspicion(userId: GraphElementId): Flow<AbusePath>
+    fun detectReferralLoops(maxDepth: Int = 6, maxCycles: Int = 20): Flow<GraphCycle>
+    fun rankSuspiciousUsers(limit: Int = 10): Flow<SuspiciousUserScore>
+}
+```
+
+### 5.3 Result Types
+
+```kotlin
+/**
+ * Value class representing one of the four shared-identifier edge labels.
+ * Use the predefined constants — do not construct with arbitrary strings.
+ */
+@JvmInline
+value class IdentifierEdgeLabel(val value: String) {
+    companion object {
+        val USES_DEVICE  = IdentifierEdgeLabel("USES_DEVICE")
+        val USES_IP      = IdentifierEdgeLabel("USES_IP")
+        val HAS_PHONE    = IdentifierEdgeLabel("HAS_PHONE")
+        val USES_PAYMENT = IdentifierEdgeLabel("USES_PAYMENT")
+        val all: List<IdentifierEdgeLabel> = listOf(USES_DEVICE, USES_IP, HAS_PHONE, USES_PAYMENT)
+    }
+}
+
+/**
+ * A cluster of users that share at least one identifier with the seed user.
+ *
+ * - [seedUserId]: the root user ID provided to [AbuserDetectionService.findAbuseCluster].
+ * - [users]: users reachable from the seed via shared identifiers, **excluding the seed user itself**.
+ * - [sharedIdentifiers]: identifier vertices (Device, IpAddress, PhoneNumber, PaymentMethod) acting as bridges.
+ */
+data class AbuseCluster(
+    val seedUserId: GraphElementId,
+    /** Cluster members, **not including** the seed user. */
+    val users: List<GraphVertex>,
+    /** Identifier vertices (Device, IpAddress, etc.) connecting the cluster. */
+    val sharedIdentifiers: List<GraphVertex>,
+) : Serializable {
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+/**
+ * A single evidence path: [fromUserId] and [toUserId] share [sharedIdentifier] via [edgeLabel].
+ *
+ * [edgeLabel] is always one of the four identifier edge labels ([IdentifierEdgeLabel]).
+ * It is never [ReferredByLabel] ("REFERRED_BY") — that is detected separately via [detectReferralLoops].
+ */
+data class AbusePath(
+    val fromUserId: GraphElementId,
+    val toUserId: GraphElementId,
+    val sharedIdentifier: GraphVertex,
+    /** One of the four identifier edge labels — always an [IdentifierEdgeLabel] constant. */
+    val edgeLabel: IdentifierEdgeLabel,
+) : Serializable {
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+data class SuspiciousUserScore(
+    val user: GraphVertex,
+    val score: Double,
+    val rank: Int,
+) : Serializable {
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+```
+
+---
+
+## 6. Algorithm Implementation Notes
+
+### `findAbuseCluster(seedUserId, maxDepth)`
+
+> **Important**: Do NOT use `edgeLabel = null` — this would traverse `REFERRED_BY` edges
+> and pull unrelated users into the cluster. Use identifier edge labels only.
+
+Multi-hop BFS restricted to identifier edges (enforces `User → Identifier → User` pattern):
+
+```kotlin
+val visited = mutableSetOf<GraphElementId>()
+val identifierVertices = mutableListOf<GraphVertex>()
+val clusterUsers = mutableListOf<GraphVertex>()
+
+// Step 1: hop out from seed user to identifier vertices
+val seedIdentifiers = ALL_IDENTIFIER_EDGE_LABELS.flatMap { edgeLabel ->
+    ops.neighbors(seedUserId, NeighborOptions(edgeLabel = edgeLabel, direction = OUTGOING, maxDepth = 1))
+}
+identifierVertices += seedIdentifiers
+
+// Step 2: for each identifier, find all connected users
+seedIdentifiers.forEach { identifierVertex ->
+    ALL_IDENTIFIER_EDGE_LABELS.forEach { edgeLabel ->
+        val connectedUsers = ops.neighbors(
+            identifierVertex.id,
+            NeighborOptions(edgeLabel = edgeLabel, direction = INCOMING, maxDepth = 1)
+        ).filter { it.id != seedUserId && it.id !in visited && it.label == UserLabel.label }
+        clusterUsers += connectedUsers
+        visited += connectedUsers.map { it.id }
+    }
+}
+
+→ AbuseCluster(seedUserId, users = clusterUsers.distinct(), sharedIdentifiers = identifierVertices.distinct())
+```
+
+Returns `AbuseCluster(users = emptyList(), sharedIdentifiers = emptyList())` when seed has no identifier links — no exception.
+
+### `explainSuspicion(userId)`
+For each `edgeLabel` in `ALL_IDENTIFIER_EDGE_LABELS` (`USES_DEVICE`, `USES_IP`, `HAS_PHONE`, `USES_PAYMENT`):
+1. `ops.findEdgesByStartId(userId, edgeLabel)` → edges to identifier vertices
+2. For each identifier edge: `ops.neighbors(identifierId, NeighborOptions(edgeLabel, INCOMING, maxDepth=1))`
+3. Filter out `userId` itself; emit `AbusePath(userId, otherUserId, identifierVertex, edgeLabel)` per other user found
+
+### `detectReferralLoops(maxDepth, maxCycles)`
+```
+ops.detectCycles(CycleOptions(
+    vertexLabel = UserLabel.label,
+    edgeLabel = ReferredByLabel.label,
+    maxDepth = maxDepth,
+    maxCycles = maxCycles
+))
+```
+
+### `rankSuspiciousUsers(limit)`
+```
+ops.pageRank(PageRankOptions(vertexLabel = null, edgeLabel = null, topK = Int.MAX_VALUE))
+  → filter { it.vertex.label == UserLabel.label }
+  → take(limit)
+  → mapIndexed { idx, s -> SuspiciousUserScore(s.vertex, s.score, idx + 1) }
+```
+
+---
+
+## 7. Module Structure
+
+```
+bluetape4k-workshop/
+├── settings.gradle.kts           ← add: includeModules("graph", false, true)
+├── gradle/libs.versions.toml     ← add: 6 bluetape4k-graph-* aliases + neo4j-java-driver
+└── graph/
+    └── abuser-detection/
+        ├── build.gradle.kts
+        ├── README.md
+        ├── README.ko.md
+        ├── docs/images/readme-diagrams/
+        │   ├── abuser-detection-architecture.svg
+        │   └── abuser-detection-architecture.png
+        └── src/
+            ├── main/kotlin/io/bluetape4k/workshop/graph/abuser/
+            │   ├── schema/AbuserDetectionSchema.kt
+            │   ├── model/AbuseCluster.kt
+            │   ├── model/AbusePath.kt
+            │   ├── model/SuspiciousUserScore.kt
+            │   ├── service/AbuserDetectionService.kt
+            │   ├── service/AbuserDetectionSuspendService.kt
+            │   └── seed/AbuserDetectionSeed.kt
+            └── test/
+                ├── kotlin/io/bluetape4k/workshop/graph/abuser/
+                │   ├── AbstractAbuserDetectionTest.kt
+                │   ├── AbstractAbuserDetectionSuspendTest.kt
+                │   ├── AbuserDetectionTinkerGraphTest.kt       (no tag — default run)
+                │   ├── AbuserDetectionSuspendTinkerGraphTest.kt (no tag)
+                │   ├── AbuserDetectionNeo4jTest.kt             (@Tag("integration"))
+                │   └── AbuserDetectionMemgraphTest.kt          (@Tag("integration"))
+                └── resources/
+                    ├── junit-platform.properties               (excludes "integration" tag by default)
+                    └── logback-test.xml
+```
+
+---
+
+## 8. Build Configuration
+
+### `gradle/libs.versions.toml` additions
+
+```toml
+[versions]
+bluetape4k-graph = "0.4.2"   # https://mvnrepository.com/artifact/io.github.bluetape4k.graph/bluetape4k-graph-bom
+
+[libraries]
+# bluetape4k-graph — versions managed by bluetape4k-graph-bom platform
+bluetape4k-graph-bom       = { module = "io.github.bluetape4k.graph:bluetape4k-graph-bom", version.ref = "bluetape4k-graph" }
+bluetape4k-graph-core      = { module = "io.github.bluetape4k.graph:bluetape4k-graph-core" }
+bluetape4k-graph-tinkerpop = { module = "io.github.bluetape4k.graph:bluetape4k-graph-tinkerpop" }
+bluetape4k-graph-neo4j     = { module = "io.github.bluetape4k.graph:bluetape4k-graph-neo4j" }
+bluetape4k-graph-memgraph  = { module = "io.github.bluetape4k.graph:bluetape4k-graph-memgraph" }
+neo4j-java-driver          = { module = "org.neo4j.driver:neo4j-java-driver" }
+```
+
+> Note: `neo4j-java-driver` version is managed by `bluetape4k-graph-bom` (platform import propagates constraints). No `version.ref` needed.
+
+### `settings.gradle.kts` addition
+
+```kotlin
+includeModules("graph", false, true)   // produces project :graph-abuser-detection
+```
+
+Place alphabetically between `gatling` and `image-processing`.
+
+### `graph/abuser-detection/build.gradle.kts`
+
+```kotlin
+configurations {
+    testImplementation.get().extendsFrom(compileOnly.get(), runtimeOnly.get())
+}
+
+tasks.test {
+    useJUnitPlatform { }
+}
+
+dependencies {
+    // BOM aligns all graph module versions
+    implementation(platform(libs.bluetape4k.graph.bom))
+
+    implementation(libs.bluetape4k.graph.core)
+    implementation(libs.bluetape4k.graph.tinkerpop)
+
+    compileOnly(libs.bluetape4k.graph.neo4j)
+    compileOnly(libs.bluetape4k.graph.memgraph)
+
+    implementation(libs.bluetape4k.coroutines)
+    implementation(libs.bluetape4k.logging)
+    implementation(libs.kotlinx.coroutines.core.lib)
+
+    // Test
+    testImplementation(project(":shared"))
+    testImplementation(libs.bluetape4k.junit5)
+    testImplementation(libs.bluetape4k.testcontainers)
+    testImplementation(libs.bluetape4k.assertions)
+    testImplementation(libs.kotlinx.coroutines.test.lib)
+    testImplementation(libs.mockk)
+
+    // Integration backends (testImplementation so drivers resolve at test classpath)
+    testImplementation(libs.bluetape4k.graph.neo4j)
+    testImplementation(libs.bluetape4k.graph.memgraph)
+    testImplementation(libs.neo4j.java.driver)
+}
+```
+
+---
+
+## 9. Test Strategy
+
+### Default run (TinkerGraph, no Docker)
+
+```bash
+./gradlew :graph-abuser-detection:test
+```
+
+Exercises: `AbuserDetectionTinkerGraphTest` + `AbuserDetectionSuspendTinkerGraphTest`
+
+### Integration run (Neo4j + Memgraph via Testcontainers)
+
+```bash
+# Run integration-tagged tests only (Docker required)
+./gradlew :graph-abuser-detection:test -Djunit.jupiter.tags="integration"
+
+# Run ALL tests including integration (unfiltered)
+./gradlew :graph-abuser-detection:test -Djunit.jupiter.execution.exclude.tags=""
+```
+
+> ⚠️ **Docker required** for integration tests. Integration test classes must use
+> `org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable` or `Assumptions.assumeTrue(DockerClientFactory.instance().isDockerAvailable)`
+> in `@BeforeAll` to produce a readable skip instead of an initialization error on machines without Docker.
+
+> ⚠️ **testMutex impact**: Integration tests hold the global workshop test mutex while Neo4j/Memgraph containers start
+> (30–90s on cold pull). Do NOT add integration tests to the default CI matrix. Run them only in a dedicated nightly job.
+
+### Test isolation (MANDATORY)
+
+`AbstractAbuserDetectionTest` **must** include:
+
+```kotlin
+@BeforeEach
+fun cleanGraph() {
+    if (ops.graphExists(graphName)) ops.dropGraph(graphName)
+    service.initialize()
+}
+```
+
+Integration-backend concrete classes (`AbuserDetectionNeo4jTest`, `AbuserDetectionMemgraphTest`) **must** include:
+
+```kotlin
+@AfterAll
+fun teardown() {
+    runCatching { if (ops.graphExists(graphName)) ops.dropGraph(graphName) }
+    driver.close()
+}
+```
+
+> Stale container note: If containers use `withReuse(true)`, graph data may persist across JVM sessions.
+> On unexpected test failures, verify with `docker ps | grep neo4j` and remove stale containers before retrying.
+
+### Test cases in `AbstractAbuserDetectionTest`
+
+1. `creates user and links device` — vertex + edge CRUD
+2. `finds shared-device abuse cluster — returns 2 other users (seed excluded)` — seed user1 + 2 others share device; `findAbuseCluster(user1)` returns `[user2, user3]` (NOT user1)
+3. `explains suspicion by shared device and IP` — `explainSuspicion` returns 2 `AbusePath` rows
+4. `detects referral loops` — A→B→C→A cycle found
+5. `ranks user at center of identifier sharing as most suspicious` — seed user has highest score
+6. `empty graph returns empty cluster` — boundary: zero neighbors
+7. `cluster excludes unrelated users` — negative: isolated user absent from cluster
+
+### Validation rules
+
+- `addUser`, `addDevice`, etc. call `requireNotBlank` per bluetape4k conventions.
+- `findAbuseCluster` validates `maxDepth in 1..10` with `require`.
+- Suspend tests use `runTest { ... }` and `coInvoking { } shouldThrow T::class` for expected exceptions.
+- Blocking exception tests use `assertFailsWith<T> { }`.
+
+---
+
+## 10. Security Notes
+
+- `PhoneNumberLabel.phone`: store E.164 **hash** only (e.g. SHA-256 hex). KDoc must say "hashed phone number; never store plaintext".
+- `PaymentMethodLabel.paymentToken`: PCI-safe token from payment processor. KDoc must say "payment processor token; never store PAN or CVV".
+- `DeviceLabel.deviceId`: hashed device fingerprint. KDoc must say so.
+- Seed data uses placeholder values (`"device-hash-a1b2c3"`, not real fingerprints).
+
+---
+
+## 11. Backend Capability Matrix
+
+| Capability | TinkerGraph | Neo4j | Memgraph | AGE | FalkorDB |
+|---|---|---|---|---|---|
+| `createVertex` / `createEdge` | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `neighbors(BOTH, multi-hop)` | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `findEdgesByStartId` | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `detectCycles(single label)` | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `pageRank(null labels)` | ✅ (in-memory) | ✅ | ✅ | partial | partial |
+| Tested in CI | ✅ | integration | integration | not exercised | not exercised |
+
+---
+
+## 12. Risks and Mitigations
+
+| Risk | Mitigation |
+|------|-----------|
+| testMutex serializes all workshop tests | Tag integration tests `@Tag("integration")`; default run is TinkerGraph-only (< 5s) |
+| TinkerGraph ID quirk (Long internally) | Never fabricate IDs; always reuse from `createVertex` return value |
+| `explainSuspicion` N×M calls per identifier type | Bounded by `ALL_IDENTIFIER_EDGE_LABELS.size = 4`; acceptable for example scope |
+| PageRank iterates over all vertex types | Service-layer post-filter to `User`; identifier vertices don't dominate because they have low fan-in |
+| Blueprint neo4j-java-driver version needs pin | Managed by `bluetape4k-graph-bom` platform; no explicit version needed |
+
+---
+
+## 13. DoD (Definition of Done)
+
+- [ ] `graph/abuser-detection/` module created with all files per §7
+- [ ] `settings.gradle.kts` and `gradle/libs.versions.toml` updated
+- [ ] `AbuserDetectionSchema.kt` with all 5 vertex labels and 5 edge labels
+- [ ] `AbuserDetectionService` + `AbuserDetectionSuspendService` implement all methods
+- [ ] `AbstractAbuserDetectionTest` covers all 7 test cases
+- [ ] `AbstractAbuserDetectionSuspendTest` covers same 7 cases with `runTest`
+- [ ] TinkerGraph tests pass without Docker: `./gradlew :graph-abuser-detection:test`
+- [ ] Neo4j and Memgraph integration tests tagged and skipped by default
+- [ ] `README.md` + `README.ko.md` written with architecture diagram
+- [ ] Diagram assets at `docs/images/readme-diagrams/abuser-detection-architecture.{svg,png}`
+- [ ] English KDoc on all public API
+- [ ] `docs/lessons/2026-05-25-graph-abuser-detection.md` committed before PR
+- [ ] CI gate: all checks SUCCESS
+
+---
+
+## Appendix — Review Iteration Log
+
+| Round | Reviewer | P0 | P1 | P2 | P3 | Applied commit |
+|-------|----------|----|----|----|----|----------------|
+| Round 1 | Developer (Sonnet) | 0 | 5 | 3 | 1 | in spec v2 |
+| Round 1 | Security (Sonnet) | 0 | 2 | 2 | 0 | in spec v2 (S1/S2 downgraded workshop scope) |
+| Round 1 | Ops/SRE (Sonnet) | 0 | 4 | 2 | 0 | in spec v2 |
+| Round 1 | User/Caller (Haiku) | 0 | 3 | 4 | 0 | in spec v2 (U2/U3 downgraded impl phase) |
+| Round 1 | Critic (Opus) | — | — | — | — | C1–C6 HIGH fixed; C7–C15 impl phase |
+| Round 1 | Codex CLI | 0 | 2 | 6 | 2 | HIGH-Codex1 (traversal fix) + HIGH-Codex2 (findOrCreate) fixed in spec v2 |
+| **Round 1 final** | **All reviewers** | **0** | **0** | impl-phase | low | **PROCEED** |

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,10 @@
 
 [versions]
 bluetape4k-dependencies-version = "1.1.3"  # https://mvnrepository.com/artifact/io.github.bluetape4k/bluetape4k-dependencies
+# TODO: Move to bluetape4k-dependencies BOM governance once bluetape4k-graph is published to Maven Central.
+# Version resolution: 0.4.0 is available in mavenLocal; 0.4.2 is the current baseVersion (not yet published).
+# Use mavenLocal() in settings.gradle.kts repositoriesMode + root build.gradle.kts when consuming 0.4.0.
+bluetape4k-graph = "0.4.0"  # mavenLocal — run: ./gradlew -p bluetape4k-graph publishBluetapeGraphPublicationToMavenLocalRepository
 
 kotlin = "2.3.21"  # https://mvnrepository.com/artifact/org.jetbrains.kotlin/kotlin-bom
 kotlinx-coroutines = "1.11.0"  # https://mvnrepository.com/artifact/org.jetbrains.kotlinx/kotlinx-coroutines-bom
@@ -161,6 +165,13 @@ gatling-plugin = { id = "io.gatling.gradle", version.ref = "gatling-plugin" }
 
 [libraries]
 jetbrains-annotations = { module = "org.jetbrains:annotations", version = "26.1.0" }  # https://mvnrepository.com/artifact/org.jetbrains/annotations
+
+# bluetape4k-graph — graph DB integrations (mavenLocal, see version note above)
+bluetape4k-graph-bom       = { module = "io.github.bluetape4k.graph:bluetape4k-graph-bom",       version.ref = "bluetape4k-graph" }
+bluetape4k-graph-core      = { module = "io.github.bluetape4k.graph:bluetape4k-graph-core" }
+bluetape4k-graph-tinkerpop = { module = "io.github.bluetape4k.graph:bluetape4k-graph-tinkerpop" }
+bluetape4k-graph-neo4j     = { module = "io.github.bluetape4k.graph:bluetape4k-graph-neo4j" }
+bluetape4k-graph-memgraph  = { module = "io.github.bluetape4k.graph:bluetape4k-graph-memgraph" }
 
 # bluetape4k
 bluetape4k-dependencies = { module = "io.github.bluetape4k:bluetape4k-dependencies", version.ref = "bluetape4k-dependencies-version" }
@@ -684,6 +695,7 @@ testcontainers-localstack = { module = "org.testcontainers:testcontainers-locals
 testcontainers-mariadb = { module = "org.testcontainers:testcontainers-mariadb" }
 testcontainers-mongodb = { module = "org.testcontainers:testcontainers-mongodb" }
 testcontainers-mysql = { module = "org.testcontainers:testcontainers-mysql" }
+testcontainers-neo4j = { module = "org.testcontainers:testcontainers-neo4j", version.ref = "testcontainers" }
 testcontainers-postgresql = { module = "org.testcontainers:testcontainers-postgresql" }
 
 jna-lib = { module = "net.java.dev.jna:jna", version.ref = "jna" }

--- a/graph/abuser-detection/README.ko.md
+++ b/graph/abuser-detection/README.ko.md
@@ -1,0 +1,179 @@
+# graph-abuser-detection
+
+[English](README.md) | [한국어](README.ko.md)
+
+bluetape4k 워크샵 모듈로, 그래프 기반 어뷰저(abuser) 탐지를 시연합니다. 이 모듈은 사용자 계정과 공유 식별자(디바이스, IP 주소, 해시된 전화번호, 결제 토큰)를 연결하는 **신원 그래프(identity graph)**를 구축하고, 그래프 알고리즘을 적용하여 어뷰저 클러스터, 의심스러운 연결 경로, 추천인 루프, PageRank 기반 위험 점수를 탐지합니다.
+
+블로킹 서비스(`AbuserDetectionService`)와 코루틴 서비스(`AbuserDetectionSuspendService`) 두 가지가 제공됩니다. 기본 테스트는 Docker 없이 인-프로세스 TinkerGraph를 사용하며, Neo4j와 Memgraph 통합 테스트는 선택적으로 실행할 수 있습니다.
+
+## 그래프 스키마
+
+### 정점(Vertex)
+
+| 레이블 | 키 프로퍼티 | 기타 프로퍼티 | 비고 |
+|---|---|---|---|
+| `User` | `userId` (불투명 문자열 / UUID) | `country` (ISO-3166-1 alpha-2) | 주 엔티티 |
+| `Device` | `deviceId` (디바이스 핑거프린트) | `platform` (`"android"`, `"ios"`, `"web"`) | |
+| `IpAddress` | `ip` (IPv4 또는 IPv6) | — | |
+| `PhoneNumber` | `phone` (E.164 SHA-256 hex 해시) | — | 원본 전화번호 저장 금지 |
+| `PaymentMethod` | `paymentToken` (결제 프로세서 토큰) | — | 원본 PAN / CVV 저장 금지 |
+
+### 엣지(Edge)
+
+| 레이블 | From | To | 프로퍼티 | 비고 |
+|---|---|---|---|---|
+| `USES_DEVICE` | `User` | `Device` | `occurredAt` (ISO-8601) | 최초 로그인 시각 |
+| `USES_IP` | `User` | `IpAddress` | `occurredAt` (ISO-8601) | 최초 접속 시각 |
+| `HAS_PHONE` | `User` | `PhoneNumber` | `occurredAt` (ISO-8601) | 최초 연결 시각 |
+| `USES_PAYMENT` | `User` | `PaymentMethod` | `occurredAt` (ISO-8601) | 최초 결제 시도 시각 |
+| `REFERRED_BY` | `User` | `User` | `occurredAt` (ISO-8601) | 추천 관계 (추천인 → 피추천인); 클러스터 BFS 탐색에서 제외 |
+
+네 가지 식별자 엣지 타입(`USES_DEVICE`, `USES_IP`, `HAS_PHONE`, `USES_PAYMENT`)은 `IdentifierEdgeLabel`에 타입 안전 값으로 정의되어 있습니다. `REFERRED_BY`는 `IdentifierEdgeLabel.all`에서 의도적으로 제외됩니다 — 추천 관계만으로는 공유 신원을 의미하지 않습니다.
+
+## 핵심 알고리즘
+
+| 메서드 | 설명 |
+|---|---|
+| `findAbuseCluster(seedUserId)` | 시드 사용자로부터 식별자 엣지를 따라 BFS 탐색하고, 각 식별자 정점에서 역방향으로 연결된 사용자를 수집합니다. 시드 사용자를 제외한 공유 사용자 목록과 공유 식별자 정점을 담은 `AbuseCluster`를 반환합니다. |
+| `explainSuspicion(userId)` | 사용자의 모든 식별자 연결 경로를 반환합니다. 블로킹 서비스는 `List<AbusePath>`, 코루틴 서비스는 cold `Flow<AbusePath>`를 반환합니다. 각 `AbusePath`에는 대상 식별자 정점 ID와 엣지 타입이 포함됩니다. |
+| `detectReferralLoops(maxDepth, maxCycles)` | `REFERRED_BY` 서브그래프 내 User 정점 사이의 방향성 사이클을 탐지합니다. 블로킹 서비스는 `List<GraphCycle>`, 코루틴 서비스는 cold `Flow<GraphCycle>`을 반환합니다. |
+| `rankSuspiciousUsers(limit)` | User 정점에 대해 PageRank를 계산하고 점수 내림차순으로 결과를 반환합니다. 각 `SuspiciousUserScore`에는 1-based 순위가 포함됩니다. PageRank 점수가 높을수록 공유 식별자 연결이 많다는 의미이며, 이는 어뷰징 위험의 지표가 됩니다. |
+
+### 결과 타입
+
+```kotlin
+// 공유 식별자로 연결된 사용자 클러스터
+data class AbuseCluster(
+    val seedUserId: GraphElementId,
+    val users: List<GraphVertex>,            // 시드 사용자 제외
+    val sharedIdentifiers: List<GraphVertex> // Device/IpAddress/PhoneNumber/PaymentMethod 정점
+)
+
+// 사용자와 공유 식별자 정점 사이의 단일 연결 경로
+data class AbusePath(
+    val identifierVertexId: GraphElementId,
+    val edgeLabel: IdentifierEdgeLabel       // USES_DEVICE | USES_IP | HAS_PHONE | USES_PAYMENT
+)
+
+// PageRank 기반 위험 순위 항목
+data class SuspiciousUserScore(
+    val user: GraphVertex,
+    val score: Double,   // 원시 PageRank 값; 높을수록 더 의심스러움
+    val rank: Int        // 1-based 순위
+)
+```
+
+## 사용 예시
+
+### 블로킹 서비스
+
+```kotlin
+val service = AbuserDetectionService(ops, graphName = "fraud_graph")
+service.initialize()
+
+// 정점 추가 (도메인 키로 find-or-create)
+val userV   = service.addUser("u-alice", "KR")
+val deviceV = service.addDevice("fp-aabbcc", "android")
+val ipV     = service.addIpAddress("203.0.113.42")
+
+// 정점 연결
+service.linkDevice(userV.id, deviceV.id, Instant.now().toString())
+service.linkIp(userV.id, ipV.id, Instant.now().toString())
+
+// 어뷰저 클러스터 탐지
+val cluster = service.findAbuseCluster(userV.id)
+if (cluster.users.isNotEmpty()) {
+    println("클러스터 크기: ${cluster.users.size}")
+}
+
+// 사용자 의심 경로 조회
+val paths = service.explainSuspicion(userV.id)
+paths.forEach { println("${it.edgeLabel.value} -> ${it.identifierVertexId}") }
+
+// 추천인 사기 루프 탐지 (기본값: maxDepth=6, maxCycles=100)
+val loops = service.detectReferralLoops()
+
+// PageRank 기반 위험 순위
+val top10 = service.rankSuspiciousUsers(limit = 10)
+top10.forEach { println("#${it.rank} ${it.user.id} score=${it.score}") }
+```
+
+### 코루틴 서비스
+
+```kotlin
+val service = AbuserDetectionSuspendService(ops, graphName = "fraud_graph")
+service.initialize()
+
+val userV  = service.addUser("u-bob", "US")
+val phoneV = service.addPhoneNumber(sha256hex("+11234567890"))  // 저장 전 반드시 해시 처리
+val payV   = service.addPaymentMethod("tok_stripe_xxxx")       // 결제 프로세서 토큰만 허용
+
+service.linkPhone(userV.id, phoneV.id, Instant.now().toString())
+service.linkPayment(userV.id, payV.id, Instant.now().toString())
+
+val cluster = service.findAbuseCluster(userV.id)
+
+// explainSuspicion은 cold Flow 반환
+service.explainSuspicion(userV.id).collect { path ->
+    println("${path.edgeLabel.value} -> ${path.identifierVertexId}")
+}
+
+// detectReferralLoops는 cold Flow 반환
+service.detectReferralLoops(maxDepth = 4).collect { cycle ->
+    println("루프: ${cycle.vertices.map { it.id }}")
+}
+
+// rankSuspiciousUsers는 cold Flow 반환
+service.rankSuspiciousUsers(limit = 5).collect { score ->
+    println("#${score.rank} score=${score.score}")
+}
+```
+
+## 보안 유의사항
+
+- **전화번호** — `addPhoneNumber` 호출 전 호출자가 반드시 E.164 형식의 SHA-256 hex 해시로 변환해야 합니다. 원본 전화번호를 그래프에 저장해서는 안 됩니다.
+- **결제 정보** — `addPaymentMethod`에는 PCI-safe 결제 프로세서 토큰(예: Stripe/Braintree 토큰)만 전달해야 합니다. 원본 PAN, 유효기간, CVV는 절대 저장해서는 안 됩니다.
+
+## 테스트 백엔드
+
+| 백엔드 | 스코프 | 요구사항 |
+|---|---|---|
+| TinkerGraph | `test` (기본) | 없음 — 인-프로세스 실행, 외부 의존성 불필요 |
+| Neo4j | `integrationTest` | Docker (`bluetape4k-testcontainers` Neo4j 런처 사용) |
+| Memgraph | `integrationTest` | Docker (`bluetape4k-testcontainers` Memgraph 런처 사용) |
+
+`test` 태스크는 `@Tag("integration")`으로 표시된 테스트를 제외합니다. `integrationTest` 태스크는 해당 태그가 붙은 테스트만 실행하며, Docker가 실행 중이어야 합니다.
+
+## 테스트 실행
+
+```bash
+# 기본 테스트 — TinkerGraph만 사용, Docker 불필요
+./gradlew :graph-abuser-detection:test
+
+# 통합 테스트 — Neo4j + Memgraph (Docker 필요)
+./gradlew :graph-abuser-detection:integrationTest
+
+# 전체 테스트
+./gradlew :graph-abuser-detection:test :graph-abuser-detection:integrationTest
+
+# 특정 테스트 클래스 실행
+./gradlew :graph-abuser-detection:test \
+  --tests "io.bluetape4k.workshop.graph.abuser.service.AbuserDetectionServiceTest"
+```
+
+## 패키지 구조
+
+```
+io.bluetape4k.workshop.graph.abuser
+├── model
+│   ├── AbuseCluster.kt          — 공유 식별자로 연결된 사용자 클러스터 결과
+│   ├── AbusePath.kt             — 사용자-식별자 단일 연결 경로
+│   ├── IdentifierEdgeLabel.kt   — 네 가지 식별자 엣지 타입의 타입 안전 열거
+│   └── SuspiciousUserScore.kt   — 단일 사용자의 PageRank 결과
+├── schema
+│   └── AbuserDetectionSchema.kt — 정점 레이블(User, Device, IpAddress, PhoneNumber, PaymentMethod)
+│                                   및 엣지 레이블(USES_DEVICE, USES_IP, HAS_PHONE, USES_PAYMENT, REFERRED_BY)
+└── service
+    ├── AbuserDetectionService.kt        — 블로킹 구현 (GraphOperations)
+    └── AbuserDetectionSuspendService.kt — 코루틴 구현 (GraphSuspendOperations + Flow)
+```

--- a/graph/abuser-detection/README.md
+++ b/graph/abuser-detection/README.md
@@ -1,0 +1,189 @@
+# graph-abuser-detection
+
+[English](README.md) | [한국어](README.ko.md)
+
+A bluetape4k workshop module demonstrating graph-based abuser detection. The module builds an
+**identity graph** that links user accounts to shared identifiers — devices, IP addresses, hashed
+phone numbers, and payment tokens — and then applies graph algorithms to surface fraud clusters,
+suspicious connection paths, referral loops, and PageRank-based risk scores.
+
+Both a blocking service (`AbuserDetectionService`) and a coroutine-friendly service
+(`AbuserDetectionSuspendService`) are provided. Tests run against TinkerGraph (in-process,
+no Docker) by default, with optional Neo4j and Memgraph integration tests.
+
+## Graph Schema
+
+### Vertices
+
+| Label | Key property | Other properties | Notes |
+|---|---|---|---|
+| `User` | `userId` (opaque string / UUID) | `country` (ISO-3166-1 alpha-2) | The primary entity |
+| `Device` | `deviceId` (device fingerprint) | `platform` (`"android"`, `"ios"`, `"web"`) | |
+| `IpAddress` | `ip` (IPv4 or IPv6) | — | |
+| `PhoneNumber` | `phone` (E.164 SHA-256 hex hash) | — | Raw phone numbers must NOT be stored |
+| `PaymentMethod` | `paymentToken` (processor token) | — | Raw PAN / CVV must NOT be stored |
+
+### Edges
+
+| Label | From | To | Property | Notes |
+|---|---|---|---|---|
+| `USES_DEVICE` | `User` | `Device` | `occurredAt` (ISO-8601) | First login from this device |
+| `USES_IP` | `User` | `IpAddress` | `occurredAt` (ISO-8601) | First observed connection |
+| `HAS_PHONE` | `User` | `PhoneNumber` | `occurredAt` (ISO-8601) | First association |
+| `USES_PAYMENT` | `User` | `PaymentMethod` | `occurredAt` (ISO-8601) | First payment attempt |
+| `REFERRED_BY` | `User` | `User` | `occurredAt` (ISO-8601) | Referral link (referrer → referred); excluded from cluster BFS |
+
+The four identifier edge types (`USES_DEVICE`, `USES_IP`, `HAS_PHONE`, `USES_PAYMENT`) are
+enumerated as typed values in `IdentifierEdgeLabel`. `REFERRED_BY` is intentionally absent
+from `IdentifierEdgeLabel.all` — referral alone does not imply shared identity.
+
+## Core Algorithms
+
+| Method | Description |
+|---|---|
+| `findAbuseCluster(seedUserId)` | BFS over outgoing identifier edges from the seed user, then reverse-traverses back to co-connected users. Returns `AbuseCluster` containing the other users and the shared identifier vertices that link them. The seed user is excluded from `AbuseCluster.users`. |
+| `explainSuspicion(userId)` | Returns all outgoing identifier paths from a user as a list (blocking) or cold `Flow` (coroutine). Each `AbusePath` names the target identifier vertex and the edge type. |
+| `detectReferralLoops(maxDepth, maxCycles)` | Detects directed cycles in the `REFERRED_BY` subgraph among User vertices. Returns `List<GraphCycle>` (blocking) or cold `Flow<GraphCycle>` (coroutine). |
+| `rankSuspiciousUsers(limit)` | Runs PageRank over User vertices and returns results sorted descending by score. Each `SuspiciousUserScore` carries a 1-based rank. Higher PageRank correlates with more shared-identifier connections, which is a proxy for abuse risk. |
+
+### Result types
+
+```kotlin
+// A cluster of users connected through shared identifiers
+data class AbuseCluster(
+    val seedUserId: GraphElementId,
+    val users: List<GraphVertex>,            // excludes seed user
+    val sharedIdentifiers: List<GraphVertex> // Device/IpAddress/PhoneNumber/PaymentMethod vertices
+)
+
+// One link from a user to a shared identifier vertex
+data class AbusePath(
+    val identifierVertexId: GraphElementId,
+    val edgeLabel: IdentifierEdgeLabel       // USES_DEVICE | USES_IP | HAS_PHONE | USES_PAYMENT
+)
+
+// PageRank-based suspicion ranking entry
+data class SuspiciousUserScore(
+    val user: GraphVertex,
+    val score: Double,   // raw PageRank value; higher = more suspicious
+    val rank: Int        // 1-based position
+)
+```
+
+## Usage
+
+### Blocking service
+
+```kotlin
+val service = AbuserDetectionService(ops, graphName = "fraud_graph")
+service.initialize()
+
+// Add vertices (find-or-create by domain key)
+val userV   = service.addUser("u-alice", "KR")
+val deviceV = service.addDevice("fp-aabbcc", "android")
+val ipV     = service.addIpAddress("203.0.113.42")
+
+// Link vertices
+service.linkDevice(userV.id, deviceV.id, Instant.now().toString())
+service.linkIp(userV.id, ipV.id, Instant.now().toString())
+
+// Detect clusters
+val cluster = service.findAbuseCluster(userV.id)
+if (cluster.users.isNotEmpty()) {
+    println("Cluster size: ${cluster.users.size}")
+}
+
+// Explain why a user is suspicious
+val paths = service.explainSuspicion(userV.id)
+paths.forEach { println("${it.edgeLabel.value} -> ${it.identifierVertexId}") }
+
+// Detect referral fraud rings (default: maxDepth=6, maxCycles=100)
+val loops = service.detectReferralLoops()
+
+// PageRank-based risk ranking
+val top10 = service.rankSuspiciousUsers(limit = 10)
+top10.forEach { println("#${it.rank} ${it.user.id} score=${it.score}") }
+```
+
+### Coroutine service
+
+```kotlin
+val service = AbuserDetectionSuspendService(ops, graphName = "fraud_graph")
+service.initialize()
+
+val userV   = service.addUser("u-bob", "US")
+val phoneV  = service.addPhoneNumber(sha256hex("+11234567890"))  // hash before storing
+val payV    = service.addPaymentMethod("tok_stripe_xxxx")       // processor token only
+
+service.linkPhone(userV.id, phoneV.id, Instant.now().toString())
+service.linkPayment(userV.id, payV.id, Instant.now().toString())
+
+val cluster = service.findAbuseCluster(userV.id)
+
+// explainSuspicion returns a cold Flow
+service.explainSuspicion(userV.id).collect { path ->
+    println("${path.edgeLabel.value} -> ${path.identifierVertexId}")
+}
+
+// detectReferralLoops returns a cold Flow
+service.detectReferralLoops(maxDepth = 4).collect { cycle ->
+    println("Loop: ${cycle.vertices.map { it.id }}")
+}
+
+// rankSuspiciousUsers returns a cold Flow
+service.rankSuspiciousUsers(limit = 5).collect { score ->
+    println("#${score.rank} score=${score.score}")
+}
+```
+
+## Security Notes
+
+- **Phone numbers** — store only an E.164-format SHA-256 hex hash via `addPhoneNumber`. The caller
+  is responsible for hashing before the call. Raw digits must never enter the graph.
+- **Payment tokens** — store only a PCI-safe processor token (e.g. Stripe/Braintree token) via
+  `addPaymentMethod`. Raw PAN, expiry, or CVV must never be stored.
+
+## Test Backends
+
+| Backend | Scope | Requirement |
+|---|---|---|
+| TinkerGraph | `test` (default) | None — runs in-process with no external dependencies |
+| Neo4j | `integrationTest` | Docker (uses `bluetape4k-testcontainers` Neo4j launcher) |
+| Memgraph | `integrationTest` | Docker (uses `bluetape4k-testcontainers` Memgraph launcher) |
+
+The `test` task excludes tests tagged `@Tag("integration")`. The `integrationTest` task includes
+only those tagged tests and requires Docker to be running.
+
+## Running Tests
+
+```bash
+# Default tests — TinkerGraph only, no Docker required
+./gradlew :graph-abuser-detection:test
+
+# Integration tests — Neo4j + Memgraph via Docker
+./gradlew :graph-abuser-detection:integrationTest
+
+# Both
+./gradlew :graph-abuser-detection:test :graph-abuser-detection:integrationTest
+
+# Single test class
+./gradlew :graph-abuser-detection:test \
+  --tests "io.bluetape4k.workshop.graph.abuser.service.AbuserDetectionServiceTest"
+```
+
+## Package Structure
+
+```
+io.bluetape4k.workshop.graph.abuser
+├── model
+│   ├── AbuseCluster.kt          — cluster result holding co-connected users + shared identifiers
+│   ├── AbusePath.kt             — single user-to-identifier edge path
+│   ├── IdentifierEdgeLabel.kt   — typed enum of the four identifier edge types
+│   └── SuspiciousUserScore.kt   — PageRank result for one user
+├── schema
+│   └── AbuserDetectionSchema.kt — vertex labels (User, Device, IpAddress, PhoneNumber, PaymentMethod)
+│                                   and edge labels (USES_DEVICE, USES_IP, HAS_PHONE, USES_PAYMENT, REFERRED_BY)
+└── service
+    ├── AbuserDetectionService.kt        — blocking implementation (GraphOperations)
+    └── AbuserDetectionSuspendService.kt — coroutine implementation (GraphSuspendOperations + Flow)
+```

--- a/graph/abuser-detection/build.gradle.kts
+++ b/graph/abuser-detection/build.gradle.kts
@@ -1,0 +1,57 @@
+plugins {
+    alias(libs.plugins.kotlin.jvm)
+}
+
+configurations {
+    // Expose compileOnly and runtimeOnly dependencies to testImplementation via extendsFrom.
+    // This avoids duplicating neo4j/memgraph on both compileOnly and testImplementation.
+    testImplementation.get().extendsFrom(compileOnly.get(), runtimeOnly.get())
+}
+
+tasks.test {
+    useJUnitPlatform {
+        // Integration tests require running Docker containers — exclude from the default test task.
+        // Run them with: ./gradlew :graph-abuser-detection:integrationTest
+        excludeTags("integration")
+    }
+}
+
+tasks.register<Test>("integrationTest") {
+    description = "Runs Neo4j and Memgraph integration tests (requires Docker)."
+    group = "verification"
+    useJUnitPlatform {
+        includeTags("integration")
+    }
+    // Inherit the same JVM args as the standard test task.
+    jvmArgs = tasks.test.get().jvmArgs
+}
+
+dependencies {
+    // Graph BOM — must be first so version-less aliases resolve correctly.
+    implementation(platform(libs.bluetape4k.graph.bom))
+
+    // Graph core + TinkerGraph (in-memory, no Docker needed for default tests)
+    implementation(libs.bluetape4k.graph.core)
+    implementation(libs.bluetape4k.graph.tinkerpop)
+
+    // Neo4j and Memgraph backends — compileOnly so tests see them via extendsFrom
+    compileOnly(libs.bluetape4k.graph.neo4j)
+    compileOnly(libs.bluetape4k.graph.memgraph)
+
+    // Bluetape4k
+    implementation(libs.bluetape4k.logging)
+    implementation(libs.bluetape4k.coroutines)
+
+    // Coroutines
+    implementation(libs.kotlinx.coroutines.core.lib)
+    testImplementation(libs.kotlinx.coroutines.test.lib)
+
+    // Test
+    testImplementation(project(":shared"))
+    testImplementation(libs.bluetape4k.junit5)
+    testImplementation(libs.bluetape4k.testcontainers)
+    // Required for Neo4jServer: Neo4jContainer supertype must be on the classpath
+    testImplementation(libs.testcontainers.neo4j)
+    testImplementation(libs.bluetape4k.assertions)
+    testImplementation(libs.mockk)
+}

--- a/graph/abuser-detection/src/main/kotlin/io/bluetape4k/workshop/graph/abuser/model/AbuseCluster.kt
+++ b/graph/abuser-detection/src/main/kotlin/io/bluetape4k/workshop/graph/abuser/model/AbuseCluster.kt
@@ -1,0 +1,38 @@
+package io.bluetape4k.workshop.graph.abuser.model
+
+import io.bluetape4k.graph.model.GraphElementId
+import io.bluetape4k.graph.model.GraphVertex
+import java.io.Serializable
+
+/**
+ * A cluster of user vertices that share at least one identifier (device, IP, phone, or payment).
+ *
+ * ## Behavior / Contract
+ * - [seedUserId] is the starting user whose identifier graph was traversed.
+ * - [users] contains all OTHER users reachable via shared identifier vertices — the seed user is
+ *   excluded from this list.
+ * - [sharedIdentifiers] are the identifier vertices (Device, IpAddress, PhoneNumber, PaymentMethod)
+ *   that link the cluster together.
+ * - An empty [users] list means the seed user has no shared-identifier neighbours and is not part
+ *   of any abuse cluster.
+ *
+ * ## Usage
+ * ```kotlin
+ * val cluster = service.findAbuseCluster(userId)
+ * if (cluster.users.isNotEmpty()) {
+ *     log.warn { "User $userId is part of an abuse cluster with ${cluster.users.size} others" }
+ * }
+ * ```
+ */
+data class AbuseCluster(
+    /** ID of the seed user whose neighbours were traversed. */
+    val seedUserId: GraphElementId,
+    /** Other users sharing at least one identifier with the seed user. */
+    val users: List<GraphVertex>,
+    /** Identifier vertices connecting the cluster. */
+    val sharedIdentifiers: List<GraphVertex>,
+) : Serializable {
+    companion object {
+        private const val serialVersionUID = 1L
+    }
+}

--- a/graph/abuser-detection/src/main/kotlin/io/bluetape4k/workshop/graph/abuser/model/AbusePath.kt
+++ b/graph/abuser-detection/src/main/kotlin/io/bluetape4k/workshop/graph/abuser/model/AbusePath.kt
@@ -1,0 +1,31 @@
+package io.bluetape4k.workshop.graph.abuser.model
+
+import io.bluetape4k.graph.model.GraphElementId
+import java.io.Serializable
+
+/**
+ * A single identifier-sharing path between a user and one of their identifier vertices.
+ *
+ * ## Behavior / Contract
+ * - [identifierVertexId] is the ID of the shared identifier vertex (Device, IpAddress, PhoneNumber,
+ *   or PaymentMethod).
+ * - [edgeLabel] identifies which type of relationship connects the user to the identifier.
+ * - Callers can group multiple [AbusePath] results by [edgeLabel] to enumerate all identifier types
+ *   that connect a suspicious user to shared resources.
+ *
+ * ## Usage
+ * ```kotlin
+ * val paths = service.explainSuspicion(userId)
+ * val devicePaths = paths.filter { it.edgeLabel == IdentifierEdgeLabel.USES_DEVICE }
+ * ```
+ */
+data class AbusePath(
+    /** ID of the shared identifier vertex (Device, IpAddress, PhoneNumber, PaymentMethod). */
+    val identifierVertexId: GraphElementId,
+    /** Edge label type describing how the user is connected to this identifier. */
+    val edgeLabel: IdentifierEdgeLabel,
+) : Serializable {
+    companion object {
+        private const val serialVersionUID = 1L
+    }
+}

--- a/graph/abuser-detection/src/main/kotlin/io/bluetape4k/workshop/graph/abuser/model/IdentifierEdgeLabel.kt
+++ b/graph/abuser-detection/src/main/kotlin/io/bluetape4k/workshop/graph/abuser/model/IdentifierEdgeLabel.kt
@@ -1,0 +1,44 @@
+package io.bluetape4k.workshop.graph.abuser.model
+
+/**
+ * Domain-level dispatch enum for user-to-identifier edge types used in abuse cluster detection.
+ *
+ * This is NOT a schema declaration (see [io.bluetape4k.workshop.graph.abuser.schema]). It is a
+ * typed wrapper over the raw edge-label strings so that service-layer dispatch is type-safe and
+ * exhaustive.
+ *
+ * ## Behavior / Contract
+ * - [all] is the authoritative ordered list of all identifier edge labels.
+ * - [REFERRED_BY] is intentionally absent from [all] — referral alone does not indicate shared
+ *   identity and must not participate in abuse-cluster BFS traversal.
+ *
+ * ## Usage
+ * ```kotlin
+ * IdentifierEdgeLabel.all.forEach { lbl ->
+ *     val neighbors = ops.neighbors(userId, NeighborOptions(lbl.value, OUTGOING, 1))
+ * }
+ * ```
+ */
+@JvmInline
+value class IdentifierEdgeLabel(val value: String) {
+
+    companion object {
+        /** Links a User vertex to a Device vertex. */
+        val USES_DEVICE = IdentifierEdgeLabel("USES_DEVICE")
+
+        /** Links a User vertex to an IpAddress vertex. */
+        val USES_IP = IdentifierEdgeLabel("USES_IP")
+
+        /** Links a User vertex to a PhoneNumber vertex. */
+        val HAS_PHONE = IdentifierEdgeLabel("HAS_PHONE")
+
+        /** Links a User vertex to a PaymentMethod vertex. */
+        val USES_PAYMENT = IdentifierEdgeLabel("USES_PAYMENT")
+
+        /**
+         * All identifier edge labels used for abuse cluster traversal.
+         * REFERRED_BY is excluded — referral alone does not indicate shared identity.
+         */
+        val all: List<IdentifierEdgeLabel> = listOf(USES_DEVICE, USES_IP, HAS_PHONE, USES_PAYMENT)
+    }
+}

--- a/graph/abuser-detection/src/main/kotlin/io/bluetape4k/workshop/graph/abuser/model/SuspiciousUserScore.kt
+++ b/graph/abuser-detection/src/main/kotlin/io/bluetape4k/workshop/graph/abuser/model/SuspiciousUserScore.kt
@@ -1,0 +1,34 @@
+package io.bluetape4k.workshop.graph.abuser.model
+
+import io.bluetape4k.graph.model.GraphVertex
+import java.io.Serializable
+
+/**
+ * PageRank-based suspicion score for a single user vertex.
+ *
+ * ## Behavior / Contract
+ * - [rank] is 1-based: `1` is the most suspicious user, `2` is second, and so on.
+ * - [score] is the raw PageRank value from the underlying graph backend; higher is more suspicious.
+ * - Results from [io.bluetape4k.workshop.graph.abuser.service.AbuserDetectionService.rankSuspiciousUsers]
+ *   are pre-sorted descending by score, so the list is already ordered from most to least suspicious.
+ *
+ * ## Usage
+ * ```kotlin
+ * val top10 = service.rankSuspiciousUsers(limit = 10)
+ * top10.forEach { score ->
+ *     println("#${score.rank} userId=${score.user.id} score=${score.score}")
+ * }
+ * ```
+ */
+data class SuspiciousUserScore(
+    /** The user vertex. */
+    val user: GraphVertex,
+    /** Raw PageRank score (higher = more suspicious). */
+    val score: Double,
+    /** 1-based rank position in the suspicion ranking. */
+    val rank: Int,
+) : Serializable {
+    companion object {
+        private const val serialVersionUID = 1L
+    }
+}

--- a/graph/abuser-detection/src/main/kotlin/io/bluetape4k/workshop/graph/abuser/schema/AbuserDetectionSchema.kt
+++ b/graph/abuser-detection/src/main/kotlin/io/bluetape4k/workshop/graph/abuser/schema/AbuserDetectionSchema.kt
@@ -1,0 +1,129 @@
+package io.bluetape4k.workshop.graph.abuser.schema
+
+import io.bluetape4k.graph.schema.EdgeLabel
+import io.bluetape4k.graph.schema.VertexLabel
+
+// ────────────────────────────────────────────────────────────────────────────
+// Vertex Labels
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Vertex label for registered user accounts.
+ *
+ * ## Properties
+ * - `userId` — stable user identifier (opaque string, e.g. UUID)
+ * - `country` — ISO-3166-1 alpha-2 country code
+ */
+object UserLabel : VertexLabel("User") {
+    val userId = string("userId")
+    val country = string("country")
+}
+
+/**
+ * Vertex label for device fingerprint identifiers.
+ *
+ * ## Properties
+ * - `deviceId` — unique device fingerprint (opaque string)
+ * - `platform` — OS/platform string, e.g. `"android"`, `"ios"`, `"web"`
+ */
+object DeviceLabel : VertexLabel("Device") {
+    val deviceId = string("deviceId")
+    val platform = string("platform")
+}
+
+/**
+ * Vertex label for IP address identifiers.
+ *
+ * ## Properties
+ * - `ip` — IPv4 or IPv6 address string
+ */
+object IpAddressLabel : VertexLabel("IpAddress") {
+    val ip = string("ip")
+}
+
+/**
+ * Vertex label for phone number identifiers.
+ *
+ * **Security**: `phone` stores an **E.164-format hash** (SHA-256 hex or equivalent).
+ * Raw phone numbers MUST NOT be persisted in the graph.
+ * Callers are responsible for hashing before calling [io.bluetape4k.workshop.graph.abuser.service.AbuserDetectionService.addPhoneNumber].
+ *
+ * ## Properties
+ * - `phone` — hashed phone number (E.164 SHA-256 hex)
+ */
+object PhoneNumberLabel : VertexLabel("PhoneNumber") {
+    val phone = string("phone")
+}
+
+/**
+ * Vertex label for payment method identifiers.
+ *
+ * **Security**: `paymentToken` stores a **PCI-safe processor token** (e.g. Stripe/Braintree token).
+ * Raw PAN, CVV, or full card numbers MUST NOT be stored.
+ * Callers must obtain a tokenised reference from the payment processor before calling
+ * [io.bluetape4k.workshop.graph.abuser.service.AbuserDetectionService.addPaymentMethod].
+ *
+ * ## Properties
+ * - `paymentToken` — processor-issued payment token (never a raw PAN or CVV)
+ */
+object PaymentMethodLabel : VertexLabel("PaymentMethod") {
+    val paymentToken = string("paymentToken")
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Edge Labels
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Edge label linking a user to a device.
+ *
+ * ## Properties
+ * - `occurredAt` — ISO-8601 timestamp of the first login from this device
+ */
+object UsesDeviceLabel : EdgeLabel("USES_DEVICE", UserLabel, DeviceLabel) {
+    val occurredAt = string("occurredAt")
+}
+
+/**
+ * Edge label linking a user to an IP address.
+ *
+ * ## Properties
+ * - `occurredAt` — ISO-8601 timestamp of the first observed connection from this IP
+ */
+object UsesIpLabel : EdgeLabel("USES_IP", UserLabel, IpAddressLabel) {
+    val occurredAt = string("occurredAt")
+}
+
+/**
+ * Edge label linking a user to a hashed phone number.
+ *
+ * ## Properties
+ * - `occurredAt` — ISO-8601 timestamp of the first association
+ */
+object HasPhoneLabel : EdgeLabel("HAS_PHONE", UserLabel, PhoneNumberLabel) {
+    val occurredAt = string("occurredAt")
+}
+
+/**
+ * Edge label linking a user to a payment method token.
+ *
+ * ## Properties
+ * - `occurredAt` — ISO-8601 timestamp of the first payment attempt
+ */
+object UsesPaymentLabel : EdgeLabel("USES_PAYMENT", UserLabel, PaymentMethodLabel) {
+    val occurredAt = string("occurredAt")
+}
+
+/**
+ * Edge label recording a referral relationship between two users.
+ *
+ * Direction: referrer → referred.
+ * This edge is intentionally **excluded** from abuse-cluster traversal because referral
+ * alone does not indicate shared identity — only shared device/IP/phone/payment does.
+ *
+ * ## Properties
+ * - `occurredAt` — ISO-8601 timestamp of the referral event
+ */
+object ReferredByLabel : EdgeLabel("REFERRED_BY", UserLabel, UserLabel) {
+    val occurredAt = string("occurredAt")
+}

--- a/graph/abuser-detection/src/main/kotlin/io/bluetape4k/workshop/graph/abuser/service/AbuserDetectionService.kt
+++ b/graph/abuser-detection/src/main/kotlin/io/bluetape4k/workshop/graph/abuser/service/AbuserDetectionService.kt
@@ -1,0 +1,384 @@
+package io.bluetape4k.workshop.graph.abuser.service
+
+import io.bluetape4k.graph.model.CycleOptions
+import io.bluetape4k.graph.model.Direction
+import io.bluetape4k.graph.model.GraphCycle
+import io.bluetape4k.graph.model.GraphEdge
+import io.bluetape4k.graph.model.GraphElementId
+import io.bluetape4k.graph.model.GraphVertex
+import io.bluetape4k.graph.model.NeighborOptions
+import io.bluetape4k.graph.model.PageRankOptions
+import io.bluetape4k.graph.repository.GraphOperations
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import io.bluetape4k.logging.warn
+import io.bluetape4k.support.requireNotBlank
+import io.bluetape4k.support.requirePositiveNumber
+import io.bluetape4k.workshop.graph.abuser.model.AbuseCluster
+import io.bluetape4k.workshop.graph.abuser.model.AbusePath
+import io.bluetape4k.workshop.graph.abuser.model.IdentifierEdgeLabel
+import io.bluetape4k.workshop.graph.abuser.model.SuspiciousUserScore
+import io.bluetape4k.workshop.graph.abuser.schema.DeviceLabel
+import io.bluetape4k.workshop.graph.abuser.schema.HasPhoneLabel
+import io.bluetape4k.workshop.graph.abuser.schema.IpAddressLabel
+import io.bluetape4k.workshop.graph.abuser.schema.PaymentMethodLabel
+import io.bluetape4k.workshop.graph.abuser.schema.PhoneNumberLabel
+import io.bluetape4k.workshop.graph.abuser.schema.ReferredByLabel
+import io.bluetape4k.workshop.graph.abuser.schema.UserLabel
+import io.bluetape4k.workshop.graph.abuser.schema.UsesDeviceLabel
+import io.bluetape4k.workshop.graph.abuser.schema.UsesIpLabel
+import io.bluetape4k.workshop.graph.abuser.schema.UsesPaymentLabel
+
+/**
+ * Blocking graph service for abuser detection.
+ *
+ * Uses a named graph on the given [GraphOperations] backend to manage user identity graphs
+ * and detect fraudulent sharing patterns.
+ *
+ * ## Behavior / Contract
+ * - [initialize] must be called before any other method to ensure the named graph exists.
+ * - Vertex mutators are idempotent: they find an existing vertex by domain key or create one.
+ * - Edge mutators call [GraphOperations.createEdge] directly; callers must avoid duplicate links.
+ * - [findAbuseCluster] excludes the seed user from [AbuseCluster.users].
+ * - [rankSuspiciousUsers] ranks User vertices by PageRank score; the [limit] applies directly to users.
+ *
+ * ## Usage
+ * ```kotlin
+ * val service = AbuserDetectionService(ops, "my_graph")
+ * service.initialize()
+ * val userV = service.addUser("u-1", "KR")
+ * val devV  = service.addDevice("d-1", "android")
+ * service.linkDevice(userV.id, devV.id, Instant.now().toString())
+ * val cluster = service.findAbuseCluster(userV.id)
+ * ```
+ */
+class AbuserDetectionService(
+    private val ops: GraphOperations,
+    private val graphName: String,
+) {
+
+    companion object : KLogging() {
+        /**
+         * Maps identifier vertex label → [IdentifierEdgeLabel] for reverse traversal.
+         *
+         * Used in [findAbuseCluster] to look up which INCOMING edge label to follow from an
+         * identifier vertex back to its connected users.
+         */
+        private val VERTEX_LABEL_TO_EDGE_LABEL: Map<String, IdentifierEdgeLabel> = mapOf(
+            DeviceLabel.label        to IdentifierEdgeLabel.USES_DEVICE,
+            IpAddressLabel.label     to IdentifierEdgeLabel.USES_IP,
+            PhoneNumberLabel.label   to IdentifierEdgeLabel.HAS_PHONE,
+            PaymentMethodLabel.label to IdentifierEdgeLabel.USES_PAYMENT,
+        )
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Lifecycle
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /**
+     * Ensures the named graph exists. Safe to call multiple times — no-op when already created.
+     */
+    fun initialize() {
+        if (!ops.graphExists(graphName)) {
+            log.debug { "Creating graph: $graphName" }
+            ops.createGraph(graphName)
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Vertex mutators (find-or-create by domain key)
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /**
+     * Finds an existing User vertex by [userId] or creates a new one.
+     *
+     * @param userId stable user identifier (opaque string, e.g. UUID)
+     * @param country ISO-3166-1 alpha-2 country code
+     */
+    fun addUser(userId: String, country: String): GraphVertex {
+        userId.requireNotBlank("userId")
+        country.requireNotBlank("country")
+        return ops.findVerticesByLabel(UserLabel.label, mapOf(UserLabel.userId.name to userId))
+            .firstOrNull()
+            ?: ops.createVertex(
+                UserLabel.label,
+                mapOf(UserLabel.userId.name to userId, UserLabel.country.name to country)
+            )
+    }
+
+    /**
+     * Finds an existing Device vertex by [deviceId] or creates a new one.
+     *
+     * @param deviceId unique device fingerprint
+     * @param platform OS/platform string, e.g. `"android"`, `"ios"`, `"web"`
+     */
+    fun addDevice(deviceId: String, platform: String): GraphVertex {
+        deviceId.requireNotBlank("deviceId")
+        platform.requireNotBlank("platform")
+        return ops.findVerticesByLabel(DeviceLabel.label, mapOf(DeviceLabel.deviceId.name to deviceId))
+            .firstOrNull()
+            ?: ops.createVertex(
+                DeviceLabel.label,
+                mapOf(DeviceLabel.deviceId.name to deviceId, DeviceLabel.platform.name to platform)
+            )
+    }
+
+    /**
+     * Finds an existing IpAddress vertex by [ip] or creates a new one.
+     *
+     * @param ip IPv4 or IPv6 address string
+     */
+    fun addIpAddress(ip: String): GraphVertex {
+        ip.requireNotBlank("ip")
+        return ops.findVerticesByLabel(IpAddressLabel.label, mapOf(IpAddressLabel.ip.name to ip))
+            .firstOrNull()
+            ?: ops.createVertex(IpAddressLabel.label, mapOf(IpAddressLabel.ip.name to ip))
+    }
+
+    /**
+     * Finds an existing PhoneNumber vertex by hashed phone or creates a new one.
+     *
+     * **Security**: [hashedPhone] MUST be an E.164-format SHA-256 hex hash.
+     * Raw phone numbers MUST NOT be passed to this method.
+     *
+     * @param hashedPhone E.164 SHA-256 hex of the phone number
+     */
+    fun addPhoneNumber(hashedPhone: String): GraphVertex {
+        hashedPhone.requireNotBlank("hashedPhone")
+        return ops.findVerticesByLabel(PhoneNumberLabel.label, mapOf(PhoneNumberLabel.phone.name to hashedPhone))
+            .firstOrNull()
+            ?: ops.createVertex(PhoneNumberLabel.label, mapOf(PhoneNumberLabel.phone.name to hashedPhone))
+    }
+
+    /**
+     * Finds an existing PaymentMethod vertex by [paymentToken] or creates a new one.
+     *
+     * **Security**: [paymentToken] MUST be a PCI-safe processor token.
+     * Raw PAN or CVV MUST NOT be passed to this method.
+     *
+     * @param paymentToken processor-issued payment token (never a raw PAN or CVV)
+     */
+    fun addPaymentMethod(paymentToken: String): GraphVertex {
+        paymentToken.requireNotBlank("paymentToken")
+        return ops.findVerticesByLabel(
+            PaymentMethodLabel.label,
+            mapOf(PaymentMethodLabel.paymentToken.name to paymentToken)
+        )
+            .firstOrNull()
+            ?: ops.createVertex(
+                PaymentMethodLabel.label,
+                mapOf(PaymentMethodLabel.paymentToken.name to paymentToken)
+            )
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Edge mutators
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /**
+     * Links a user to a device with a `USES_DEVICE` edge.
+     *
+     * @param userVertexId graph ID of the User vertex
+     * @param deviceVertexId graph ID of the Device vertex
+     * @param occurredAt ISO-8601 timestamp of the first login from this device
+     */
+    fun linkDevice(userVertexId: GraphElementId, deviceVertexId: GraphElementId, occurredAt: String): GraphEdge {
+        occurredAt.requireNotBlank("occurredAt")
+        return ops.createEdge(
+            userVertexId,
+            deviceVertexId,
+            UsesDeviceLabel.label,
+            mapOf(UsesDeviceLabel.occurredAt.name to occurredAt),
+        )
+    }
+
+    /**
+     * Links a user to an IP address with a `USES_IP` edge.
+     *
+     * @param userVertexId graph ID of the User vertex
+     * @param ipVertexId graph ID of the IpAddress vertex
+     * @param occurredAt ISO-8601 timestamp of the first observed connection
+     */
+    fun linkIp(userVertexId: GraphElementId, ipVertexId: GraphElementId, occurredAt: String): GraphEdge {
+        occurredAt.requireNotBlank("occurredAt")
+        return ops.createEdge(
+            userVertexId,
+            ipVertexId,
+            UsesIpLabel.label,
+            mapOf(UsesIpLabel.occurredAt.name to occurredAt),
+        )
+    }
+
+    /**
+     * Links a user to a phone number with a `HAS_PHONE` edge.
+     *
+     * @param userVertexId graph ID of the User vertex
+     * @param phoneVertexId graph ID of the PhoneNumber vertex
+     * @param occurredAt ISO-8601 timestamp of the first association
+     */
+    fun linkPhone(userVertexId: GraphElementId, phoneVertexId: GraphElementId, occurredAt: String): GraphEdge {
+        occurredAt.requireNotBlank("occurredAt")
+        return ops.createEdge(
+            userVertexId,
+            phoneVertexId,
+            HasPhoneLabel.label,
+            mapOf(HasPhoneLabel.occurredAt.name to occurredAt),
+        )
+    }
+
+    /**
+     * Links a user to a payment method with a `USES_PAYMENT` edge.
+     *
+     * @param userVertexId graph ID of the User vertex
+     * @param paymentVertexId graph ID of the PaymentMethod vertex
+     * @param occurredAt ISO-8601 timestamp of the first payment attempt
+     */
+    fun linkPayment(userVertexId: GraphElementId, paymentVertexId: GraphElementId, occurredAt: String): GraphEdge {
+        occurredAt.requireNotBlank("occurredAt")
+        return ops.createEdge(
+            userVertexId,
+            paymentVertexId,
+            UsesPaymentLabel.label,
+            mapOf(UsesPaymentLabel.occurredAt.name to occurredAt),
+        )
+    }
+
+    /**
+     * Records a referral relationship from [referrerVertexId] to [referredVertexId].
+     *
+     * @param referrerVertexId graph ID of the referring User vertex
+     * @param referredVertexId graph ID of the referred User vertex
+     * @param occurredAt ISO-8601 timestamp of the referral event
+     */
+    fun linkReferral(referrerVertexId: GraphElementId, referredVertexId: GraphElementId, occurredAt: String): GraphEdge {
+        occurredAt.requireNotBlank("occurredAt")
+        return ops.createEdge(
+            referrerVertexId,
+            referredVertexId,
+            ReferredByLabel.label,
+            mapOf(ReferredByLabel.occurredAt.name to occurredAt),
+        )
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Query algorithms
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /**
+     * Finds all users that share at least one identifier with the given seed user.
+     *
+     * Algorithm:
+     * 1. Collect all identifier vertices reachable from [seedUserId] via OUTGOING identifier edges.
+     * 2. For each identifier vertex, collect INCOMING users via the same identifier edge type.
+     * 3. Remove the seed user itself from the result.
+     *
+     * @param seedUserId graph vertex ID of the seed user
+     * @return [AbuseCluster] where [AbuseCluster.users] excludes the seed user.
+     *         Returns an empty cluster if the seed user does not exist.
+     */
+    fun findAbuseCluster(seedUserId: GraphElementId): AbuseCluster {
+        val emptyCluster = AbuseCluster(seedUserId, emptyList(), emptyList())
+
+        if (ops.findVertexById(seedUserId) == null) {
+            log.warn { "findAbuseCluster: seed user vertex not found [seedUserId=$seedUserId, graphName=$graphName] — returning empty cluster" }
+            return emptyCluster
+        }
+
+        // Step 1: traverse OUTGOING identifier edges to gather shared identifiers
+        val seedIdentifiers = IdentifierEdgeLabel.all.flatMap { edgeLabel ->
+            ops.neighbors(seedUserId, NeighborOptions(edgeLabel.value, Direction.OUTGOING, 1))
+        }
+
+        if (seedIdentifiers.isEmpty()) {
+            return emptyCluster
+        }
+
+        // Step 2: reverse-traverse from each identifier to find co-connected users
+        val clusterUsers = mutableListOf<GraphVertex>()
+        for (identifierVertex in seedIdentifiers) {
+            val reverseLabel = VERTEX_LABEL_TO_EDGE_LABEL[identifierVertex.label]
+            if (reverseLabel == null) {
+                log.warn { "findAbuseCluster: unknown identifier vertex label '${identifierVertex.label}' — skipping reverse traversal" }
+                continue
+            }
+            ops.neighbors(
+                identifierVertex.id,
+                NeighborOptions(reverseLabel.value, Direction.INCOMING, 1)
+            ).filterTo(clusterUsers) { it.id != seedUserId }
+        }
+
+        return AbuseCluster(
+            seedUserId = seedUserId,
+            users = clusterUsers.distinctBy { it.id },
+            sharedIdentifiers = seedIdentifiers.distinctBy { it.id },
+        )
+    }
+
+    /**
+     * Returns the shared identifier paths that connect the given user to other users.
+     *
+     * Each [AbusePath] describes one identifier vertex and the edge type connecting the user to it.
+     *
+     * @param userId graph vertex ID of the user to explain
+     * @return list of [AbusePath] entries; empty if the user has no outgoing identifier edges
+     */
+    fun explainSuspicion(userId: GraphElementId): List<AbusePath> {
+        val paths = mutableListOf<AbusePath>()
+        for (edgeLabel in IdentifierEdgeLabel.all) {
+            ops.findEdgesByStartId(userId, edgeLabel.value)
+                .mapTo(paths) { edge ->
+                    AbusePath(
+                        identifierVertexId = edge.endId,
+                        edgeLabel = edgeLabel,
+                    )
+                }
+        }
+        return paths
+    }
+
+    /**
+     * Detects referral loops — cycles among User vertices via REFERRED_BY edges.
+     *
+     * @param maxDepth maximum traversal depth when searching for cycles (default 6)
+     * @param maxCycles maximum number of cycles to return (default 100)
+     * @return list of detected [GraphCycle]s; empty if no loops exist
+     */
+    fun detectReferralLoops(maxDepth: Int = 6, maxCycles: Int = 100): List<GraphCycle> {
+        maxDepth.requirePositiveNumber("maxDepth")
+        maxCycles.requirePositiveNumber("maxCycles")
+        return ops.detectCycles(
+            CycleOptions(
+                vertexLabel = UserLabel.label,
+                edgeLabel   = ReferredByLabel.label,
+                maxDepth    = maxDepth,
+                maxCycles   = maxCycles,
+            )
+        )
+    }
+
+    /**
+     * Ranks users by PageRank score descending.
+     *
+     * PageRank is computed over all graph vertices and edges; results are then filtered to the
+     * User label. Higher score indicates a user is more highly connected in the identity graph,
+     * which correlates with shared-identifier abuse risk.
+     *
+     * @param limit maximum number of [SuspiciousUserScore] entries to return (default 20, must be > 0)
+     * @return list sorted descending by score with 1-based [SuspiciousUserScore.rank]
+     */
+    fun rankSuspiciousUsers(limit: Int = 20): List<SuspiciousUserScore> {
+        limit.requirePositiveNumber("limit")
+        // vertexLabel = UserLabel.label ensures PageRank is computed and ranked
+        // among User vertices only — so topK = limit applies directly to users.
+        return ops.pageRank(PageRankOptions(vertexLabel = UserLabel.label, topK = limit))
+            .withIndex()
+            .map { (index, pageRankScore) ->
+                SuspiciousUserScore(
+                    user  = pageRankScore.vertex,
+                    score = pageRankScore.score,
+                    rank  = index + 1,
+                )
+            }
+    }
+}

--- a/graph/abuser-detection/src/main/kotlin/io/bluetape4k/workshop/graph/abuser/service/AbuserDetectionSuspendService.kt
+++ b/graph/abuser-detection/src/main/kotlin/io/bluetape4k/workshop/graph/abuser/service/AbuserDetectionSuspendService.kt
@@ -1,0 +1,411 @@
+package io.bluetape4k.workshop.graph.abuser.service
+
+import io.bluetape4k.graph.model.CycleOptions
+import io.bluetape4k.graph.model.Direction
+import io.bluetape4k.graph.model.GraphCycle
+import io.bluetape4k.graph.model.GraphEdge
+import io.bluetape4k.graph.model.GraphElementId
+import io.bluetape4k.graph.model.GraphVertex
+import io.bluetape4k.graph.model.NeighborOptions
+import io.bluetape4k.graph.model.PageRankOptions
+import io.bluetape4k.graph.repository.GraphSuspendOperations
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.logging.debug
+import io.bluetape4k.logging.warn
+import io.bluetape4k.support.requireNotBlank
+import io.bluetape4k.support.requirePositiveNumber
+import io.bluetape4k.workshop.graph.abuser.model.AbuseCluster
+import io.bluetape4k.workshop.graph.abuser.model.AbusePath
+import io.bluetape4k.workshop.graph.abuser.model.IdentifierEdgeLabel
+import io.bluetape4k.workshop.graph.abuser.model.SuspiciousUserScore
+import io.bluetape4k.workshop.graph.abuser.schema.DeviceLabel
+import io.bluetape4k.workshop.graph.abuser.schema.HasPhoneLabel
+import io.bluetape4k.workshop.graph.abuser.schema.IpAddressLabel
+import io.bluetape4k.workshop.graph.abuser.schema.PaymentMethodLabel
+import io.bluetape4k.workshop.graph.abuser.schema.PhoneNumberLabel
+import io.bluetape4k.workshop.graph.abuser.schema.ReferredByLabel
+import io.bluetape4k.workshop.graph.abuser.schema.UserLabel
+import io.bluetape4k.workshop.graph.abuser.schema.UsesDeviceLabel
+import io.bluetape4k.workshop.graph.abuser.schema.UsesIpLabel
+import io.bluetape4k.workshop.graph.abuser.schema.UsesPaymentLabel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.flow.withIndex
+
+/**
+ * Coroutine-based graph service for abuser detection.
+ *
+ * Mirrors the API of [AbuserDetectionService] with suspend/Flow return types for non-blocking
+ * use in coroutine contexts. All read-heavy operations that can return many results expose a
+ * cold [Flow] so callers control back-pressure and cancellation.
+ *
+ * ## Behavior / Contract
+ * - [initialize] must be called before any other method to ensure the named graph exists.
+ * - Vertex mutators are idempotent: they find an existing vertex by domain key or create one.
+ * - Edge mutators call [GraphSuspendOperations.createEdge] directly; callers must avoid duplicate links.
+ * - [findAbuseCluster] excludes the seed user from [AbuseCluster.users].
+ * - [rankSuspiciousUsers] returns a cold [Flow] of User vertices ranked by PageRank; ranks are 1-based.
+ * - Never wrap suspend calls in `runCatching` — [kotlinx.coroutines.CancellationException] must propagate.
+ *
+ * ## Usage
+ * ```kotlin
+ * val service = AbuserDetectionSuspendService(ops, "my_graph")
+ * service.initialize()
+ * val userV = service.addUser("u-1", "KR")
+ * val devV  = service.addDevice("d-1", "android")
+ * service.linkDevice(userV.id, devV.id, Instant.now().toString())
+ * val cluster = service.findAbuseCluster(userV.id)
+ * service.rankSuspiciousUsers(limit = 10).collect { score -> println(score) }
+ * ```
+ */
+class AbuserDetectionSuspendService(
+    private val ops: GraphSuspendOperations,
+    private val graphName: String,
+) {
+
+    companion object : KLoggingChannel() {
+        /**
+         * Maps identifier vertex label → [IdentifierEdgeLabel] for reverse traversal.
+         *
+         * Used in [findAbuseCluster] to look up which INCOMING edge label to follow from an
+         * identifier vertex back to its connected users.
+         */
+        private val VERTEX_LABEL_TO_EDGE_LABEL: Map<String, IdentifierEdgeLabel> = mapOf(
+            DeviceLabel.label        to IdentifierEdgeLabel.USES_DEVICE,
+            IpAddressLabel.label     to IdentifierEdgeLabel.USES_IP,
+            PhoneNumberLabel.label   to IdentifierEdgeLabel.HAS_PHONE,
+            PaymentMethodLabel.label to IdentifierEdgeLabel.USES_PAYMENT,
+        )
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Lifecycle
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /**
+     * Ensures the named graph exists. Safe to call multiple times — no-op when already created.
+     */
+    suspend fun initialize() {
+        if (!ops.graphExists(graphName)) {
+            log.debug { "Creating graph: $graphName" }
+            ops.createGraph(graphName)
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Vertex mutators (find-or-create by domain key)
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /**
+     * Finds an existing User vertex by [userId] or creates a new one.
+     *
+     * @param userId stable user identifier (opaque string, e.g. UUID)
+     * @param country ISO-3166-1 alpha-2 country code
+     */
+    suspend fun addUser(userId: String, country: String): GraphVertex {
+        userId.requireNotBlank("userId")
+        country.requireNotBlank("country")
+        return ops.findVerticesByLabel(UserLabel.label, mapOf(UserLabel.userId.name to userId))
+            .firstOrNull()
+            ?: ops.createVertex(
+                UserLabel.label,
+                mapOf(UserLabel.userId.name to userId, UserLabel.country.name to country)
+            )
+    }
+
+    /**
+     * Finds an existing Device vertex by [deviceId] or creates a new one.
+     *
+     * @param deviceId unique device fingerprint
+     * @param platform OS/platform string, e.g. `"android"`, `"ios"`, `"web"`
+     */
+    suspend fun addDevice(deviceId: String, platform: String): GraphVertex {
+        deviceId.requireNotBlank("deviceId")
+        platform.requireNotBlank("platform")
+        return ops.findVerticesByLabel(DeviceLabel.label, mapOf(DeviceLabel.deviceId.name to deviceId))
+            .firstOrNull()
+            ?: ops.createVertex(
+                DeviceLabel.label,
+                mapOf(DeviceLabel.deviceId.name to deviceId, DeviceLabel.platform.name to platform)
+            )
+    }
+
+    /**
+     * Finds an existing IpAddress vertex by [ip] or creates a new one.
+     *
+     * @param ip IPv4 or IPv6 address string
+     */
+    suspend fun addIpAddress(ip: String): GraphVertex {
+        ip.requireNotBlank("ip")
+        return ops.findVerticesByLabel(IpAddressLabel.label, mapOf(IpAddressLabel.ip.name to ip))
+            .firstOrNull()
+            ?: ops.createVertex(IpAddressLabel.label, mapOf(IpAddressLabel.ip.name to ip))
+    }
+
+    /**
+     * Finds an existing PhoneNumber vertex by hashed phone or creates a new one.
+     *
+     * **Security**: [hashedPhone] MUST be an E.164-format SHA-256 hex hash.
+     * Raw phone numbers MUST NOT be passed to this method.
+     *
+     * @param hashedPhone E.164 SHA-256 hex of the phone number
+     */
+    suspend fun addPhoneNumber(hashedPhone: String): GraphVertex {
+        hashedPhone.requireNotBlank("hashedPhone")
+        return ops.findVerticesByLabel(PhoneNumberLabel.label, mapOf(PhoneNumberLabel.phone.name to hashedPhone))
+            .firstOrNull()
+            ?: ops.createVertex(PhoneNumberLabel.label, mapOf(PhoneNumberLabel.phone.name to hashedPhone))
+    }
+
+    /**
+     * Finds an existing PaymentMethod vertex by [paymentToken] or creates a new one.
+     *
+     * **Security**: [paymentToken] MUST be a PCI-safe processor token.
+     * Raw PAN or CVV MUST NOT be passed to this method.
+     *
+     * @param paymentToken processor-issued payment token (never a raw PAN or CVV)
+     */
+    suspend fun addPaymentMethod(paymentToken: String): GraphVertex {
+        paymentToken.requireNotBlank("paymentToken")
+        return ops.findVerticesByLabel(
+            PaymentMethodLabel.label,
+            mapOf(PaymentMethodLabel.paymentToken.name to paymentToken)
+        )
+            .firstOrNull()
+            ?: ops.createVertex(
+                PaymentMethodLabel.label,
+                mapOf(PaymentMethodLabel.paymentToken.name to paymentToken)
+            )
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Edge mutators
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /**
+     * Links a user to a device with a `USES_DEVICE` edge.
+     *
+     * @param userVertexId graph ID of the User vertex
+     * @param deviceVertexId graph ID of the Device vertex
+     * @param occurredAt ISO-8601 timestamp of the first login from this device
+     */
+    suspend fun linkDevice(
+        userVertexId: GraphElementId,
+        deviceVertexId: GraphElementId,
+        occurredAt: String,
+    ): GraphEdge {
+        occurredAt.requireNotBlank("occurredAt")
+        return ops.createEdge(
+            userVertexId,
+            deviceVertexId,
+            UsesDeviceLabel.label,
+            mapOf(UsesDeviceLabel.occurredAt.name to occurredAt),
+        )
+    }
+
+    /**
+     * Links a user to an IP address with a `USES_IP` edge.
+     *
+     * @param userVertexId graph ID of the User vertex
+     * @param ipVertexId graph ID of the IpAddress vertex
+     * @param occurredAt ISO-8601 timestamp of the first observed connection
+     */
+    suspend fun linkIp(
+        userVertexId: GraphElementId,
+        ipVertexId: GraphElementId,
+        occurredAt: String,
+    ): GraphEdge {
+        occurredAt.requireNotBlank("occurredAt")
+        return ops.createEdge(
+            userVertexId,
+            ipVertexId,
+            UsesIpLabel.label,
+            mapOf(UsesIpLabel.occurredAt.name to occurredAt),
+        )
+    }
+
+    /**
+     * Links a user to a phone number with a `HAS_PHONE` edge.
+     *
+     * @param userVertexId graph ID of the User vertex
+     * @param phoneVertexId graph ID of the PhoneNumber vertex
+     * @param occurredAt ISO-8601 timestamp of the first association
+     */
+    suspend fun linkPhone(
+        userVertexId: GraphElementId,
+        phoneVertexId: GraphElementId,
+        occurredAt: String,
+    ): GraphEdge {
+        occurredAt.requireNotBlank("occurredAt")
+        return ops.createEdge(
+            userVertexId,
+            phoneVertexId,
+            HasPhoneLabel.label,
+            mapOf(HasPhoneLabel.occurredAt.name to occurredAt),
+        )
+    }
+
+    /**
+     * Links a user to a payment method with a `USES_PAYMENT` edge.
+     *
+     * @param userVertexId graph ID of the User vertex
+     * @param paymentVertexId graph ID of the PaymentMethod vertex
+     * @param occurredAt ISO-8601 timestamp of the first payment attempt
+     */
+    suspend fun linkPayment(
+        userVertexId: GraphElementId,
+        paymentVertexId: GraphElementId,
+        occurredAt: String,
+    ): GraphEdge {
+        occurredAt.requireNotBlank("occurredAt")
+        return ops.createEdge(
+            userVertexId,
+            paymentVertexId,
+            UsesPaymentLabel.label,
+            mapOf(UsesPaymentLabel.occurredAt.name to occurredAt),
+        )
+    }
+
+    /**
+     * Records a referral relationship from [referrerVertexId] to [referredVertexId].
+     *
+     * @param referrerVertexId graph ID of the referring User vertex
+     * @param referredVertexId graph ID of the referred User vertex
+     * @param occurredAt ISO-8601 timestamp of the referral event
+     */
+    suspend fun linkReferral(
+        referrerVertexId: GraphElementId,
+        referredVertexId: GraphElementId,
+        occurredAt: String,
+    ): GraphEdge {
+        occurredAt.requireNotBlank("occurredAt")
+        return ops.createEdge(
+            referrerVertexId,
+            referredVertexId,
+            ReferredByLabel.label,
+            mapOf(ReferredByLabel.occurredAt.name to occurredAt),
+        )
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Query algorithms
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /**
+     * Finds all users that share at least one identifier with the given seed user.
+     *
+     * Algorithm:
+     * 1. Collect all identifier vertices reachable from [seedUserId] via OUTGOING identifier edges.
+     * 2. For each identifier vertex, collect INCOMING users via the same identifier edge type.
+     * 3. Remove the seed user itself from the result.
+     *
+     * @param seedUserId graph vertex ID of the seed user
+     * @return [AbuseCluster] where [AbuseCluster.users] excludes the seed user.
+     *         Returns an empty cluster if the seed user does not exist.
+     */
+    suspend fun findAbuseCluster(seedUserId: GraphElementId): AbuseCluster {
+        val emptyCluster = AbuseCluster(seedUserId, emptyList(), emptyList())
+
+        if (ops.findVertexById(seedUserId) == null) {
+            log.warn { "findAbuseCluster: seed user vertex not found [seedUserId=$seedUserId, graphName=$graphName] — returning empty cluster" }
+            return emptyCluster
+        }
+
+        // Step 1: traverse OUTGOING identifier edges to gather shared identifiers
+        val seedIdentifiers = buildList {
+            for (edgeLabel in IdentifierEdgeLabel.all) {
+                addAll(
+                    ops.neighbors(seedUserId, NeighborOptions(edgeLabel.value, Direction.OUTGOING, 1))
+                        .toList()
+                )
+            }
+        }
+
+        if (seedIdentifiers.isEmpty()) {
+            return emptyCluster
+        }
+
+        // Step 2: reverse-traverse from each identifier to find co-connected users
+        val clusterUsers = mutableListOf<GraphVertex>()
+        for (identifierVertex in seedIdentifiers) {
+            val reverseLabel = VERTEX_LABEL_TO_EDGE_LABEL[identifierVertex.label]
+            if (reverseLabel == null) {
+                log.warn { "findAbuseCluster: unknown identifier vertex label '${identifierVertex.label}' — skipping reverse traversal" }
+                continue
+            }
+            ops.neighbors(
+                identifierVertex.id,
+                NeighborOptions(reverseLabel.value, Direction.INCOMING, 1)
+            ).toList().filterTo(clusterUsers) { it.id != seedUserId }
+        }
+
+        return AbuseCluster(
+            seedUserId = seedUserId,
+            users = clusterUsers.distinctBy { it.id },
+            sharedIdentifiers = seedIdentifiers.distinctBy { it.id },
+        )
+    }
+
+    /**
+     * Returns a cold [Flow] of shared identifier paths that connect the given user to other users.
+     *
+     * Each [AbusePath] describes one identifier vertex and the edge type connecting the user to it.
+     *
+     * @param userId graph vertex ID of the user to explain
+     * @return cold [Flow] of [AbusePath] entries; empty if the user has no outgoing identifier edges
+     */
+    fun explainSuspicion(userId: GraphElementId): Flow<AbusePath> = flow {
+        for (edgeLabel in IdentifierEdgeLabel.all) {
+            ops.findEdgesByStartId(userId, edgeLabel.value).collect { edge ->
+                emit(AbusePath(identifierVertexId = edge.endId, edgeLabel = edgeLabel))
+            }
+        }
+    }
+
+    /**
+     * Returns a cold [Flow] of detected referral loops — cycles among User vertices via REFERRED_BY edges.
+     *
+     * @param maxDepth maximum traversal depth when searching for cycles (default 6)
+     * @param maxCycles maximum number of cycles to return (default 100)
+     * @return cold [Flow] of [GraphCycle]s; empty if no loops exist
+     */
+    fun detectReferralLoops(maxDepth: Int = 6, maxCycles: Int = 100): Flow<GraphCycle> {
+        maxDepth.requirePositiveNumber("maxDepth")
+        maxCycles.requirePositiveNumber("maxCycles")
+        return ops.detectCycles(
+            CycleOptions(
+                vertexLabel = UserLabel.label,
+                edgeLabel   = ReferredByLabel.label,
+                maxDepth    = maxDepth,
+                maxCycles   = maxCycles,
+            )
+        )
+    }
+
+    /**
+     * Returns a cold [Flow] of users ranked by PageRank score descending.
+     *
+     * PageRank is computed over all graph vertices and edges; results are then filtered to the
+     * User label. Higher score indicates a user is more highly connected in the identity graph.
+     * Each emitted [SuspiciousUserScore.rank] is 1-based.
+     *
+     * @param limit maximum number of [SuspiciousUserScore] entries to emit (default 20, must be > 0)
+     * @return cold [Flow] sorted descending by score with 1-based [SuspiciousUserScore.rank]
+     */
+    fun rankSuspiciousUsers(limit: Int = 20): Flow<SuspiciousUserScore> {
+        limit.requirePositiveNumber("limit")
+        // vertexLabel = UserLabel.label ensures topK = limit applies directly to users.
+        return ops.pageRank(PageRankOptions(vertexLabel = UserLabel.label, topK = limit))
+            .withIndex()
+            .map { (index, pageRankScore) ->
+                SuspiciousUserScore(
+                    user  = pageRankScore.vertex,
+                    score = pageRankScore.score,
+                    rank  = index + 1,
+                )
+            }
+    }
+}

--- a/graph/abuser-detection/src/test/kotlin/io/bluetape4k/workshop/graph/abuser/AbstractAbuserDetectionSuspendTest.kt
+++ b/graph/abuser-detection/src/test/kotlin/io/bluetape4k/workshop/graph/abuser/AbstractAbuserDetectionSuspendTest.kt
@@ -1,0 +1,273 @@
+package io.bluetape4k.workshop.graph.abuser
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeEmpty
+import io.bluetape4k.assertions.shouldBeGreaterThan
+import io.bluetape4k.assertions.shouldBePositive
+import io.bluetape4k.assertions.shouldContain
+import io.bluetape4k.assertions.shouldHaveSize
+import io.bluetape4k.assertions.shouldNotBeEmpty
+import io.bluetape4k.assertions.shouldNotContain
+import io.bluetape4k.graph.model.GraphElementId
+import io.bluetape4k.graph.repository.GraphSuspendOperations
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.workshop.graph.abuser.model.SuspiciousUserScore
+import io.bluetape4k.workshop.graph.abuser.schema.DeviceLabel
+import io.bluetape4k.workshop.graph.abuser.schema.IpAddressLabel
+import io.bluetape4k.workshop.graph.abuser.schema.PaymentMethodLabel
+import io.bluetape4k.workshop.graph.abuser.schema.PhoneNumberLabel
+import io.bluetape4k.workshop.graph.abuser.schema.UserLabel
+import io.bluetape4k.workshop.graph.abuser.seed.AbuserDetectionSeed
+import io.bluetape4k.workshop.graph.abuser.seed.seedReferralLoop
+import io.bluetape4k.workshop.graph.abuser.seed.seedSharedIdentifiers
+import io.bluetape4k.workshop.graph.abuser.service.AbuserDetectionSuspendService
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+/**
+ * Abstract test suite for [AbuserDetectionSuspendService].
+ *
+ * Concrete subclasses supply [ops] and [service] backed by a specific graph backend.
+ * Each test runs against a clean graph — [cleanGraph] drops and re-initializes before every test.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+abstract class AbstractAbuserDetectionSuspendTest {
+
+    protected abstract val graphName: String
+    protected abstract val ops: GraphSuspendOperations
+    protected abstract val service: AbuserDetectionSuspendService
+
+    @BeforeEach
+    fun cleanGraph() = runSuspendIO {
+        ops.dropGraph(graphName)
+        service.initialize()
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Vertex mutator tests
+    // ─────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `addUser creates a new User vertex`() = runSuspendIO {
+        val user = service.addUser("user-1", "KR")
+
+        user.label shouldBeEqualTo UserLabel.label
+        user.properties[UserLabel.userId.name] shouldBeEqualTo "user-1"
+        user.properties[UserLabel.country.name] shouldBeEqualTo "KR"
+    }
+
+    @Test
+    fun `addUser returns existing vertex on second call (idempotent)`() = runSuspendIO {
+        val first = service.addUser("user-1", "KR")
+        val second = service.addUser("user-1", "KR")
+
+        first.id shouldBeEqualTo second.id
+    }
+
+    @Test
+    fun `addDevice creates a new Device vertex`() = runSuspendIO {
+        val device = service.addDevice("device-1", "android")
+
+        device.label shouldBeEqualTo DeviceLabel.label
+        device.properties[DeviceLabel.deviceId.name] shouldBeEqualTo "device-1"
+        device.properties[DeviceLabel.platform.name] shouldBeEqualTo "android"
+    }
+
+    @Test
+    fun `addIpAddress creates a new IpAddress vertex`() = runSuspendIO {
+        val ip = service.addIpAddress("10.0.0.1")
+
+        ip.label shouldBeEqualTo IpAddressLabel.label
+        ip.properties[IpAddressLabel.ip.name] shouldBeEqualTo "10.0.0.1"
+    }
+
+    @Test
+    fun `addPhoneNumber creates a PhoneNumber vertex`() = runSuspendIO {
+        val phone = service.addPhoneNumber("sha256-hashed-phone-value")
+
+        phone.label shouldBeEqualTo PhoneNumberLabel.label
+        phone.properties[PhoneNumberLabel.phone.name] shouldBeEqualTo "sha256-hashed-phone-value"
+    }
+
+    @Test
+    fun `addPaymentMethod creates a PaymentMethod vertex`() = runSuspendIO {
+        val payment = service.addPaymentMethod("tok_visa_4242")
+
+        payment.label shouldBeEqualTo PaymentMethodLabel.label
+        payment.properties[PaymentMethodLabel.paymentToken.name] shouldBeEqualTo "tok_visa_4242"
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // findAbuseCluster tests
+    // ─────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `findAbuseCluster returns cluster users for user sharing device`() = runSuspendIO {
+        val seed: AbuserDetectionSeed = seedSharedIdentifiers(service)
+
+        val cluster = service.findAbuseCluster(seed.user1.id)
+
+        cluster.users.shouldNotBeEmpty()
+        val clusterUserIds = cluster.users.map { it.id }
+        clusterUserIds shouldContain seed.user2.id
+        clusterUserIds shouldContain seed.user3.id
+    }
+
+    @Test
+    fun `findAbuseCluster cluster users excludes seed user`() = runSuspendIO {
+        val seed = seedSharedIdentifiers(service)
+
+        val cluster = service.findAbuseCluster(seed.user1.id)
+
+        val clusterUserIds = cluster.users.map { it.id }
+        clusterUserIds shouldNotContain seed.user1.id
+    }
+
+    @Test
+    fun `findAbuseCluster sharedIdentifiers contains the shared device`() = runSuspendIO {
+        val seed = seedSharedIdentifiers(service)
+
+        val cluster = service.findAbuseCluster(seed.user1.id)
+
+        cluster.sharedIdentifiers.shouldNotBeEmpty()
+        cluster.sharedIdentifiers.map { it.id } shouldContain seed.deviceA.id
+    }
+
+    @Test
+    fun `findAbuseCluster returns empty cluster for isolated user`() = runSuspendIO {
+        val seed = seedSharedIdentifiers(service)
+
+        val cluster = service.findAbuseCluster(seed.unrelatedUser.id)
+
+        cluster.users.shouldBeEmpty()
+    }
+
+    @Test
+    fun `findAbuseCluster returns empty cluster for unknown vertex ID`() = runSuspendIO {
+        val unknownId = GraphElementId("non-existent-vertex-id-9999")
+
+        val cluster = service.findAbuseCluster(unknownId)
+
+        cluster.users.shouldBeEmpty()
+        cluster.sharedIdentifiers.shouldBeEmpty()
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // explainSuspicion tests
+    // ─────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `explainSuspicion flow emits AbusePaths for connected user`() = runSuspendIO {
+        val seed = seedSharedIdentifiers(service)
+
+        val paths = service.explainSuspicion(seed.user1.id).toList()
+
+        // user1 has USES_DEVICE (deviceA) and USES_IP (ipA) edges
+        paths shouldHaveSize 2
+        val identifierIds = paths.map { it.identifierVertexId }
+        identifierIds shouldContain seed.deviceA.id
+        identifierIds shouldContain seed.ipA.id
+    }
+
+    @Test
+    fun `explainSuspicion flow does not emit cluster device for isolated user`() = runSuspendIO {
+        val seed = seedSharedIdentifiers(service)
+
+        val paths = service.explainSuspicion(seed.unrelatedUser.id).toList()
+
+        val identifierIds = paths.map { it.identifierVertexId }
+        identifierIds shouldNotContain seed.deviceA.id
+        identifierIds shouldNotContain seed.ipA.id
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // detectReferralLoops tests
+    // ─────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `detectReferralLoops flow emits detected cycles`() = runSuspendIO {
+        val seed = seedSharedIdentifiers(service)
+        seedReferralLoop(service, seed)
+
+        val cycles = service.detectReferralLoops().toList()
+
+        cycles.shouldNotBeEmpty()
+    }
+
+    @Test
+    fun `detectReferralLoops flow is empty when no cycles exist`() = runSuspendIO {
+        service.addUser("u-a", "KR")
+        service.addUser("u-b", "KR")
+
+        val cycles = service.detectReferralLoops().toList()
+
+        cycles.shouldBeEmpty()
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // rankSuspiciousUsers tests
+    // ─────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `rankSuspiciousUsers flow emits non-empty ordered scores`() = runSuspendIO {
+        val seed = seedSharedIdentifiers(service)
+        seedReferralLoop(service, seed)
+
+        val scores: List<SuspiciousUserScore> = service.rankSuspiciousUsers(limit = 10).toList()
+
+        scores.shouldNotBeEmpty()
+        scores.forEachIndexed { index, score ->
+            score.rank shouldBeEqualTo (index + 1)
+            score.score shouldBeGreaterThan 0.0
+            score.user.label shouldBeEqualTo UserLabel.label
+        }
+    }
+
+    @Test
+    fun `rankSuspiciousUsers respects limit`() = runSuspendIO {
+        val seed = seedSharedIdentifiers(service)
+        seedReferralLoop(service, seed)
+
+        val scores = service.rankSuspiciousUsers(limit = 2).toList()
+
+        scores shouldHaveSize 2
+        scores.first().rank shouldBeEqualTo 1
+        scores.last().rank shouldBeEqualTo 2
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Flow cancellation test (suspend-only)
+    // ─────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `rankSuspiciousUsers flow honours take(1) cancellation`() = runSuspendIO {
+        val seed = seedSharedIdentifiers(service)
+        seedReferralLoop(service, seed)
+
+        // onEach delay makes the flow slow so cancellation is meaningful;
+        // take(1) cancels the flow after the first emission
+        val first: List<SuspiciousUserScore> = service.rankSuspiciousUsers(limit = 10)
+            .onEach { delay(10) }
+            .take(1)
+            .toList()
+
+        first shouldHaveSize 1
+        first.first().rank shouldBeEqualTo 1
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // initialize idempotency test
+    // ─────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `initialize is idempotent - calling twice does not throw`() = runSuspendIO {
+        service.initialize()
+        service.initialize()
+        // no exception = success
+    }
+}

--- a/graph/abuser-detection/src/test/kotlin/io/bluetape4k/workshop/graph/abuser/AbstractAbuserDetectionTest.kt
+++ b/graph/abuser-detection/src/test/kotlin/io/bluetape4k/workshop/graph/abuser/AbstractAbuserDetectionTest.kt
@@ -1,0 +1,252 @@
+package io.bluetape4k.workshop.graph.abuser
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeEmpty
+import io.bluetape4k.assertions.shouldBeGreaterThan
+import io.bluetape4k.assertions.shouldBePositive
+import io.bluetape4k.assertions.shouldContain
+import io.bluetape4k.assertions.shouldHaveSize
+import io.bluetape4k.assertions.shouldNotBeEmpty
+import io.bluetape4k.assertions.shouldNotContain
+import io.bluetape4k.graph.model.GraphElementId
+import io.bluetape4k.graph.repository.GraphOperations
+import io.bluetape4k.workshop.graph.abuser.schema.DeviceLabel
+import io.bluetape4k.workshop.graph.abuser.schema.IpAddressLabel
+import io.bluetape4k.workshop.graph.abuser.schema.PaymentMethodLabel
+import io.bluetape4k.workshop.graph.abuser.schema.PhoneNumberLabel
+import io.bluetape4k.workshop.graph.abuser.schema.UserLabel
+import io.bluetape4k.workshop.graph.abuser.seed.AbuserDetectionSeed
+import io.bluetape4k.workshop.graph.abuser.seed.seedReferralLoop
+import io.bluetape4k.workshop.graph.abuser.seed.seedSharedIdentifiers
+import io.bluetape4k.workshop.graph.abuser.service.AbuserDetectionService
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+/**
+ * Abstract test suite for [AbuserDetectionService].
+ *
+ * Concrete subclasses supply [ops] and [service] backed by a specific graph backend.
+ * Each test runs against a clean graph — [cleanGraph] drops and re-initializes before every test.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+abstract class AbstractAbuserDetectionTest {
+
+    protected abstract val graphName: String
+    protected abstract val ops: GraphOperations
+    protected abstract val service: AbuserDetectionService
+
+    @BeforeEach
+    fun cleanGraph() {
+        ops.dropGraph(graphName)
+        service.initialize()
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Vertex mutator tests
+    // ─────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `addUser creates a new User vertex`() {
+        val user = service.addUser("user-1", "KR")
+
+        user.label shouldBeEqualTo UserLabel.label
+        user.properties[UserLabel.userId.name] shouldBeEqualTo "user-1"
+        user.properties[UserLabel.country.name] shouldBeEqualTo "KR"
+    }
+
+    @Test
+    fun `addUser returns existing vertex on second call (idempotent)`() {
+        val first = service.addUser("user-1", "KR")
+        val second = service.addUser("user-1", "KR")
+
+        first.id shouldBeEqualTo second.id
+    }
+
+    @Test
+    fun `addDevice creates a new Device vertex`() {
+        val device = service.addDevice("device-1", "android")
+
+        device.label shouldBeEqualTo DeviceLabel.label
+        device.properties[DeviceLabel.deviceId.name] shouldBeEqualTo "device-1"
+        device.properties[DeviceLabel.platform.name] shouldBeEqualTo "android"
+    }
+
+    @Test
+    fun `addIpAddress creates a new IpAddress vertex`() {
+        val ip = service.addIpAddress("10.0.0.1")
+
+        ip.label shouldBeEqualTo IpAddressLabel.label
+        ip.properties[IpAddressLabel.ip.name] shouldBeEqualTo "10.0.0.1"
+    }
+
+    @Test
+    fun `addPhoneNumber creates a PhoneNumber vertex`() {
+        val phone = service.addPhoneNumber("sha256-hashed-phone-value")
+
+        phone.label shouldBeEqualTo PhoneNumberLabel.label
+        phone.properties[PhoneNumberLabel.phone.name] shouldBeEqualTo "sha256-hashed-phone-value"
+    }
+
+    @Test
+    fun `addPaymentMethod creates a PaymentMethod vertex`() {
+        val payment = service.addPaymentMethod("tok_visa_4242")
+
+        payment.label shouldBeEqualTo PaymentMethodLabel.label
+        payment.properties[PaymentMethodLabel.paymentToken.name] shouldBeEqualTo "tok_visa_4242"
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // findAbuseCluster tests
+    // ─────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `findAbuseCluster returns cluster users for user sharing device`() {
+        val seed: AbuserDetectionSeed = seedSharedIdentifiers(service)
+
+        val cluster = service.findAbuseCluster(seed.user1.id)
+
+        cluster.users.shouldNotBeEmpty()
+        val clusterUserIds = cluster.users.map { it.id }
+        clusterUserIds shouldContain seed.user2.id
+        clusterUserIds shouldContain seed.user3.id
+    }
+
+    @Test
+    fun `findAbuseCluster cluster users excludes seed user`() {
+        val seed = seedSharedIdentifiers(service)
+
+        val cluster = service.findAbuseCluster(seed.user1.id)
+
+        val clusterUserIds = cluster.users.map { it.id }
+        clusterUserIds shouldNotContain seed.user1.id
+    }
+
+    @Test
+    fun `findAbuseCluster sharedIdentifiers contains the shared device`() {
+        val seed = seedSharedIdentifiers(service)
+
+        val cluster = service.findAbuseCluster(seed.user1.id)
+
+        cluster.sharedIdentifiers.shouldNotBeEmpty()
+        cluster.sharedIdentifiers.map { it.id } shouldContain seed.deviceA.id
+    }
+
+    @Test
+    fun `findAbuseCluster returns empty cluster for isolated user`() {
+        val seed = seedSharedIdentifiers(service)
+
+        val cluster = service.findAbuseCluster(seed.unrelatedUser.id)
+
+        // unrelatedUser shares no identifiers with the cluster users
+        cluster.users.shouldBeEmpty()
+    }
+
+    @Test
+    fun `findAbuseCluster returns empty cluster for unknown vertex ID`() {
+        val unknownId = GraphElementId("non-existent-vertex-id-9999")
+
+        val cluster = service.findAbuseCluster(unknownId)
+
+        cluster.users.shouldBeEmpty()
+        cluster.sharedIdentifiers.shouldBeEmpty()
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // explainSuspicion tests
+    // ─────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `explainSuspicion returns AbusePaths for connected user`() {
+        val seed = seedSharedIdentifiers(service)
+
+        val paths = service.explainSuspicion(seed.user1.id)
+
+        // user1 has USES_DEVICE (deviceA) and USES_IP (ipA) edges
+        paths shouldHaveSize 2
+        val identifierIds = paths.map { it.identifierVertexId }
+        identifierIds shouldContain seed.deviceA.id
+        identifierIds shouldContain seed.ipA.id
+    }
+
+    @Test
+    fun `explainSuspicion returns empty list for isolated user`() {
+        val seed = seedSharedIdentifiers(service)
+
+        val paths = service.explainSuspicion(seed.unrelatedUser.id)
+
+        // unrelatedUser has only deviceB — no shared identifiers with cluster users
+        // but explainSuspicion returns ALL outgoing identifier edges, so deviceB appears
+        // The test verifies no null/crash, and that no cluster device appears
+        val identifierIds = paths.map { it.identifierVertexId }
+        identifierIds shouldNotContain seed.deviceA.id
+        identifierIds shouldNotContain seed.ipA.id
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // detectReferralLoops tests
+    // ─────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `detectReferralLoops returns detected cycles in referral graph`() {
+        val seed = seedSharedIdentifiers(service)
+        seedReferralLoop(service, seed)
+
+        val cycles = service.detectReferralLoops()
+
+        cycles.shouldNotBeEmpty()
+    }
+
+    @Test
+    fun `detectReferralLoops returns empty list when no cycles exist`() {
+        // No referral links added
+        service.addUser("u-a", "KR")
+        service.addUser("u-b", "KR")
+
+        val cycles = service.detectReferralLoops()
+
+        cycles.shouldBeEmpty()
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // rankSuspiciousUsers tests
+    // ─────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `rankSuspiciousUsers returns non-empty list with valid sequential ranks`() {
+        val seed = seedSharedIdentifiers(service)
+        seedReferralLoop(service, seed)
+
+        val scores = service.rankSuspiciousUsers(limit = 10)
+
+        scores.shouldNotBeEmpty()
+        scores.forEachIndexed { index, score ->
+            score.rank shouldBeEqualTo (index + 1)
+            score.score shouldBeGreaterThan 0.0
+            score.user.label shouldBeEqualTo UserLabel.label
+        }
+    }
+
+    @Test
+    fun `rankSuspiciousUsers respects limit`() {
+        val seed = seedSharedIdentifiers(service)
+        seedReferralLoop(service, seed)
+
+        val scores = service.rankSuspiciousUsers(limit = 2)
+
+        scores shouldHaveSize 2
+        scores.first().rank shouldBeEqualTo 1
+        scores.last().rank shouldBeEqualTo 2
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // initialize idempotency test
+    // ─────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `initialize is idempotent - calling twice does not throw`() {
+        service.initialize()
+        service.initialize()
+        // no exception = success
+    }
+}

--- a/graph/abuser-detection/src/test/kotlin/io/bluetape4k/workshop/graph/abuser/AbuserDetectionSuspendTinkerGraphTest.kt
+++ b/graph/abuser-detection/src/test/kotlin/io/bluetape4k/workshop/graph/abuser/AbuserDetectionSuspendTinkerGraphTest.kt
@@ -1,0 +1,30 @@
+package io.bluetape4k.workshop.graph.abuser
+
+import io.bluetape4k.graph.repository.GraphSuspendOperations
+import io.bluetape4k.graph.tinkerpop.TinkerGraphSuspendOperations
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.workshop.graph.abuser.service.AbuserDetectionSuspendService
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.TestInstance
+
+/**
+ * [AbuserDetectionSuspendService] tests backed by TinkerGraph (in-memory, no Docker required).
+ *
+ * All 16 tests from [AbstractAbuserDetectionSuspendTest] run against an in-process
+ * TinkerGraphSuspendOperations instance. The graph is cleared and re-initialized before
+ * each test via the base [cleanGraph] setup.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class AbuserDetectionSuspendTinkerGraphTest : AbstractAbuserDetectionSuspendTest() {
+
+    companion object : KLoggingChannel()
+
+    override val graphName = "test_abuser_suspend"
+    override val ops: GraphSuspendOperations = TinkerGraphSuspendOperations()
+    override val service = AbuserDetectionSuspendService(ops, graphName)
+
+    @AfterAll
+    fun tearDown() {
+        ops.close()
+    }
+}

--- a/graph/abuser-detection/src/test/kotlin/io/bluetape4k/workshop/graph/abuser/AbuserDetectionTinkerGraphTest.kt
+++ b/graph/abuser-detection/src/test/kotlin/io/bluetape4k/workshop/graph/abuser/AbuserDetectionTinkerGraphTest.kt
@@ -1,0 +1,29 @@
+package io.bluetape4k.workshop.graph.abuser
+
+import io.bluetape4k.graph.repository.GraphOperations
+import io.bluetape4k.graph.tinkerpop.TinkerGraphOperations
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.workshop.graph.abuser.service.AbuserDetectionService
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.TestInstance
+
+/**
+ * [AbuserDetectionService] tests backed by TinkerGraph (in-memory, no Docker required).
+ *
+ * All 15 tests from [AbstractAbuserDetectionTest] run against an in-process TinkerGraph instance.
+ * The graph is cleared and re-initialized before each test via the base [cleanGraph] setup.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class AbuserDetectionTinkerGraphTest : AbstractAbuserDetectionTest() {
+
+    companion object : KLogging()
+
+    override val graphName = "test_abuser"
+    override val ops: GraphOperations = TinkerGraphOperations()
+    override val service = AbuserDetectionService(ops, graphName)
+
+    @AfterAll
+    fun tearDown() {
+        ops.close()
+    }
+}

--- a/graph/abuser-detection/src/test/kotlin/io/bluetape4k/workshop/graph/abuser/MemgraphAbuserDetectionSuspendTest.kt
+++ b/graph/abuser-detection/src/test/kotlin/io/bluetape4k/workshop/graph/abuser/MemgraphAbuserDetectionSuspendTest.kt
@@ -1,0 +1,49 @@
+package io.bluetape4k.workshop.graph.abuser
+
+import io.bluetape4k.graph.memgraph.MemgraphGraphSuspendOperations
+import io.bluetape4k.graph.repository.GraphSuspendOperations
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.logging.warn
+import io.bluetape4k.testcontainers.graphdb.MemgraphServer
+import io.bluetape4k.workshop.graph.abuser.service.AbuserDetectionSuspendService
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.TestInstance
+import org.neo4j.driver.AuthTokens
+import org.neo4j.driver.Driver
+import org.neo4j.driver.GraphDatabase
+
+/**
+ * [AbuserDetectionSuspendService] integration tests backed by a Memgraph Testcontainer.
+ *
+ * Requires Docker. Run with: `./gradlew :graph-abuser-detection:integrationTest`
+ * The default `:test` task excludes this class via `@Tag("integration")`.
+ */
+@Tag("integration")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class MemgraphAbuserDetectionSuspendTest : AbstractAbuserDetectionSuspendTest() {
+
+    companion object : KLoggingChannel() {
+        private val memgraph = MemgraphServer.Launcher.memgraph
+    }
+
+    override val graphName = "memgraph_suspend"
+
+    private val driver: Driver by lazy {
+        GraphDatabase.driver(memgraph.boltUrl, AuthTokens.none())
+    }
+
+    override val ops: GraphSuspendOperations by lazy {
+        MemgraphGraphSuspendOperations(driver)
+    }
+
+    override val service by lazy {
+        AbuserDetectionSuspendService(ops, graphName)
+    }
+
+    @AfterAll
+    fun tearDown() {
+        runCatching { driver.close() }
+            .onFailure { log.warn(it) { "Driver close failed during tearDown — possible resource leak" } }
+    }
+}

--- a/graph/abuser-detection/src/test/kotlin/io/bluetape4k/workshop/graph/abuser/MemgraphAbuserDetectionTest.kt
+++ b/graph/abuser-detection/src/test/kotlin/io/bluetape4k/workshop/graph/abuser/MemgraphAbuserDetectionTest.kt
@@ -1,0 +1,49 @@
+package io.bluetape4k.workshop.graph.abuser
+
+import io.bluetape4k.graph.memgraph.MemgraphGraphOperations
+import io.bluetape4k.graph.repository.GraphOperations
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.warn
+import io.bluetape4k.testcontainers.graphdb.MemgraphServer
+import io.bluetape4k.workshop.graph.abuser.service.AbuserDetectionService
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.TestInstance
+import org.neo4j.driver.AuthTokens
+import org.neo4j.driver.Driver
+import org.neo4j.driver.GraphDatabase
+
+/**
+ * [AbuserDetectionService] integration tests backed by a Memgraph Testcontainer.
+ *
+ * Requires Docker. Run with: `./gradlew :graph-abuser-detection:integrationTest`
+ * The default `:test` task excludes this class via `@Tag("integration")`.
+ */
+@Tag("integration")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class MemgraphAbuserDetectionTest : AbstractAbuserDetectionTest() {
+
+    companion object : KLogging() {
+        private val memgraph = MemgraphServer.Launcher.memgraph
+    }
+
+    override val graphName = "memgraph"
+
+    private val driver: Driver by lazy {
+        GraphDatabase.driver(memgraph.boltUrl, AuthTokens.none())
+    }
+
+    override val ops: GraphOperations by lazy {
+        MemgraphGraphOperations(driver)
+    }
+
+    override val service by lazy {
+        AbuserDetectionService(ops, graphName)
+    }
+
+    @AfterAll
+    fun tearDown() {
+        runCatching { driver.close() }
+            .onFailure { log.warn(it) { "Driver close failed during tearDown — possible resource leak" } }
+    }
+}

--- a/graph/abuser-detection/src/test/kotlin/io/bluetape4k/workshop/graph/abuser/Neo4jAbuserDetectionSuspendTest.kt
+++ b/graph/abuser-detection/src/test/kotlin/io/bluetape4k/workshop/graph/abuser/Neo4jAbuserDetectionSuspendTest.kt
@@ -1,0 +1,48 @@
+package io.bluetape4k.workshop.graph.abuser
+
+import io.bluetape4k.graph.neo4j.Neo4jGraphSuspendOperations
+import io.bluetape4k.graph.repository.GraphSuspendOperations
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.logging.warn
+import io.bluetape4k.testcontainers.graphdb.Neo4jServer
+import io.bluetape4k.workshop.graph.abuser.service.AbuserDetectionSuspendService
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.TestInstance
+import org.neo4j.driver.Driver
+import org.neo4j.driver.GraphDatabase
+
+/**
+ * [AbuserDetectionSuspendService] integration tests backed by a Neo4j Testcontainer.
+ *
+ * Requires Docker. Run with: `./gradlew :graph-abuser-detection:integrationTest`
+ * The default `:test` task excludes this class via `@Tag("integration")`.
+ */
+@Tag("integration")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class Neo4jAbuserDetectionSuspendTest : AbstractAbuserDetectionSuspendTest() {
+
+    companion object : KLoggingChannel() {
+        private val neo4j = Neo4jServer.Launcher.neo4j
+    }
+
+    override val graphName = "neo4j_suspend"
+
+    private val driver: Driver by lazy {
+        GraphDatabase.driver(neo4j.url)
+    }
+
+    override val ops: GraphSuspendOperations by lazy {
+        Neo4jGraphSuspendOperations(driver)
+    }
+
+    override val service by lazy {
+        AbuserDetectionSuspendService(ops, graphName)
+    }
+
+    @AfterAll
+    fun tearDown() {
+        runCatching { driver.close() }
+            .onFailure { log.warn(it) { "Driver close failed during tearDown — possible resource leak" } }
+    }
+}

--- a/graph/abuser-detection/src/test/kotlin/io/bluetape4k/workshop/graph/abuser/Neo4jAbuserDetectionTest.kt
+++ b/graph/abuser-detection/src/test/kotlin/io/bluetape4k/workshop/graph/abuser/Neo4jAbuserDetectionTest.kt
@@ -1,0 +1,48 @@
+package io.bluetape4k.workshop.graph.abuser
+
+import io.bluetape4k.graph.neo4j.Neo4jGraphOperations
+import io.bluetape4k.graph.repository.GraphOperations
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.warn
+import io.bluetape4k.testcontainers.graphdb.Neo4jServer
+import io.bluetape4k.workshop.graph.abuser.service.AbuserDetectionService
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.TestInstance
+import org.neo4j.driver.Driver
+import org.neo4j.driver.GraphDatabase
+
+/**
+ * [AbuserDetectionService] integration tests backed by a Neo4j Testcontainer.
+ *
+ * Requires Docker. Run with: `./gradlew :graph-abuser-detection:integrationTest`
+ * The default `:test` task excludes this class via `@Tag("integration")`.
+ */
+@Tag("integration")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class Neo4jAbuserDetectionTest : AbstractAbuserDetectionTest() {
+
+    companion object : KLogging() {
+        private val neo4j = Neo4jServer.Launcher.neo4j
+    }
+
+    override val graphName = "neo4j"
+
+    private val driver: Driver by lazy {
+        GraphDatabase.driver(neo4j.url)
+    }
+
+    override val ops: GraphOperations by lazy {
+        Neo4jGraphOperations(driver)
+    }
+
+    override val service by lazy {
+        AbuserDetectionService(ops, graphName)
+    }
+
+    @AfterAll
+    fun tearDown() {
+        runCatching { driver.close() }
+            .onFailure { log.warn(it) { "Driver close failed during tearDown — possible resource leak" } }
+    }
+}

--- a/graph/abuser-detection/src/test/kotlin/io/bluetape4k/workshop/graph/abuser/seed/AbuserDetectionSeed.kt
+++ b/graph/abuser-detection/src/test/kotlin/io/bluetape4k/workshop/graph/abuser/seed/AbuserDetectionSeed.kt
@@ -1,0 +1,114 @@
+package io.bluetape4k.workshop.graph.abuser.seed
+
+import io.bluetape4k.graph.model.GraphVertex
+import io.bluetape4k.workshop.graph.abuser.service.AbuserDetectionService
+import io.bluetape4k.workshop.graph.abuser.service.AbuserDetectionSuspendService
+
+private const val SEED_TIMESTAMP = "2026-01-01T00:00:00Z"
+
+/**
+ * Snapshot of all vertices created by [seedSharedIdentifiers].
+ *
+ * @property user1 first cluster member (shares deviceA and ipA with user2)
+ * @property user2 second cluster member (shares deviceA and ipA with user1; shares deviceA with user3)
+ * @property user3 third cluster member (shares only deviceA with user1 and user2)
+ * @property deviceA shared device — connects user1, user2, and user3
+ * @property ipA shared IP address — connects user1 and user2 only
+ * @property unrelatedUser isolated user with no shared identifiers
+ * @property deviceB private device belonging only to unrelatedUser
+ */
+data class AbuserDetectionSeed(
+    val user1: GraphVertex,
+    val user2: GraphVertex,
+    val user3: GraphVertex,
+    val deviceA: GraphVertex,
+    val ipA: GraphVertex,
+    val unrelatedUser: GraphVertex,
+    val deviceB: GraphVertex,
+)
+
+// ─────────────────────────────────────────────────────────────────────────
+// Blocking helpers
+// ─────────────────────────────────────────────────────────────────────────
+
+/**
+ * Creates a cluster of users sharing device/IP identifiers plus one isolated user.
+ *
+ * Graph structure:
+ * ```
+ * user1 ──USES_DEVICE──► deviceA ◄──USES_DEVICE── user2
+ * user1 ──USES_IP──────► ipA     ◄──USES_IP─────  user2
+ * user3 ──USES_DEVICE──► deviceA
+ * unrelatedUser ──USES_DEVICE──► deviceB   (no shared identifiers)
+ * ```
+ */
+fun seedSharedIdentifiers(service: AbuserDetectionService): AbuserDetectionSeed {
+    val user1 = service.addUser("user-1", "KR")
+    val user2 = service.addUser("user-2", "KR")
+    val user3 = service.addUser("user-3", "US")
+    val unrelatedUser = service.addUser("unrelated-user", "JP")
+
+    val deviceA = service.addDevice("device-A", "android")
+    val ipA = service.addIpAddress("192.168.1.1")
+    val deviceB = service.addDevice("device-B", "ios")
+
+    // Cluster edges
+    service.linkDevice(user1.id, deviceA.id, SEED_TIMESTAMP)
+    service.linkDevice(user2.id, deviceA.id, SEED_TIMESTAMP)
+    service.linkDevice(user3.id, deviceA.id, SEED_TIMESTAMP)
+    service.linkIp(user1.id, ipA.id, SEED_TIMESTAMP)
+    service.linkIp(user2.id, ipA.id, SEED_TIMESTAMP)
+
+    // Isolated user edge (private device — no sharing)
+    service.linkDevice(unrelatedUser.id, deviceB.id, SEED_TIMESTAMP)
+
+    return AbuserDetectionSeed(user1, user2, user3, deviceA, ipA, unrelatedUser, deviceB)
+}
+
+/**
+ * Adds a REFERRED_BY cycle on top of an existing [seed]: user1 → user2 → user3 → user1.
+ */
+fun seedReferralLoop(service: AbuserDetectionService, seed: AbuserDetectionSeed) {
+    service.linkReferral(seed.user1.id, seed.user2.id, SEED_TIMESTAMP)
+    service.linkReferral(seed.user2.id, seed.user3.id, SEED_TIMESTAMP)
+    service.linkReferral(seed.user3.id, seed.user1.id, SEED_TIMESTAMP)
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Coroutine helpers
+// ─────────────────────────────────────────────────────────────────────────
+
+/**
+ * Suspend variant of [seedSharedIdentifiers].
+ */
+suspend fun seedSharedIdentifiers(service: AbuserDetectionSuspendService): AbuserDetectionSeed {
+    val user1 = service.addUser("user-1", "KR")
+    val user2 = service.addUser("user-2", "KR")
+    val user3 = service.addUser("user-3", "US")
+    val unrelatedUser = service.addUser("unrelated-user", "JP")
+
+    val deviceA = service.addDevice("device-A", "android")
+    val ipA = service.addIpAddress("192.168.1.1")
+    val deviceB = service.addDevice("device-B", "ios")
+
+    // Cluster edges
+    service.linkDevice(user1.id, deviceA.id, SEED_TIMESTAMP)
+    service.linkDevice(user2.id, deviceA.id, SEED_TIMESTAMP)
+    service.linkDevice(user3.id, deviceA.id, SEED_TIMESTAMP)
+    service.linkIp(user1.id, ipA.id, SEED_TIMESTAMP)
+    service.linkIp(user2.id, ipA.id, SEED_TIMESTAMP)
+
+    // Isolated user edge
+    service.linkDevice(unrelatedUser.id, deviceB.id, SEED_TIMESTAMP)
+
+    return AbuserDetectionSeed(user1, user2, user3, deviceA, ipA, unrelatedUser, deviceB)
+}
+
+/**
+ * Suspend variant of [seedReferralLoop].
+ */
+suspend fun seedReferralLoop(service: AbuserDetectionSuspendService, seed: AbuserDetectionSeed) {
+    service.linkReferral(seed.user1.id, seed.user2.id, SEED_TIMESTAMP)
+    service.linkReferral(seed.user2.id, seed.user3.id, SEED_TIMESTAMP)
+    service.linkReferral(seed.user3.id, seed.user1.id, SEED_TIMESTAMP)
+}

--- a/graph/abuser-detection/src/test/resources/junit-platform.properties
+++ b/graph/abuser-detection/src/test/resources/junit-platform.properties
@@ -1,0 +1,6 @@
+junit.jupiter.extensions.autodetection.enabled=true
+junit.jupiter.testinstance.lifecycle.default=per_class
+
+junit.jupiter.execution.parallel.enabled=false
+junit.jupiter.execution.parallel.mode.default=same_thread
+junit.jupiter.execution.parallel.mode.classes.default=concurrent

--- a/graph/abuser-detection/src/test/resources/logback-test.xml
+++ b/graph/abuser-detection/src/test/resources/logback-test.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
+        <immediateFlush>true</immediateFlush>
+        <encoder>
+            <!-- @formatter:off -->
+            <pattern>%d{HH:mm:ss.SSS} %highlight(%-5level) [%blue(%36.36t)] %yellow(%logger{36}):%line: %msg%n%ex</pattern>
+            <!-- @formatter:on -->
+            <charset>UTF-8</charset>
+        </encoder>
+    </appender>
+
+    <logger name="io.bluetape4k.workshop.graph.abuser" level="DEBUG"/>
+
+    <root level="INFO">
+        <appender-ref ref="Console"/>
+    </root>
+
+</configuration>

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -24,6 +24,7 @@ includeModules("exposed", false, true)
 includeModules("gateway", false, false)
 includeModules("gatling", false, true)
 includeModules("graalvm", false, false)
+includeModules("graph", false, true)        // graph/abuser-detection — Issue #12
 includeModules("image-processing", false, true)
 includeModules("io", false, false)
 includeModules("json", false, false)


### PR DESCRIPTION
## Summary

Implements the `graph/abuser-detection` module as specified in Epic #9 / Issue #12.

Builds an **identity graph** that links user accounts to shared identifiers (devices, IP addresses,
hashed phone numbers, payment tokens) and applies graph algorithms to surface fraud clusters,
suspicious paths, referral loops, and PageRank risk scores.

## Changes

### New module: `graph/abuser-detection`

**Domain models**
- `AbuseCluster` — co-connected users + shared identifier vertices
- `AbusePath` — single user→identifier edge path
- `IdentifierEdgeLabel` — typed enum of four identifier edge types
- `SuspiciousUserScore` — PageRank result for one user
- All implement `java.io.Serializable` with `serialVersionUID`

**Schema**
- Vertices: `User`, `Device`, `IpAddress`, `PhoneNumber`, `PaymentMethod`
- Edges: `USES_DEVICE`, `USES_IP`, `HAS_PHONE`, `USES_PAYMENT`, `REFERRED_BY`

**Services**
- `AbuserDetectionService` — blocking, backed by `GraphOperations`
- `AbuserDetectionSuspendService` — coroutine/Flow, backed by `GraphSuspendOperations`
- Both: `findAbuseCluster`, `explainSuspicion`, `detectReferralLoops`, `rankSuspiciousUsers`

**Tests**
- TinkerGraph unit tests (37 tests, no Docker, default `:test` task)
- Neo4j integration tests (`@Tag("integration")`, `:integrationTest` task)
- Memgraph integration tests (`@Tag("integration")`, `:integrationTest` task)

### Modified files
- `settings.gradle.kts` — register `:graph-abuser-detection` module
- `build.gradle.kts` — add `:graph-abuser-detection` to build
- `gradle/libs.versions.toml` — add `testcontainers-neo4j` alias

## Test Results

```
./gradlew :graph-abuser-detection:test
BUILD SUCCESSFUL

AbuserDetectionTinkerGraphTest:        18 tests, 0 failures
AbuserDetectionSuspendTinkerGraphTest: 19 tests, 0 failures
Total: 37 passing, 0 failed
```

Integration tests require Docker:
```bash
./gradlew :graph-abuser-detection:integrationTest
```

## 6-R Code Review Findings Applied

| Severity | Issue | Fix |
|---|---|---|
| P1/HIGH | Test `rankSuspiciousUsers respects limit` did not assert actual size | `shouldHaveSize 2` + rank checks added |
| P1/HIGH | `runCatching { driver.close() }` silently swallowed in tearDown | `.onFailure { log.warn(it) { ... } }` added |
| P2/MEDIUM | `detectReferralLoops` missing parameter validation | `maxDepth/maxCycles.requirePositiveNumber()` added |
| P2/MEDIUM | Unknown identifier label skip unlogged | `log.warn { "unknown label..." }` added |
| P3/LOW | Missing seed vertex logged at DEBUG | Promoted to WARN |
| P3/LOW | Mutable `var rank` in Flow | Replaced with `withIndex().map {}` |

## Security Notes

- Phone numbers: only SHA-256 hex hashes stored (E.164 format)
- Payment methods: only PCI-safe processor tokens stored (no PAN/CVV)

Closes #12