### PR TITLE
feat: add leader-zookeeper workshop module (Issue #10 PR-B)

### DIFF
--- a/docs/lessons/2026-05-25-leader-zookeeper.md
+++ b/docs/lessons/2026-05-25-leader-zookeeper.md
@@ -187,10 +187,44 @@ ZooKeeperLeaderGroupElector(curator, "/test/group", options)  // 컴파일 오�
 
 ---
 
-## 8. 검증 결과
+## 8. Step 6-R 코드 리뷰 발견 사항
+
+### 8-1. `kotlin.test.assertFailsWith` 는 CLAUDE.md에서 금지
+
+- **문제**: `LeaderZookeeperPropertiesValidationTest`가 `import kotlin.test.assertFailsWith` 를 사용
+- **수정**: `import io.bluetape4k.assertions.assertFailsWith` 로 대체
+- **규칙**: CLAUDE.md 명시 금지 목록: "Do not use JUnit assertThrows, invoking { } shouldThrow, or kotlin.test.assertFailsWith in new tests"
+
+### 8-2. `runTest {}` 표현식 바디도 `: Unit` 추가 권장
+
+`runTest` 자체가 `Unit`을 반환하므로 기술적으로는 불필요하지만,
+`runBlocking + assertion` 패턴과의 일관성을 위해 `: Unit` 명시 권장.
+
+규칙:
+- `fun test() = runBlocking { ... }` → **반드시** `: Unit`
+- `fun test() = runTest { ... }` → `runTest`가 `Unit` 반환이므로 선택적, 일관성을 위해 추가 권장
+
+### 8-3. 서비스 레이어 행동 테스트 부재
+
+컨텍스트 테스트(T0)는 Spring 빈 와이어링만 확인. `runLeaderWork()`, `inspectState()` 등 실제
+서비스 메서드의 반환값/부수효과 테스트가 없었음.
+
+- **수정**: `LeaderServiceBehaviorTest` 추가 (4개 테스트: BlockingLeaderService 2개, GroupLeaderService 2개)
+- **패턴**: AbstractLeaderZookeeperTest의 공유 `curator` 를 사용하여 Spring 컨텍스트 없이 서비스 직접 생성
+
+### 8-4. 숫자 타임아웃 필드 검증 누락
+
+`ZooKeeperConfig` 의 `sessionTimeoutMs`, `connectionTimeoutMs`, `blockUntilConnectedSeconds` 가
+음수 또는 0이어도 통과됨.
+
+- **수정**: `ZooKeeperConfig.init {}` 에 `requirePositiveNumber` 추가
+
+---
+
+## 9. 최종 검증 결과
 
 - **빌드**: `./gradlew :leader-leader-zookeeper:compileKotlin` → BUILD SUCCESSFUL
-- **테스트**: `./gradlew :leader-leader-zookeeper:test --rerun-tasks` → **18 tests, 0 failures**
+- **테스트**: `./gradlew :leader-leader-zookeeper:test --rerun-tasks` → **22 tests, 0 failures**
 
 | 테스트 | 결과 |
 |--------|------|
@@ -204,4 +238,5 @@ ZooKeeperLeaderGroupElector(curator, "/test/group", options)  // 컴파일 오�
 | T7 R16AutoExtendIgnoredTest | ✅ 1 pass |
 | T8 SessionLossFailoverTest | ✅ 1 pass |
 | T9 LeaderZookeeperPropertiesValidationTest | ✅ 3 pass |
-| **합계** | **18 pass / 0 fail** |
+| LeaderServiceBehaviorTest | ✅ 4 pass (신규) |
+| **합계** | **22 pass / 0 fail** |

--- a/docs/lessons/2026-05-25-leader-zookeeper.md
+++ b/docs/lessons/2026-05-25-leader-zookeeper.md
@@ -1,0 +1,207 @@
+# leader-zookeeper 워크숍 — 교훈 및 결정 기록
+
+**날짜**: 2026-05-25  
+**이슈**: #10 bluetape4k-leader 예제 제작 (PR-B: leader-zookeeper 신규 모듈)  
+**브랜치**: `feat/leader-zookeeper`  
+**모듈**: `:leader-leader-zookeeper`
+
+---
+
+## 1. R16 — ZooKeeper는 TTL이 없다
+
+### 근본 원인
+
+Redis 기반 `LettuceLeaderElector`는 `SET NX EX`로 TTL을 설정하여 `leaseTime`/`autoExtend`가 의미있다.
+ZooKeeper 기반 elector는 **세션 기반 에페메랄 znode**를 사용하기 때문에 TTL이 존재하지 않는다.
+
+### 결정
+
+- `LeaderZookeeperProperties`에 `leaseTime`/`autoExtend` 필드를 **의도적으로 포함하지 않음**
+- `LeaderElectionOptions.autoExtend = true` 설정 시 라이브러리 내부에서 WARN 로그 출력 후 무시됨
+- T7 테스트(`R16AutoExtendIgnoredTest`)로 이 계약을 명시적으로 검증
+
+### 향후 적용
+
+ZooKeeper 기반 elector 사용 시 Redis 패턴의 `leaseTime`/`autoExtend` 설정을 그대로 복사하지 말 것.
+세션 만료 기반 페일오버를 위해 `sessionTimeoutMs` 를 적절히 튜닝할 것.
+
+---
+
+## 2. SuspendedJobTester — rounds × blockCount = totalUnits
+
+### 근본 원인
+
+`SuspendedJobTester.workers(N).rounds(R)` 의 실제 총 실행 횟수는
+`totalUnits = rounds × blockCount` 이다 (workers 수가 아님!).
+
+- `workers(8).rounds(1).add { ... }` → totalUnits = **1** (8이 아님!)
+- 8개 worker가 모두 시작하지만, 첫 번째 worker만 workUnit 0을 가져가고 나머지는 즉시 break
+
+### 증상
+
+- T3 `SuspendSingleLeaderTest` 2번째 테스트 (`peakConcurrent never exceeds 1`):
+  - `executed.get() = 1 shouldBeGreaterThan 3` → **AssertionFailedError**
+- T5 `SuspendGroupLeaderTest`:
+  - 1개 worker만 진입 → `enteredLatch(2)` 미달 → `releaseLatch.await(3s)` 타임아웃 → **IllegalStateException**
+
+### 수정
+
+| 테스트 | 변경 전 | 변경 후 | 이유 |
+|--------|--------|--------|------|
+| T3 (SuspendSingleLeaderTest, 2nd) | `.rounds(1)` | `.rounds(8)` | totalUnits=8, 8개 worker 각 1번 실행 |
+| T5 (SuspendGroupLeaderTest) | `.rounds(1)` | `.rounds(MAX_LEADERS)` = `.rounds(2)` | totalUnits=2, 2개 worker 동시 진입 |
+
+### 규칙
+
+`SuspendedJobTester`의 동작 공식:
+```
+totalUnits = rounds × blockCount
+```
+동시에 실행할 작업 수 = workers 수와 rounds를 모두 고려하여 `totalUnits >= 원하는_동시_실행_수` 가 되도록 설정.
+
+---
+
+## 3. @Test 메서드의 Unit 반환 타입
+
+### 근본 원인
+
+`fun test() = runBlocking { ... expr ... }` 형식에서 마지막 `expr` 이 `Unit` 이 아닌 값을 반환하면
+(예: `shouldBeEqualTo` 가 receiver를 반환하는 경우) 테스트 메서드 자체가 비-Unit 타입이 된다.
+
+JUnit 5는 `@Test` 메서드가 값을 반환하는 경우 **WARNING 로그와 함께 테스트를 실행하지 않는다**.
+
+```
+[WARNING] @Test method '...' must not return a value. It will not be executed.
+```
+
+이 경고는 BUILD SUCCESSFUL로 마스킹되어 테스트가 통과한 것처럼 보일 수 있다.
+
+### 수정
+
+표현식 바디(expression body)에 `: Unit` 반환 타입 어노테이션 추가:
+```kotlin
+// Before (silently excluded!)
+@Test
+fun `test`() = runBlocking { ... shouldBeEqualTo expected }
+
+// After (runs correctly)
+@Test
+fun `test`(): Unit = runBlocking { ... shouldBeEqualTo expected }
+```
+
+### 규칙
+
+`fun test() = runBlocking { ... }` 패턴에서 마지막 표현식이 assertion (특히 receiver를 반환하는
+`shouldBeEqualTo`, `shouldBeGreaterThan` 등)인 경우 반드시 `: Unit` 추가.
+
+---
+
+## 4. T8 세션 소실 테스트 — 컨테이너 재시작 대신 클라이언트 세션 닫기
+
+### 근본 원인
+
+`ZooKeeperServer(reuse = true)` (기본값)로 생성된 컨테이너를 `stop()`/`start()` 하면,
+**포트가 재매핑**되어 기존 Curator 클라이언트가 구 포트를 계속 사용한다.
+
+### 결정
+
+컨테이너를 재시작하는 대신 **클라이언트 측 세션을 직접 닫는** 방식 채택:
+```kotlin
+clientA.zookeeperClient.zooKeeper.close()
+// Curator가 세션 소실을 감지하고 새 세션으로 재연결
+```
+
+이 방식은 ZooKeeper 클러스터에서 프로세스 크래시를 시뮬레이션하는 결정론적이고 안정적인 방법이다.
+
+### 향후 적용
+
+ZooKeeper/Curator 기반 테스트에서 세션 소실을 시뮬레이션할 때는
+컨테이너 재시작 대신 `zookeeperClient.zooKeeper.close()` 를 사용할 것.
+
+---
+
+## 5. ConnectionStateListener는 start() 이전에 등록
+
+### 근본 원인
+
+`CuratorFramework.start()` 이후에 `ConnectionStateListener`를 등록하면
+초기 `CONNECTED` 상태 변경 이벤트를 놓칠 수 있다.
+
+### 결정
+
+리스너를 `start()` 이전에 등록:
+```kotlin
+client.connectionStateListenable.addListener(listener)
+client.start()
+check(client.blockUntilConnected(timeoutSec, TimeUnit.SECONDS)) { ... }
+```
+
+---
+
+## 6. T7 ListAppender — additivity="true" 필요
+
+### 근본 원인
+
+T7 테스트는 `io.bluetape4k.leader.zookeeper` 로거에 `ListAppender`를 추가한다.
+`logback-test.xml`에서 이 로거의 `additivity="false"` 로 설정된 경우,
+`ListAppender`를 다른 로거 계층(예: 루트 로거)에 추가해도 이벤트가 전달되지 않는다.
+
+### 수정
+
+`logback-test.xml`에서 `io.bluetape4k.leader.zookeeper` 로거의 `additivity="true"` 설정을 유지:
+```xml
+<logger name="io.bluetape4k.leader.zookeeper" level="DEBUG" additivity="true"/>
+```
+
+그리고 `@AfterEach` 에서 `detachAppender(appender)` 호출로 누수 방지:
+```kotlin
+@AfterEach fun teardownLogCapture() {
+    (LoggerFactory.getLogger("io.bluetape4k.leader.zookeeper") as Logger).detachAppender(appender)
+    appender.stop()
+}
+```
+
+---
+
+## 7. ZooKeeperLeaderGroupElector 생성자 인수 순서
+
+### 근본 원인
+
+컴파일러는 `(client, basePath, options)` 바이트코드 순서로 생성자를 생성하지만,
+라이브러리의 실제 파라미터명은 `options` (not `groupOptions`)이다.
+
+### 결정
+
+**명명된 인수(named arguments)를 항상 사용**:
+```kotlin
+// ✅ 명명된 인수 (올바름)
+ZooKeeperLeaderGroupElector(
+    client = curator,
+    options = LeaderGroupElectionOptions(maxLeaders = 2, waitTime = 500.milliseconds),
+    basePath = "/test/group"
+)
+
+// ❌ 위치 인수 (순서 오류 위험)
+ZooKeeperLeaderGroupElector(curator, "/test/group", options)  // 컴파일 오류 가능
+```
+
+---
+
+## 8. 검증 결과
+
+- **빌드**: `./gradlew :leader-leader-zookeeper:compileKotlin` → BUILD SUCCESSFUL
+- **테스트**: `./gradlew :leader-leader-zookeeper:test --rerun-tasks` → **18 tests, 0 failures**
+
+| 테스트 | 결과 |
+|--------|------|
+| T0 LeaderZookeeperContextTest | ✅ 1 pass |
+| T1 BlockingSingleLeaderTest | ✅ 3 pass |
+| T2 ConcurrentBlockingLeaderTest | ✅ 1 pass |
+| T3 SuspendSingleLeaderTest | ✅ 2 pass |
+| T4 GroupLeaderTest | ✅ 1 pass |
+| T5 SuspendGroupLeaderTest | ✅ 1 pass |
+| T6 ExtensionFunctionTest | ✅ 4 pass |
+| T7 R16AutoExtendIgnoredTest | ✅ 1 pass |
+| T8 SessionLossFailoverTest | ✅ 1 pass |
+| T9 LeaderZookeeperPropertiesValidationTest | ✅ 3 pass |
+| **합계** | **18 pass / 0 fail** |

--- a/docs/superpowers/plans/2026-05-25-leader-zookeeper-plan.md
+++ b/docs/superpowers/plans/2026-05-25-leader-zookeeper-plan.md
@@ -171,7 +171,15 @@ Apache Curator 기반 `bluetape4k-leader-zookeeper:0.2.1` 라이브러리를 워
     }
     ```
 - **English KDoc**: CancellationException 재throw 정책, `runBlocking` 사용 위치 (스케줄러 경계만)
-- **검증**: 컴파일 + T3 통과
+- **검증**: 컴파일 + T3 통과 + **CancellationException rethrow 단위 테스트 (H6)**:
+  ```kotlin
+  @Test fun `runScheduled rethrows CancellationException`() {
+      val service = SuspendLeaderZkService(mockk { coEvery { runIfLeader(any()) { any() } } throws CancellationException("test") })
+      assertFailsWith<CancellationException> { service.runScheduled() }
+  }
+  ```
+  단위 테스트는 Spring 컨텍스트 불필요 — MockK로 `SuspendLeaderElector` stub. `SuspendLeaderZkService`의 `runScheduled()` 직접 호출 → `CancellationException` 전파 확인.
+  동일 패턴을 `SuspendGroupLeaderService`에도 적용 (T-SVC-4).
 - **의존**: T-CFG-1
 
 #### T-SVC-3: GroupLeaderService — complexity: medium
@@ -196,7 +204,7 @@ Apache Curator 기반 `bluetape4k-leader-zookeeper:0.2.1` 라이브러리를 워
   - `suspend fun runLeaderWork(lockName): String?`
   - `@Scheduled` wrapper — **CancellationException 재throw 포함** (SuspendLeaderZkService와 동일 패턴)
 - **English KDoc**: SuspendLeaderZkService 패턴 cross-link
-- **검증**: 컴파일 + T5 통과
+- **검증**: 컴파일 + T5 통과 + CancellationException rethrow 단위 테스트 (T-SVC-2와 동일 패턴, `SuspendGroupLeaderElector` stub 사용)
 - **의존**: T-CFG-1
 
 #### T-RES-1: application.yml — complexity: low

--- a/docs/superpowers/plans/2026-05-25-leader-zookeeper-plan.md
+++ b/docs/superpowers/plans/2026-05-25-leader-zookeeper-plan.md
@@ -1,0 +1,531 @@
+# leader/leader-zookeeper 워크숍 모듈 구현 플랜
+
+> 작성일: 2026-05-25  
+> 작업 브랜치: feat/leader-zookeeper  
+> 관련 이슈: #10 (bluetape4k-leader 예제 제작 Epic) — PR-B  
+> 관련 스펙: `docs/superpowers/specs/2026-05-25-leader-zookeeper-design.md`
+
+---
+
+## 1. 목표 및 범위
+
+Apache Curator 기반 `bluetape4k-leader-zookeeper:0.2.1` 라이브러리를 워크숍에 도입하는
+신규 모듈 `leader/leader-zookeeper/`를 처음부터 구현한다. 기존 `leader/leader-election/`
+(Redis/Lettuce) 모듈의 Spring Boot 4 컨벤션을 따르되, ZooKeeper 고유의 R16 계약
+(세션 기반 ephemeral node, TTL 없음)을 명시적으로 시연한다.
+
+### 산출물
+
+1. `gradle/libs.versions.toml` — `bluetape4k-leader-zookeeper` alias 1개 추가 (버전 핀 없음, BOM 관리)
+2. 신규 모듈 디렉터리 `leader/leader-zookeeper/` (settings.gradle.kts는 `includeModules("leader", ...)` 헬퍼가 자동 등록 — 별도 수정 불필요)
+3. `build.gradle.kts` + main/test 소스 + 리소스 + 양 언어 README
+4. 9개 테스트 클래스 (T0~T8) — DoD 통과 기준
+
+### 비-목표
+
+- `ListeningLeaderElector` 래퍼는 ZK 모듈에 포함하지 않음 (라이브러리 미제공). README에서 cross-link만 제공.
+- 새 라이브러리 버전 배포는 본 작업 범위 외 (BOM 1.1.3 사용).
+- T5 `LeaseExpiryTest` / T6 `RedisFailureTest`류 smoke 태그는 ZK 모듈에서 사용하지 않음 (R16: TTL 부재로 의미 없음).
+
+---
+
+## 2. 모듈 등록 검증 (사전 확인)
+
+`settings.gradle.kts` 라인 32 `includeModules("leader", false, true)` 헬퍼가
+`leader/` 하위 디렉터리를 자동으로 `:leader:<dir>` 프로젝트로 등록한다.
+→ **settings.gradle.kts 수정은 필요 없음.** 단, `leader/leader-zookeeper/build.gradle.kts`가
+생성된 직후 `./gradlew projects` 출력에 `:leader:leader-zookeeper`가 나타나는지 확인.
+
+---
+
+## 3. 작업 목록 (Task Breakdown)
+
+### Phase 0 — 카탈로그 및 모듈 골격
+
+#### T-CAT-1: Gradle 카탈로그 alias 등록 — complexity: low
+- **파일**: `gradle/libs.versions.toml`
+- **변경**: line 208 (`bluetape4k-leader-redis-lettuce`) 다음 줄에 추가:
+  ```toml
+  bluetape4k-leader-zookeeper = { module = "io.github.bluetape4k.leader:bluetape4k-leader-zookeeper" }
+  ```
+- **검증**: alias key `libs.bluetape4k.leader.zookeeper`로 변환됨을 `./gradlew help` 또는 build 단계에서 확인
+- **버전 핀 금지** — `bluetape4k-dependencies` BOM 1.1.3이 0.2.1을 관리
+- **의존**: 없음
+
+#### T-MOD-1: 모듈 디렉터리 골격 생성 — complexity: low
+- **파일/디렉터리**:
+  - `leader/leader-zookeeper/`
+  - `leader/leader-zookeeper/src/main/kotlin/io/bluetape4k/workshop/leader/zookeeper/{config,service}/`
+  - `leader/leader-zookeeper/src/main/resources/`
+  - `leader/leader-zookeeper/src/test/kotlin/io/bluetape4k/workshop/leader/zookeeper/`
+  - `leader/leader-zookeeper/src/test/resources/`
+- **검증**: `./gradlew projects` 출력에 `:leader:leader-zookeeper` 등장
+- **의존**: T-CAT-1 (alias가 있어야 build.gradle.kts 작성 가능)
+
+#### T-MOD-2: build.gradle.kts 작성 — complexity: high
+- **파일**: `leader/leader-zookeeper/build.gradle.kts`
+- **내용**:
+  - `plugins { alias(libs.plugins.kotlin.spring); alias(libs.plugins.spring.boot) }`
+  - `springBoot.mainClass.set("io.bluetape4k.workshop.leader.zookeeper.LeaderZookeeperAppKt")`
+  - `configurations { testImplementation.get().extendsFrom(compileOnly.get(), runtimeOnly.get()) }`
+  - `tasks.test { useJUnitPlatform { excludeTags("smoke") } }` (smoke tag 없어도 ALA 컨벤션 유지)
+  - dependencies:
+    - `implementation(libs.bluetape4k.leader.zookeeper)` — Apache Curator transitive
+    - `implementation(libs.bluetape4k.logging)`
+    - `implementation(libs.spring.boot.autoconfigure.lib)` + `libs.spring.boot.starter.actuator`
+    - `annotationProcessor(libs.spring.boot.autoconfigure.processor)` + `libs.spring.boot.configuration.processor`
+    - `runtimeOnly(libs.spring.boot.devtools)`
+    - testImplementation: `project(":shared")`, `bluetape4k.coroutines`, `bluetape4k.junit5`, `kotlinx.coroutines.test.lib`, `bluetape4k.testcontainers`, `bluetape4k.assertions`, `spring.boot.starter.test` (mockito-core/junit-vintage/junit exclude), `mockk`
+    - testImplementation: `ch.qos.logback:logback-classic` 명시 — T7 `ListAppender<ILoggingEvent>` 사용을 위해 (또는 Spring Boot test 의존성으로 충분한지 검증)
+- **검증**: `./gradlew :leader:leader-zookeeper:compileKotlin` 성공
+- **의존**: T-CAT-1, T-MOD-1
+
+### Phase 1 — 메인 소스 (Production)
+
+#### T-APP-1: LeaderZookeeperApp 메인 클래스 — complexity: low
+- **파일**: `leader/leader-zookeeper/src/main/kotlin/io/bluetape4k/workshop/leader/zookeeper/LeaderZookeeperApp.kt`
+- **내용**:
+  - `@SpringBootApplication`, `@EnableScheduling`
+  - `class LeaderZookeeperApp`
+  - `fun main(args: Array<String>) { runApplication<LeaderZookeeperApp>(*args) }`
+  - English KDoc on class (1줄 요약 + `## Behavior / Contract` 섹션: 이 앱은 ZK 기반 4-elector 데모임을 명시)
+- **검증**: 컴파일 성공
+- **의존**: T-MOD-2
+
+#### T-PROPS-1: LeaderZookeeperProperties — complexity: medium
+- **파일**: `leader/leader-zookeeper/src/main/kotlin/io/bluetape4k/workshop/leader/zookeeper/config/LeaderZookeeperProperties.kt`
+- **내용**: 스펙 §5.1 그대로
+  - `@ConfigurationProperties(prefix = "leader.zookeeper")`
+  - `data class LeaderZookeeperProperties` (Serializable, serialVersionUID)
+  - 필드: `zookeeper`(중첩), `basePath`, `waitTime: java.time.Duration`, `groupMaxLeaders: Int`, `jobFixedDelay`, `suspendJobFixedDelay`, `groupJobFixedDelay`, `suspendGroupJobFixedDelay`
+  - **R16 — leaseTime/autoExtend 의도적 부재** (코드 주석 명시)
+  - 중첩 `data class ZooKeeperConfig`: `connectString`, `sessionTimeoutMs`, `connectionTimeoutMs`, `blockUntilConnectedSeconds`
+  - `init { basePath.requireNotBlank("basePath"); groupMaxLeaders.requirePositiveNumber("groupMaxLeaders"); zookeeper.connectString.requireNotBlank("connectString") }`
+- **English KDoc**: `## Behavior / Contract (R16 — ZooKeeper has no TTL)` 섹션 + `## Production Considerations` 섹션 (스펙 §5.1 KDoc 전체 사용)
+- **검증**: `compileKotlin` 성공; `@ConfigurationProperties` 어노테이션 프로세서 메타데이터 생성 확인
+- **의존**: T-APP-1
+
+#### T-CFG-1: LeaderZookeeperConfig (Spring 빈 등록) — complexity: high
+- **파일**: `leader/leader-zookeeper/src/main/kotlin/io/bluetape4k/workshop/leader/zookeeper/config/LeaderZookeeperConfig.kt`
+- **내용**: 스펙 §5.2 정밀 구현
+  - `@Configuration`, `@EnableConfigurationProperties(LeaderZookeeperProperties::class)`
+  - `companion object : KLogging()`
+  - `@Bean(destroyMethod = "close")` `fun curatorFramework(props): CuratorFramework`:
+    1. `CuratorFrameworkFactory.newClient(connectString, sessionTimeoutMs, connectionTimeoutMs, ExponentialBackoffRetry(1000, 3))`
+    2. **start() 호출 전에** `connectionStateListenable.addListener { _, newState -> ... }` 등록 (SUSPENDED/LOST/RECONNECTED 로깅)
+    3. `client.start()`
+    4. `if (!client.blockUntilConnected(cfg.blockUntilConnectedSeconds, TimeUnit.SECONDS)) { client.close(); error("...") }` — **C2: 명시적 close**
+    5. ACL 주석 명시 (`OPEN_ACL_UNSAFE` default; production은 `DigestACLProvider` 권장)
+  - 4개 elector 빈:
+    - `@Bean fun leaderElector(curator, props): ZooKeeperLeaderElector` (basePath: `${props.basePath}/single`, options.waitTime = `props.waitTime.toKotlinDuration()`)
+    - `@Bean fun suspendLeaderElector(curator, props): ZooKeeperSuspendLeaderElector` (basePath: `${props.basePath}/single-suspend`)
+    - `@Bean fun leaderGroupElector(curator, props): ZooKeeperLeaderGroupElector` (basePath: `${props.basePath}/group`, options: `LeaderGroupElectionOptions(props.groupMaxLeaders, waitTime = ...)`)
+    - `@Bean fun suspendLeaderGroupElector(curator, props): ZooKeeperSuspendLeaderGroupElector` (basePath: `${props.basePath}/group-suspend`)
+  - **R16 — leaseTime 미설정** (LeaderElectionOptions에 leaseTime 인자 미전달)
+- **English KDoc**: ConnectionStateListener 등록 시점, blockUntilConnected 실패 시 자원 정리, ACL 기본값 한계
+- **검증**: 컴파일; `@SpringBootTest` 컨텍스트 로드 (T0)
+- **의존**: T-PROPS-1
+
+#### T-SVC-1: BlockingLeaderService — complexity: medium
+- **파일**: `leader/leader-zookeeper/src/main/kotlin/io/bluetape4k/workshop/leader/zookeeper/service/BlockingLeaderService.kt`
+- **내용**: 스펙 §5.3 BlockingLeaderService
+  - `@Service`
+  - `companion object : KLogging()`
+  - `executionCount: AtomicInteger`
+  - `fun runLeaderWork(lockName = "workshop:blocking-job"): String?` — `elector.runIfLeader(lockName) { ... }` 사용
+  - `@Scheduled(fixedDelayString = "\${leader.zookeeper.job-fixed-delay:PT10S}")` `fun runScheduled()` — try/catch Exception (CancellationException 노출 없음 — blocking)
+- **English KDoc**: `## Behavior / Contract` (skip semantics, executionCount는 테스트용)
+- **검증**: 컴파일 + T1 통과
+- **의존**: T-CFG-1
+
+#### T-SVC-2: SuspendLeaderZkService — complexity: medium
+- **파일**: `leader/leader-zookeeper/src/main/kotlin/io/bluetape4k/workshop/leader/zookeeper/service/SuspendLeaderZkService.kt`
+- **내용**: 스펙 §5.3 SuspendLeaderZkService
+  - `@Service`
+  - `companion object : KLoggingChannel()` (coroutine-safe)
+  - `executionCount: AtomicInteger`
+  - `suspend fun runLeaderWork(lockName: String = "workshop:suspend-job"): String?`
+  - `@Scheduled` wrapper:
+    ```kotlin
+    fun runScheduled() {
+        try { runBlocking { runLeaderWork() } }
+        catch (e: CancellationException) { throw e }  // O6 fix
+        catch (e: Exception) { log.warn(e) { "..." } }
+    }
+    ```
+- **English KDoc**: CancellationException 재throw 정책, `runBlocking` 사용 위치 (스케줄러 경계만)
+- **검증**: 컴파일 + T3 통과
+- **의존**: T-CFG-1
+
+#### T-SVC-3: GroupLeaderService — complexity: medium
+- **파일**: `leader/leader-zookeeper/src/main/kotlin/io/bluetape4k/workshop/leader/zookeeper/service/GroupLeaderService.kt`
+- **내용**: 스펙 §5.3 GroupLeaderService
+  - `@Service`
+  - `ZooKeeperLeaderGroupElector` 주입
+  - `companion object : KLogging()`
+  - `fun runLeaderWork(lockName = "workshop:group-job"): String?` — `groupElector.runIfLeader(lockName) { ... }`
+  - `fun inspectState(lockName): LeaderGroupState` — 활성/슬롯 검증용 (테스트용 헬퍼; KDoc에 internal exposure 명시)
+  - `@Scheduled` wrapper: try/catch Exception (blocking이므로 CancellationException 분기 불필요)
+- **English KDoc**: `maxLeaders` 의미, inspectState 사용 권장 시점
+- **검증**: 컴파일 + T4 통과
+- **의존**: T-CFG-1
+
+#### T-SVC-4: SuspendGroupLeaderService — complexity: medium
+- **파일**: `leader/leader-zookeeper/src/main/kotlin/io/bluetape4k/workshop/leader/zookeeper/service/SuspendGroupLeaderService.kt`
+- **내용**: 스펙 §5.3 SuspendGroupLeaderService
+  - `@Service`
+  - `ZooKeeperSuspendLeaderGroupElector` 주입
+  - `companion object : KLoggingChannel()`
+  - `suspend fun runLeaderWork(lockName): String?`
+  - `@Scheduled` wrapper — **CancellationException 재throw 포함** (SuspendLeaderZkService와 동일 패턴)
+- **English KDoc**: SuspendLeaderZkService 패턴 cross-link
+- **검증**: 컴파일 + T5 통과
+- **의존**: T-CFG-1
+
+#### T-RES-1: application.yml — complexity: low
+- **파일**: `leader/leader-zookeeper/src/main/resources/application.yml`
+- **내용**:
+  - `spring.application.name: leader-zookeeper`
+  - `leader.zookeeper`:
+    - `zookeeper.connect-string: localhost:2181`
+    - `zookeeper.session-timeout-ms: 60000`
+    - `zookeeper.connection-timeout-ms: 15000`
+    - `zookeeper.block-until-connected-seconds: 10`
+    - `base-path: /workshop/leader-zookeeper`
+    - `wait-time: 2s`
+    - `group-max-leaders: 2`
+    - `job-fixed-delay: PT10S`
+    - `suspend-job-fixed-delay: PT12S`
+    - `group-job-fixed-delay: PT15S`
+    - `suspend-group-job-fixed-delay: PT18S`
+  - `management.endpoints.web.exposure.include: health,info`
+  - `logging.level`:
+    - `io.bluetape4k.workshop.leader.zookeeper: INFO`
+    - `io.bluetape4k.leader.zookeeper: DEBUG`
+- **검증**: 부트 시 바인딩 오류 없음 (T0가 검증)
+- **의존**: T-PROPS-1
+
+#### T-RES-2: logback-spring.xml — complexity: low
+- **파일**: `leader/leader-zookeeper/src/main/resources/logback-spring.xml`
+- **내용**: `leader-election`의 `logback-spring.xml`을 그대로 복제하고 logger 이름만 변경
+  - `<logger name="io.bluetape4k.workshop.leader.zookeeper" level="INFO"/>`
+  - `<logger name="io.bluetape4k.leader.zookeeper" level="DEBUG"/>`
+- **검증**: 앱 부트 콘솔 로그 정상 출력
+- **의존**: T-APP-1
+
+### Phase 2 — 테스트 인프라
+
+#### T-TEST-RES-1: junit-platform.properties + logback-test.xml — complexity: low
+- **파일**:
+  - `leader/leader-zookeeper/src/test/resources/junit-platform.properties`
+  - `leader/leader-zookeeper/src/test/resources/logback-test.xml`
+- **내용**:
+  - `junit-platform.properties`: `leader-election`의 것을 복제 (PER_CLASS, parallel=false, exclude tag smoke, constructor autowire=all)
+  - `logback-test.xml`: `leader-election`의 것을 복제 + `io.bluetape4k.leader.zookeeper` 레벨 추가
+- **검증**: 테스트 실행 시 로그 캡처 가능
+- **의존**: T-MOD-2
+
+#### T-TEST-BASE-1: AbstractLeaderZookeeperTest — complexity: high
+- **파일**: `leader/leader-zookeeper/src/test/kotlin/io/bluetape4k/workshop/leader/zookeeper/AbstractLeaderZookeeperTest.kt`
+- **내용**: 스펙 §5.4 정밀 구현
+  - `@TestInstance(TestInstance.Lifecycle.PER_CLASS)`
+  - `abstract class AbstractLeaderZookeeperTest`
+  - `companion object : KLogging()`:
+    - `val zookeeper: ZooKeeperServer = ZooKeeperServer.Launcher.zookeeper`
+    - `val curator: CuratorFramework by lazy { ZooKeeperServer.Launcher.getCuratorFramework(zookeeper).also { it.start(); it.blockUntilConnected(10, TimeUnit.SECONDS); ShutdownQueue.register { it.close() } } }`
+  - factory 메서드 4종 (`newElector`, `newSuspendElector`, `newGroupElector(maxLeaders=2)`, `newSuspendGroupElector(maxLeaders=2)`) — 모두 `waitTime = 500.milliseconds`
+  - `fun randomLockName(prefix = "t") = "$prefix:${UUID.randomUUID()}"`
+- **English KDoc**: 단일 shared curator 정당성 (InterProcessMutex는 thread-keyed); ZK Launcher 싱글턴 사용 이유
+- **검증**: 모든 테스트의 베이스로 의존성 만족; T1~T7 통과 (T8은 별도 격리)
+- **의존**: T-CFG-1 (elector 타입을 노출하므로)
+
+### Phase 3 — 테스트 클래스 (T0~T8)
+
+#### T-T0: LeaderZookeeperContextTest — complexity: medium
+- **파일**: `leader/leader-zookeeper/src/test/kotlin/io/bluetape4k/workshop/leader/zookeeper/LeaderZookeeperContextTest.kt`
+- **내용**:
+  - `@SpringBootTest`
+  - companion: `ZooKeeperServer.Launcher.zookeeper` + `@DynamicPropertySource` `leader.zookeeper.zookeeper.connect-string` 주입
+  - 생성자 주입: `ZooKeeperLeaderElector`, `ZooKeeperSuspendLeaderElector`, `ZooKeeperLeaderGroupElector`, `ZooKeeperSuspendLeaderGroupElector`, `BlockingLeaderService`, `SuspendLeaderZkService`, `GroupLeaderService`, `SuspendGroupLeaderService`
+  - `@Test fun `Spring context loads all 4 electors and 4 services``: 모든 빈 shouldNotBeNull
+- **English KDoc**: T0 목적, `@DynamicPropertySource` 사용 이유
+- **검증**: `./gradlew :leader:leader-zookeeper:test --tests "*Context*"` 성공
+- **의존**: T-SVC-{1..4}, T-RES-1, T-TEST-RES-1
+
+#### T-T1: BlockingSingleLeaderTest — complexity: medium
+- **파일**: `.../BlockingSingleLeaderTest.kt`
+- **내용**:
+  - extends `AbstractLeaderZookeeperTest`
+  - `@Test runIfLeader returns "done"`: `newElector().runIfLeader(randomLockName()) { "done" } shouldBeEqualTo "done"`
+  - `@Test runAsyncIfLeader returns CompletableFuture<42>`: `newElector().runAsyncIfLeader(randomLockName(), VirtualThreadExecutor) { CompletableFuture.completedFuture(42) }.get(5, SECONDS) shouldBeEqualTo 42`
+  - `@Test runIfLeader returns null when action body throws — caught at caller`: (선택, 동작 명확화용)
+- **English KDoc**: T1 목적 (single-leader 두 진입점)
+- **검증**: 통과
+- **의존**: T-TEST-BASE-1
+
+#### T-T2: ConcurrentBlockingLeaderTest — complexity: high
+- **파일**: `.../ConcurrentBlockingLeaderTest.kt`
+- **내용**:
+  - extends `AbstractLeaderZookeeperTest`
+  - `@Test 8 workers contend; peakConcurrent ≤ 1`:
+    - `val peakConcurrent = AtomicInteger(0)`; `val current = AtomicInteger(0)`; `val executed = AtomicInteger(0)`
+    - `val lockName = randomLockName("t2")`
+    - `val elector = newElector()` — **단일 shared curator + 단일 elector** (스펙 §5.4 근거)
+    - `MultithreadingTester().workers(8).rounds(1).add { elector.runIfLeader(lockName) { val c = current.incrementAndGet(); peakConcurrent.updateAndGet { max(it, c) }; executed.incrementAndGet(); Thread.sleep(600); current.decrementAndGet() } }.run()`
+    - `peakConcurrent.get() shouldBeLessOrEqualTo 1`; `executed.get() shouldBeGreaterThan 0`
+- **English KDoc**: T2 목적, `Thread.sleep(600)` (>waitTime=500ms) 정당성, single shared curator/elector 정당성
+- **검증**: 통과
+- **의존**: T-TEST-BASE-1
+
+#### T-T3: SuspendSingleLeaderTest — complexity: high
+- **파일**: `.../SuspendSingleLeaderTest.kt`
+- **내용**:
+  - extends `AbstractLeaderZookeeperTest`
+  - `@Test runIfLeader (suspend) returns "done"`: `runTest { newSuspendElector().runIfLeader(randomLockName()) { "done" } shouldBeEqualTo "done" }`
+  - `@Test 8 suspend coroutines contend; peakConcurrent ≤ 1`:
+    - `SuspendedJobTester` 8-coroutine + shared `suspendElector`
+    - `peakConcurrent` 패턴 + `delay(600.milliseconds)`
+- **English KDoc**: SuspendedJobTester 사용 이유; per-call single-thread dispatcher가 라이브러리 내부에서 처리되므로 외부 동기화 불필요
+- **검증**: 통과
+- **의존**: T-TEST-BASE-1
+
+#### T-T4: GroupLeaderTest — complexity: high
+- **파일**: `.../GroupLeaderTest.kt`
+- **내용**: 스펙 §5.5 T4 CountDownLatch 패턴 정밀 구현
+  - extends `AbstractLeaderZookeeperTest`
+  - `@Test maxLeaders=2 admits exactly 2 simultaneous holders`:
+    - `val maxLeaders = 2`
+    - `val groupElector = newGroupElector(maxLeaders)`
+    - `val lockName = randomLockName("t4")`
+    - `val enteredLatch = CountDownLatch(maxLeaders)`
+    - `val releaseLatch = CountDownLatch(1)`
+    - `val peakConcurrent = AtomicInteger(0)`; `val current = AtomicInteger(0)`
+    - body:
+      ```kotlin
+      MultithreadingTester().workers(4).rounds(1).add {
+          groupElector.runIfLeader(lockName) {
+              val c = current.incrementAndGet()
+              peakConcurrent.updateAndGet { max(it, c) }
+              try {
+                  enteredLatch.countDown()
+                  check(releaseLatch.await(3, TimeUnit.SECONDS)) { "releaseLatch timeout" }
+              } finally { current.decrementAndGet() }
+          }
+      }
+      ```
+    - Separate orchestrator thread (또는 별도 `CompletableFuture.runAsync`)에서: `enteredLatch.await(3, SECONDS)` 성공 시 `releaseLatch.countDown()`
+    - assert: `peakConcurrent.get() shouldBeEqualTo maxLeaders` (== 2)
+- **English KDoc**: `CountDownLatch` 핸드쉐이크 정당성 (6T1 해결); `MultithreadingTester.run()` 외부에서 sampling 불가능한 이유
+- **검증**: 통과
+- **의존**: T-TEST-BASE-1
+
+#### T-T5: SuspendGroupLeaderTest — complexity: high
+- **파일**: `.../SuspendGroupLeaderTest.kt`
+- **내용**: T4와 동일 패턴, `SuspendedJobTester(coroutines=4)` 사용:
+  - `delay(600.milliseconds)` 사용
+  - `enteredLatch`/`releaseLatch`는 `java.util.concurrent.CountDownLatch` (동작 동일)
+  - 또는 `Channel`/`Job.join` 기반 코루틴 패턴 — 결정은 구현자가 가독성 우선
+- **English KDoc**: T4 패턴 cross-link
+- **검증**: 통과
+- **의존**: T-TEST-BASE-1
+
+#### T-T6: ExtensionFunctionTest — complexity: medium
+- **파일**: `.../ExtensionFunctionTest.kt`
+- **내용**: `CuratorFramework`의 4 elector-family extension 함수 커버
+  - extends `AbstractLeaderZookeeperTest`
+  - `@Test runIfLeader extension returns "done"`: `curator.runIfLeader(randomLockName(), basePath = "/test/ext-single") { "done" } shouldBeEqualTo "done"`
+  - `@Test runAsyncIfLeader extension returns 42`: `curator.runAsyncIfLeader(randomLockName(), basePath = "/test/ext-single-async") { CompletableFuture.completedFuture(42) }.get(5, SECONDS) shouldBeEqualTo 42`
+  - `@Test suspendRunIfLeader extension returns "done"`: `runTest { curator.suspendRunIfLeader(randomLockName(), basePath = "/test/ext-suspend") { "done" } shouldBeEqualTo "done" }`
+  - `@Test runIfLeaderGroup extension admits leader`: `curator.runIfLeaderGroup(randomLockName(), basePath = "/test/ext-group", groupOptions = LeaderGroupElectionOptions(2, waitTime = 500.ms)) { "done" } shouldBeEqualTo "done"`
+  - (선택 5th) `@Test suspendRunIfLeaderGroup extension`: 위 코루틴 버전
+- **English KDoc**: T6은 라이브러리 extension API 매끄러움 검증
+- **검증**: 통과
+- **의존**: T-TEST-BASE-1
+- **참고**: 라이브러리 실제 시그니처는 `inline fun <T> CuratorFramework.runIfLeader(lockName, basePath, options, action)` 형태. 구현자는 컴파일러 안내에 따라 인자 이름/순서 맞춤.
+
+#### T-T7: R16AutoExtendIgnoredTest — complexity: high
+- **파일**: `.../R16AutoExtendIgnoredTest.kt`
+- **내용**: 스펙 §5.5 T7 Logback ListAppender 패턴
+  - extends `AbstractLeaderZookeeperTest`
+  - field: `private lateinit var appender: ListAppender<ILoggingEvent>`
+  - `@BeforeEach setupLogCapture()`: `LoggerFactory.getLogger("io.bluetape4k.leader.zookeeper") as Logger` → `ListAppender<ILoggingEvent>().also { it.start() }` 첨부
+  - `@AfterEach teardownLogCapture()`: appender.stop() + detach (테스트 격리)
+  - `@Test autoExtend option is silently ignored with WARN log`:
+    - `val elector = ZooKeeperLeaderElector(curator, "/test/r16", LeaderElectionOptions(autoExtend = true, waitTime = 500.milliseconds))`
+    - `val result = elector.runIfLeader(randomLockName()) { "r16-done" }`
+    - `result shouldBeEqualTo "r16-done"`
+    - `val warnEvents = appender.list.filter { it.level == Level.WARN && "autoExtend" in it.formattedMessage }`
+    - `warnEvents.shouldNotBeEmpty()`
+- **English KDoc**: T7은 R16 계약의 관찰 가능한 시연; ListAppender 패턴 이유 (Logback 의존 — Spring Boot test가 제공)
+- **검증**: 통과; `LeaderElectionOptions.autoExtend` 시그니처 라이브러리 확인 후 인자 이름 조정
+- **의존**: T-TEST-BASE-1
+- **참고**: 만약 라이브러리가 INFO 레벨로 로그 시 자동 차감을 알린다면 spec과 합의된 WARN 레벨 어설션 실패 가능 — 구현 시 실제 라이브러리 로그 레벨 확인 후 spec 업데이트 권고 (advisor consult)
+
+#### T-T8: SessionLossFailoverTest — complexity: high
+- **파일**: `.../SessionLossFailoverTest.kt`
+- **내용**: 스펙 §5.4 T8 격리 컨테이너 패턴
+  - `@TestInstance(TestInstance.Lifecycle.PER_CLASS)`
+  - **격리된 ZK 인스턴스 사용** — `ZooKeeperServer.Launcher.zookeeper` 절대 사용 금지
+  - fields:
+    - `private lateinit var isolatedZk: ZooKeeperServer`
+    - `private lateinit var clientA: CuratorFramework`
+    - `private lateinit var clientB: CuratorFramework`
+  - `@BeforeAll fun startIsolatedZk()`: `ZooKeeperServer().also { it.start() }`; 2개 클라이언트 생성 (`ZooKeeperServer.Launcher.getCuratorFramework(isolatedZk)`) → 각각 `start()` + `blockUntilConnected(10, SECONDS)`
+  - `@AfterAll fun stopIsolatedZk()`: `runCatching { clientA.close() }`; `runCatching { clientB.close() }`; `runCatching { isolatedZk.stop() }`
+  - `@Test session expiry causes leadership failover`:
+    1. workerA: `clientA.runIfLeader(lockName, basePath = "/test/t8") { Thread.sleep(...) }` 또는 명시적 `InterProcessMutex` 획득
+    2. `isolatedZk.stop()` — 세션 만료 시뮬레이션
+    3. 일정 대기 (예: `Awaitility`로 ConnectionState.LOST 관측)
+    4. `isolatedZk.start()` — 재기동
+    5. workerB: `clientB.runIfLeader(lockName, ...) { "B-acquired" }` 성공 (Ephemeral 사라짐 → 경쟁자 자동 선출)
+    6. assert: workerB가 leadership 획득
+  - **타이밍**: ZK session 만료는 sessionTimeoutMs 기반 — 테스트용 `sessionTimeoutMs` 짧게 설정 (예: 3초) + `Awaitility.atMost(15.seconds)` 대기
+- **English KDoc**: T8 isolation 정당성 (싱글턴 파괴 방지); R16 시연 의도
+- **검증**: 통과; 타이밍 flake 시 Awaitility/timeout 조정
+- **의존**: T-TEST-BASE-1 (코드는 extends하지만 companion curator는 사용 안 함)
+- **참고**: 시간 정밀도 높음 — `@Tag("smoke")` 부여 후 `excludeTags("smoke")`로 기본 빌드에서 제외할지 결정 (DoD에서 "T8 통과 필수"이므로 기본 포함; CI가 flaky하면 spec 업데이트 후 smoke 처리)
+
+### Phase 4 — 문서
+
+#### T-DOC-1: README.md (English) — complexity: medium
+- **파일**: `leader/leader-zookeeper/README.md`
+- **내용** (스펙 §7 DoD):
+  1. **Architecture**: 모듈 다이어그램 (SVG+PNG, `docs/images/readme-diagrams/` 하위; mermaid/ASCII 금지) — Curator + ZK + 4 elector 빈 구조
+  2. **Core features**: 4 elector 종류 + R16 callout 정의
+  3. **Usage examples — side-by-side**:
+     - single-leader (`runIfLeader`) + group-leader (`maxLeaders=2`) 코드 예제
+     - blocking + suspend 코루틴 버전
+  4. **R16 — ZooKeeper has no TTL** (전용 섹션):
+     - leaseTime/autoExtend 부재 사유
+     - sessionTimeoutMs로 failover latency 조율
+     - T8 시나리오 다이어그램 또는 시퀀스 (선택)
+  5. **Configuration options**: `leader.zookeeper.*` 프로퍼티 전체 표
+  6. **Production Considerations**: ACL/TLS/SASL 권장사항 + sessionTimeoutMs 튜닝
+  7. **Dependency instructions**: 카탈로그 alias 사용법, BOM 참조
+  8. Cross-link: `leader/leader-election/` (Redis 비교)
+- **검증**: `git diff --check`, README 컨텐츠 영문 일관성 (CLAUDE.md 정책)
+- **의존**: T-MOD-1 (모듈 디렉터리 존재)
+
+#### T-DOC-2: README.ko.md (Korean) — complexity: low
+- **파일**: `leader/leader-zookeeper/README.ko.md`
+- **내용**: T-DOC-1 한국어 번역본 (CLAUDE.md README locale 정책 — 멀티링구얼 허용)
+  - 동일 구조, 동일 이미지 자산 참조
+  - R16 callout, side-by-side 코드 예제, ACL/TLS 권장사항 모두 포함
+- **검증**: README.md와 섹션 1:1 대응 확인
+- **의존**: T-DOC-1
+
+### Phase 5 — 검증 (DoD)
+
+#### T-VRF-1: 전체 테스트 실행 + DoD 체크 — complexity: medium
+- **명령**:
+  ```bash
+  ./gradlew :leader:leader-zookeeper:compileKotlin
+  ./gradlew :leader:leader-zookeeper:test
+  ```
+- **DoD 통과 기준** (스펙 §7):
+  - [ ] T0~T8 9개 테스트 모두 통과
+  - [ ] `compileKotlin` 0 errors, 0 unresolved deprecation
+  - [ ] IDE diagnostics 0 errors (해당 시 `ide_diagnostics` 결과 첨부)
+  - [ ] HIGH/CRITICAL code review 0 (`/oh-my-claudecode:code-reviewer` 실행)
+  - [ ] README.md + README.ko.md (R16 callout, side-by-side, ACL/TLS 포함)
+  - [ ] English KDoc on all public types
+  - [ ] T4/T5 CountDownLatch 핸드쉐이크 + `peakConcurrent` 검증
+  - [ ] T7 Logback ListAppender WARN 캡처
+  - [ ] T8 세션 만료 시나리오 통과
+  - [ ] `@Scheduled` wrapper CancellationException 재throw 적용 (SVC-2, SVC-4)
+- **의존**: T-T0~T-T8, T-DOC-1, T-DOC-2
+
+#### T-VRF-2: 코드 리뷰 — complexity: medium
+- **명령**: `/oh-my-claudecode:code-reviewer` (CRITICAL/HIGH 0 통과 시까지 반복)
+- **체크리스트**:
+  - CLAUDE.md 정책 준수: KDoc 영문, 한국어 로그 없음, `!!` 없음, `runCatching` 동기만, `CancellationException` 재throw, `@Synchronized` 없음
+  - bluetape4k 패턴: `requireNotBlank` 등 사용, `KLogging`/`KLoggingChannel` companion, `@TestInstance(PER_CLASS)`, `bluetape4k-assertions` 매처
+  - Spring Boot 4 패턴: `@Bean(destroyMethod = "close")`, `@DynamicPropertySource`, `@ConfigurationProperties` 어노테이션 프로세서
+  - Testcontainers: `ZooKeeperServer.Launcher.zookeeper` 싱글턴, `@Testcontainers` 미사용
+- **의존**: T-VRF-1
+
+---
+
+## 4. 의존성 그래프 (요약)
+
+```
+T-CAT-1 ─┐
+         ├─ T-MOD-1 ─ T-MOD-2 ─ T-APP-1 ─ T-PROPS-1 ─ T-CFG-1 ─┬─ T-SVC-1 ─┐
+         │                                                      ├─ T-SVC-2 ─┤
+         │                                                      ├─ T-SVC-3 ─┤
+         │                                                      └─ T-SVC-4 ─┤
+         │                                                                  │
+         │                                       T-RES-1 ──────────────────┤
+         │                                       T-RES-2 ──────────────────┤
+         │                                                                  │
+         └─ T-TEST-RES-1 ─ T-TEST-BASE-1 ─┬─ T-T0 ←─────────────────────────┤
+                                          ├─ T-T1                            │
+                                          ├─ T-T2                            │
+                                          ├─ T-T3                            │
+                                          ├─ T-T4                            │
+                                          ├─ T-T5                            │
+                                          ├─ T-T6                            │
+                                          ├─ T-T7                            │
+                                          └─ T-T8                            │
+                                                                             │
+                          T-DOC-1 ─ T-DOC-2 ──────────────────────────────── │
+                                                                             │
+                          T-VRF-1 (모든 위 작업) ─ T-VRF-2 ─────────────────┘
+```
+
+---
+
+## 5. 우선순위 실행 순서 (Ordered Task List)
+
+| Order | Task ID | Complexity | 비고 |
+|---|---|---|---|
+| 1 | T-CAT-1 | low | 카탈로그 alias |
+| 2 | T-MOD-1 | low | 디렉터리 골격 |
+| 3 | T-MOD-2 | high | build.gradle.kts |
+| 4 | T-APP-1 | low | 메인 App |
+| 5 | T-PROPS-1 | medium | Properties (R16 KDoc) |
+| 6 | T-CFG-1 | high | Config 빈 (ConnectionStateListener, 자원 누수 방지) |
+| 7 | T-SVC-1 | medium | BlockingLeaderService |
+| 8 | T-SVC-2 | medium | SuspendLeaderZkService (Cancellation rethrow) |
+| 9 | T-SVC-3 | medium | GroupLeaderService |
+| 10 | T-SVC-4 | medium | SuspendGroupLeaderService (Cancellation rethrow) |
+| 11 | T-RES-1 | low | application.yml |
+| 12 | T-RES-2 | low | logback-spring.xml |
+| 13 | T-TEST-RES-1 | low | junit-platform.properties + logback-test.xml |
+| 14 | T-TEST-BASE-1 | high | AbstractLeaderZookeeperTest (lazy shared curator) |
+| 15 | T-T0 | medium | Spring context |
+| 16 | T-T1 | medium | runIfLeader + runAsyncIfLeader |
+| 17 | T-T2 | high | MultithreadingTester 동시성 |
+| 18 | T-T3 | high | SuspendedJobTester |
+| 19 | T-T4 | high | Group CountDownLatch 핸드쉐이크 |
+| 20 | T-T5 | high | Suspend Group |
+| 21 | T-T6 | medium | Extension 함수 |
+| 22 | T-T7 | high | Logback ListAppender (R16 WARN) |
+| 23 | T-T8 | high | 격리 ZK 컨테이너, 세션 만료 |
+| 24 | T-DOC-1 | medium | README.md (영) |
+| 25 | T-DOC-2 | low | README.ko.md |
+| 26 | T-VRF-1 | medium | DoD 체크 |
+| 27 | T-VRF-2 | medium | code-reviewer HIGH/CRITICAL 0 |
+
+---
+
+## 6. 위험 요소 및 미해결 항목
+
+| ID | 위험 | 대응 |
+|---|---|---|
+| R-1 | T7 WARN 로그 캡처 실패 (실제 로그 레벨이 INFO일 가능성) | 구현 후 라이브러리 실제 로그 확인; 다를 경우 spec 업데이트 advisor 호출 |
+| R-2 | T6 라이브러리 extension 함수 시그니처 변경 (basePath default) | 컴파일 에러 시 라이브러리 소스 조회 후 인자 명시 |
+| R-3 | T8 세션 만료 타이밍 flake (CI 환경) | `sessionTimeoutMs=3000`, `Awaitility.atMost(15.seconds)` 시작값; flake 시 `@Tag("smoke")` 부여 검토 |
+| R-4 | `bluetape4k-leader-zookeeper` BOM 미포함 (1.1.3 검증) | T-CAT-1 직후 `./gradlew :leader:leader-zookeeper:dependencies` 로 0.2.1 해석 확인 |
+| R-5 | T-T0 `@DynamicPropertySource` 와 nested `zookeeper.connect-string` 바인딩 | 키는 `leader.zookeeper.zookeeper.connect-string` (이중 zookeeper) — application.yml과 동일 구조 |
+| R-6 | T7 ListAppender가 `logback-test.xml`의 ROOT logger 설정과 충돌 | `addAppender`만 사용하고 ROOT level 변경 금지; `@AfterEach`에서 반드시 `detachAppender` |
+
+---
+
+## 7. 참고 자료
+
+- 스펙: `docs/superpowers/specs/2026-05-25-leader-zookeeper-design.md`
+- 참조 모듈: `leader/leader-election/` (Redis/Lettuce)
+- 라이브러리 소스: `/Users/debop/work/bluetape4k/bluetape4k-leader/leader-zookeeper/`
+- 라이브러리 테스트 베이스: `AbstractZooKeeperLeaderTest` (단일 shared curator 패턴 출처)
+- CLAUDE.md (워크숍 루트): 로깅 영문, KDoc 영문, CancellationException 재throw, Testcontainers Launcher 싱글턴

--- a/docs/superpowers/plans/2026-05-25-leader-zookeeper-plan.md
+++ b/docs/superpowers/plans/2026-05-25-leader-zookeeper-plan.md
@@ -19,7 +19,7 @@ Apache Curator 기반 `bluetape4k-leader-zookeeper:0.2.1` 라이브러리를 워
 1. `gradle/libs.versions.toml` — `bluetape4k-leader-zookeeper` alias 1개 추가 (버전 핀 없음, BOM 관리)
 2. 신규 모듈 디렉터리 `leader/leader-zookeeper/` (settings.gradle.kts는 `includeModules("leader", ...)` 헬퍼가 자동 등록 — 별도 수정 불필요)
 3. `build.gradle.kts` + main/test 소스 + 리소스 + 양 언어 README
-4. 9개 테스트 클래스 (T0~T8) — DoD 통과 기준
+4. 10개 테스트 클래스 (T0~T9) — DoD 통과 기준
 
 ### 비-목표
 
@@ -100,7 +100,8 @@ Apache Curator 기반 `bluetape4k-leader-zookeeper:0.2.1` 라이브러리를 워
   - 필드: `zookeeper`(중첩), `basePath`, `waitTime: java.time.Duration`, `groupMaxLeaders: Int`, `jobFixedDelay`, `suspendJobFixedDelay`, `groupJobFixedDelay`, `suspendGroupJobFixedDelay`
   - **R16 — leaseTime/autoExtend 의도적 부재** (코드 주석 명시)
   - 중첩 `data class ZooKeeperConfig`: `connectString`, `sessionTimeoutMs`, `connectionTimeoutMs`, `blockUntilConnectedSeconds`
-  - `init { basePath.requireNotBlank("basePath"); groupMaxLeaders.requirePositiveNumber("groupMaxLeaders"); zookeeper.connectString.requireNotBlank("connectString") }`
+  - Outer `init { basePath.requireNotBlank("basePath"); groupMaxLeaders.requirePositiveNumber("groupMaxLeaders") }` — connectString is validated inside `ZooKeeperConfig.init` (not outer class)
+  - `ZooKeeperConfig.init { connectString.requireNotBlank("connectString") }` — spec §5.1 ZooKeeperConfig.init already shows this correctly
 - **English KDoc**: `## Behavior / Contract (R16 — ZooKeeper has no TTL)` 섹션 + `## Production Considerations` 섹션 (스펙 §5.1 KDoc 전체 사용)
 - **검증**: `compileKotlin` 성공; `@ConfigurationProperties` 어노테이션 프로세서 메타데이터 생성 확인
 - **의존**: T-APP-1
@@ -119,8 +120,24 @@ Apache Curator 기반 `bluetape4k-leader-zookeeper:0.2.1` 라이브러리를 워
   - 4개 elector 빈:
     - `@Bean fun leaderElector(curator, props): ZooKeeperLeaderElector` (basePath: `${props.basePath}/single`, options.waitTime = `props.waitTime.toKotlinDuration()`)
     - `@Bean fun suspendLeaderElector(curator, props): ZooKeeperSuspendLeaderElector` (basePath: `${props.basePath}/single-suspend`)
-    - `@Bean fun leaderGroupElector(curator, props): ZooKeeperLeaderGroupElector` (basePath: `${props.basePath}/group`, options: `LeaderGroupElectionOptions(props.groupMaxLeaders, waitTime = ...)`)
-    - `@Bean fun suspendLeaderGroupElector(curator, props): ZooKeeperSuspendLeaderGroupElector` (basePath: `${props.basePath}/group-suspend`)
+    - `@Bean fun leaderGroupElector(curator, props): ZooKeeperLeaderGroupElector`:
+      ```kotlin
+      ZooKeeperLeaderGroupElector(
+          client = curator,
+          options = LeaderGroupElectionOptions(maxLeaders = props.groupMaxLeaders, waitTime = props.waitTime.toKotlinDuration()),
+          basePath = "${props.basePath}/group"
+      )
+      ```
+      **NOTE (T3-1)**: Parameter order is `(client, options, basePath)` — NOT `(client, basePath, options)`. Confirmed from library source `ZooKeeperLeaderGroupElector.kt:179-184`.
+    - `@Bean fun suspendLeaderGroupElector(curator, props): ZooKeeperSuspendLeaderGroupElector`:
+      ```kotlin
+      ZooKeeperSuspendLeaderGroupElector(
+          client = curator,
+          options = LeaderGroupElectionOptions(maxLeaders = props.groupMaxLeaders, waitTime = props.waitTime.toKotlinDuration()),
+          basePath = "${props.basePath}/group-suspend"
+      )
+      ```
+      Same parameter order as ZooKeeperLeaderGroupElector.
   - **R16 — leaseTime 미설정** (LeaderElectionOptions에 leaseTime 인자 미전달)
 - **English KDoc**: ConnectionStateListener 등록 시점, blockUntilConnected 실패 시 자원 정리, ACL 기본값 한계
 - **검증**: 컴파일; `@SpringBootTest` 컨텍스트 로드 (T0)
@@ -232,7 +249,8 @@ Apache Curator 기반 `bluetape4k-leader-zookeeper:0.2.1` 라이브러리를 워
   - `abstract class AbstractLeaderZookeeperTest`
   - `companion object : KLogging()`:
     - `val zookeeper: ZooKeeperServer = ZooKeeperServer.Launcher.zookeeper`
-    - `val curator: CuratorFramework by lazy { ZooKeeperServer.Launcher.getCuratorFramework(zookeeper).also { it.start(); it.blockUntilConnected(10, TimeUnit.SECONDS); ShutdownQueue.register { it.close() } } }`
+    - `val curator: CuratorFramework by lazy { ZooKeeperServer.Launcher.getCuratorFramework(zookeeper).also { it.start(); check(it.blockUntilConnected(10, TimeUnit.SECONDS)) { "Test curator could not connect to ZooKeeper within 10s (url=${zookeeper.url})" }; ShutdownQueue.register { it.close() } } }`
+    - **NOTE (T2-1)**: `blockUntilConnected` return value MUST be checked — otherwise slow CI silently uses a CONNECTING state curator.
   - factory 메서드 4종 (`newElector`, `newSuspendElector`, `newGroupElector(maxLeaders=2)`, `newSuspendGroupElector(maxLeaders=2)`) — 모두 `waitTime = 500.milliseconds`
   - `fun randomLockName(prefix = "t") = "$prefix:${UUID.randomUUID()}"`
 - **English KDoc**: 단일 shared curator 정당성 (InterProcessMutex는 thread-keyed); ZK Launcher 싱글턴 사용 이유
@@ -272,7 +290,7 @@ Apache Curator 기반 `bluetape4k-leader-zookeeper:0.2.1` 라이브러리를 워
     - `val lockName = randomLockName("t2")`
     - `val elector = newElector()` — **단일 shared curator + 단일 elector** (스펙 §5.4 근거)
     - `MultithreadingTester().workers(8).rounds(1).add { elector.runIfLeader(lockName) { val c = current.incrementAndGet(); peakConcurrent.updateAndGet { max(it, c) }; executed.incrementAndGet(); Thread.sleep(600); current.decrementAndGet() } }.run()`
-    - `peakConcurrent.get() shouldBeLessOrEqualTo 1`; `executed.get() shouldBeGreaterThan 0`
+    - `peakConcurrent.get() shouldBeLessOrEqualTo 1`; `executed.get() shouldBeGreaterThan 3` — asserting > 3 (not just > 0) ensures at least some workers acquired in sequence; a 0-count means ZK/waitTime misconfiguration, not timing
 - **English KDoc**: T2 목적, `Thread.sleep(600)` (>waitTime=500ms) 정당성, single shared curator/elector 정당성
 - **검증**: 통과
 - **의존**: T-TEST-BASE-1
@@ -313,7 +331,20 @@ Apache Curator 기반 `bluetape4k-leader-zookeeper:0.2.1` 라이브러리를 워
           }
       }
       ```
-    - Separate orchestrator thread (또는 별도 `CompletableFuture.runAsync`)에서: `enteredLatch.await(3, SECONDS)` 성공 시 `releaseLatch.countDown()`
+    - **⚠️ CRITICAL ORDERING (T5-1)**: The orchestrator MUST start BEFORE `MultithreadingTester.run()` — `run()` blocks the calling thread until all workers finish:
+      ```kotlin
+      // CORRECT: orchestrator thread starts before blocking .run()
+      val orchestrator = Thread {
+          check(enteredLatch.await(5, TimeUnit.SECONDS)) {
+              "Not enough workers entered — CI too slow or maxLeaders not reached"
+          }
+          releaseLatch.countDown()
+      }
+      orchestrator.start()  // ← START BEFORE .run()
+      MultithreadingTester().workers(4).rounds(1).add { ... }.run()  // blocks here
+      orchestrator.join(6_000)
+      ```
+      If orchestrator starts AFTER `.run()`, workers block on `releaseLatch.await` forever → deadlock.
     - assert: `peakConcurrent.get() shouldBeEqualTo maxLeaders` (== 2)
 - **English KDoc**: `CountDownLatch` 핸드쉐이크 정당성 (6T1 해결); `MultithreadingTester.run()` 외부에서 sampling 불가능한 이유
 - **검증**: 통과
@@ -324,6 +355,7 @@ Apache Curator 기반 `bluetape4k-leader-zookeeper:0.2.1` 라이브러리를 워
 - **내용**: T4와 동일 패턴, `SuspendedJobTester(coroutines=4)` 사용:
   - `delay(600.milliseconds)` 사용
   - `enteredLatch`/`releaseLatch`는 `java.util.concurrent.CountDownLatch` (동작 동일)
+  - **⚠️ CRITICAL (T5-1)**: T4와 동일하게 orchestrator를 `SuspendedJobTester.run()` 이전에 시작해야 함 — `run()`이 blocking이므로 이후에 시작 시 deadlock 발생
   - 또는 `Channel`/`Job.join` 기반 코루틴 패턴 — 결정은 구현자가 가독성 우선
 - **English KDoc**: T4 패턴 cross-link
 - **검증**: 통과
@@ -336,12 +368,23 @@ Apache Curator 기반 `bluetape4k-leader-zookeeper:0.2.1` 라이브러리를 워
   - `@Test runIfLeader extension returns "done"`: `curator.runIfLeader(randomLockName(), basePath = "/test/ext-single") { "done" } shouldBeEqualTo "done"`
   - `@Test runAsyncIfLeader extension returns 42`: `curator.runAsyncIfLeader(randomLockName(), basePath = "/test/ext-single-async") { CompletableFuture.completedFuture(42) }.get(5, SECONDS) shouldBeEqualTo 42`
   - `@Test suspendRunIfLeader extension returns "done"`: `runTest { curator.suspendRunIfLeader(randomLockName(), basePath = "/test/ext-suspend") { "done" } shouldBeEqualTo "done" }`
-  - `@Test runIfLeaderGroup extension admits leader`: `curator.runIfLeaderGroup(randomLockName(), basePath = "/test/ext-group", groupOptions = LeaderGroupElectionOptions(2, waitTime = 500.ms)) { "done" } shouldBeEqualTo "done"`
+  - `@Test runIfLeaderGroup extension admits leader`:
+    ```kotlin
+    curator.runIfLeaderGroup(
+        randomLockName(),
+        options = LeaderGroupElectionOptions(2, waitTime = 500.milliseconds),  // param is "options", NOT "groupOptions"
+        basePath = "/test/ext-group"
+    ) { "done" } shouldBeEqualTo "done"
+    ```
+    **⚠️ COMPILE FIX (T3-2)**: The parameter is named `options`, NOT `groupOptions`. Source-verified from `ZooKeeperLeaderGroupElector.kt:181`. Using `groupOptions=` causes compile error.
   - (선택 5th) `@Test suspendRunIfLeaderGroup extension`: 위 코루틴 버전
 - **English KDoc**: T6은 라이브러리 extension API 매끄러움 검증
 - **검증**: 통과
 - **의존**: T-TEST-BASE-1
-- **참고**: 라이브러리 실제 시그니처는 `inline fun <T> CuratorFramework.runIfLeader(lockName, basePath, options, action)` 형태. 구현자는 컴파일러 안내에 따라 인자 이름/순서 맞춤.
+- **참고**: 
+  - `runIfLeaderGroup`/`suspendRunIfLeaderGroup` 시그니처: `(lockName, options: LeaderGroupElectionOptions = .Default, basePath: String = ..., action)` — 파라미터명 `options` (NOT `groupOptions`)
+  - `runIfLeader`/`suspendRunIfLeader` 시그니처: `(lockName, basePath, options, action)` 순서 확인
+  - ⚠️ 모든 extension 함수는 named argument로 명시적 호출 권장 (순서 혼동 방지)
 
 #### T-T7: R16AutoExtendIgnoredTest — complexity: high
 - **파일**: `.../R16AutoExtendIgnoredTest.kt`
@@ -349,41 +392,128 @@ Apache Curator 기반 `bluetape4k-leader-zookeeper:0.2.1` 라이브러리를 워
   - extends `AbstractLeaderZookeeperTest`
   - field: `private lateinit var appender: ListAppender<ILoggingEvent>`
   - `@BeforeEach setupLogCapture()`: `LoggerFactory.getLogger("io.bluetape4k.leader.zookeeper") as Logger` → `ListAppender<ILoggingEvent>().also { it.start() }` 첨부
-  - `@AfterEach teardownLogCapture()`: appender.stop() + detach (테스트 격리)
+  - `@AfterEach teardownLogCapture()`:
+    ```kotlin
+    @AfterEach fun teardownLogCapture() {
+        (LoggerFactory.getLogger("io.bluetape4k.leader.zookeeper") as Logger).detachAppender(appender)
+        appender.stop()
+    }
+    ```
+    **⚠️ MUST call detachAppender BEFORE stop() (T5-4)** — `stop()` alone does NOT remove the appender from the logger. Without `detachAppender`, the stopped appender leaks into subsequent tests sharing the same logger.
   - `@Test autoExtend option is silently ignored with WARN log`:
     - `val elector = ZooKeeperLeaderElector(curator, "/test/r16", LeaderElectionOptions(autoExtend = true, waitTime = 500.milliseconds))`
     - `val result = elector.runIfLeader(randomLockName()) { "r16-done" }`
     - `result shouldBeEqualTo "r16-done"`
     - `val warnEvents = appender.list.filter { it.level == Level.WARN && "autoExtend" in it.formattedMessage }`
     - `warnEvents.shouldNotBeEmpty()`
+    - **NOTE**: The WARN message is in Korean: `"ZooKeeper 는 TTL 이 없는 세션 기반 락 — autoExtend=true 설정이 무시됩니다. ..."`. The ASCII token `"autoExtend"` appears verbatim in the Korean text. **Do NOT change the assertion substring** — `"autoExtend" in formattedMessage` is correct and source-confirmed from `ZooKeeperLeaderElector.kt:111-112`.
 - **English KDoc**: T7은 R16 계약의 관찰 가능한 시연; ListAppender 패턴 이유 (Logback 의존 — Spring Boot test가 제공)
 - **검증**: 통과; `LeaderElectionOptions.autoExtend` 시그니처 라이브러리 확인 후 인자 이름 조정
 - **의존**: T-TEST-BASE-1
-- **참고**: 만약 라이브러리가 INFO 레벨로 로그 시 자동 차감을 알린다면 spec과 합의된 WARN 레벨 어설션 실패 가능 — 구현 시 실제 라이브러리 로그 레벨 확인 후 spec 업데이트 권고 (advisor consult)
+- **참고**: 라이브러리 WARN 레벨 확인됨 — `ZooKeeperLeaderElector.kt:110-115`: `if (options.autoExtend) { log.warn { "ZooKeeper 는 TTL 이 없는 세션 기반 락 — autoExtend=true 설정이 무시됩니다..." } }`. R-1 위험 항목 무효화됨(퇴역). WARN 레벨 어설션이 정확함.
 
 #### T-T8: SessionLossFailoverTest — complexity: high
 - **파일**: `.../SessionLossFailoverTest.kt`
-- **내용**: 스펙 §5.4 T8 격리 컨테이너 패턴
-  - `@TestInstance(TestInstance.Lifecycle.PER_CLASS)`
-  - **격리된 ZK 인스턴스 사용** — `ZooKeeperServer.Launcher.zookeeper` 절대 사용 금지
+- **내용**: 클라이언트 측 세션 강제 종료로 R16 세션 만료 시나리오 시연
+  - **⚠️ STANDALONE class — does NOT extend AbstractLeaderZookeeperTest (H1)**:
+    `AbstractLeaderZookeeperTest`를 상속하면 싱글턴 `ZooKeeperServer.Launcher.zookeeper`가 companion을 통해 접근 가능해져 격리 보장이 깨짐 → standalone `@TestInstance(PER_CLASS)` 클래스로 구현
+  - **⚠️ NO container restart (T2-2/T6-2 CRITICAL fix)**:
+    `ZooKeeperServer(reuse=true)` default로 `stop()`/`start()`는 포트가 바뀌어 curator 클라이언트가 stale 상태가 됨. 컨테이너 재시작 대신 **클라이언트 측 세션 강제 종료** 사용.
   - fields:
     - `private lateinit var isolatedZk: ZooKeeperServer`
     - `private lateinit var clientA: CuratorFramework`
     - `private lateinit var clientB: CuratorFramework`
-  - `@BeforeAll fun startIsolatedZk()`: `ZooKeeperServer().also { it.start() }`; 2개 클라이언트 생성 (`ZooKeeperServer.Launcher.getCuratorFramework(isolatedZk)`) → 각각 `start()` + `blockUntilConnected(10, SECONDS)`
-  - `@AfterAll fun stopIsolatedZk()`: `runCatching { clientA.close() }`; `runCatching { clientB.close() }`; `runCatching { isolatedZk.stop() }`
-  - `@Test session expiry causes leadership failover`:
-    1. workerA: `clientA.runIfLeader(lockName, basePath = "/test/t8") { Thread.sleep(...) }` 또는 명시적 `InterProcessMutex` 획득
-    2. `isolatedZk.stop()` — 세션 만료 시뮬레이션
-    3. 일정 대기 (예: `Awaitility`로 ConnectionState.LOST 관측)
-    4. `isolatedZk.start()` — 재기동
-    5. workerB: `clientB.runIfLeader(lockName, ...) { "B-acquired" }` 성공 (Ephemeral 사라짐 → 경쟁자 자동 선출)
-    6. assert: workerB가 leadership 획득
-  - **타이밍**: ZK session 만료는 sessionTimeoutMs 기반 — 테스트용 `sessionTimeoutMs` 짧게 설정 (예: 3초) + `Awaitility.atMost(15.seconds)` 대기
-- **English KDoc**: T8 isolation 정당성 (싱글턴 파괴 방지); R16 시연 의도
-- **검증**: 통과; 타이밍 flake 시 Awaitility/timeout 조정
-- **의존**: T-TEST-BASE-1 (코드는 extends하지만 companion curator는 사용 안 함)
-- **참고**: 시간 정밀도 높음 — `@Tag("smoke")` 부여 후 `excludeTags("smoke")`로 기본 빌드에서 제외할지 결정 (DoD에서 "T8 통과 필수"이므로 기본 포함; CI가 flaky하면 spec 업데이트 후 smoke 처리)
+    - `fun randomLockName(prefix: String = "t8") = "$prefix:${UUID.randomUUID()}"` — AbstractLeaderZookeeperTest 미상속이므로 로컬 선언
+  - `@BeforeAll fun startIsolatedZk()`:
+    ```kotlin
+    @BeforeAll fun startIsolatedZk() {
+        isolatedZk = ZooKeeperServer(reuse = false).also { it.start() }  // reuse=false for controllable lifecycle
+        clientA = ZooKeeperServer.Launcher.getCuratorFramework(isolatedZk).also {
+            it.start()
+            check(it.blockUntilConnected(10, TimeUnit.SECONDS)) { "clientA connection timeout" }
+        }
+        clientB = ZooKeeperServer.Launcher.getCuratorFramework(isolatedZk).also {
+            it.start()
+            check(it.blockUntilConnected(10, TimeUnit.SECONDS)) { "clientB connection timeout" }
+        }
+    }
+    ```
+  - `@AfterAll fun stopIsolatedZk()`:
+    ```kotlin
+    @AfterAll fun stopIsolatedZk() {
+        runCatching { clientA.close() }
+        runCatching { clientB.close() }
+        runCatching { isolatedZk.stop() }
+    }
+    ```
+  - `@Test session loss causes leadership failover`:
+    ```kotlin
+    @Test fun `session loss causes leadership failover`() {
+        val lockName = randomLockName()
+        val workerAHoldingLatch = CountDownLatch(1)  // T5-2: ensure workerA HOLDS the lock before session close
+        val workerADoneLatch = CountDownLatch(1)
+        
+        // workerA acquires leadership in background thread
+        val workerAThread = Thread {
+            clientA.runIfLeader(lockName, basePath = "/test/t8") {
+                workerAHoldingLatch.countDown()  // signal: "I now hold the lock"
+                Thread.sleep(60_000)  // hold indefinitely until session closed
+                "A-done"
+            }
+            workerADoneLatch.countDown()
+        }
+        workerAThread.start()
+        
+        // Wait for workerA to hold the lock before proceeding
+        check(workerAHoldingLatch.await(10, TimeUnit.SECONDS)) { "workerA did not acquire leadership in time" }
+        
+        // Simulate session expiry by closing the underlying ZooKeeper client connection
+        // This forces Curator into LOST state and removes ephemeral nodes
+        clientA.zookeeperClient.zooKeeper.close()  // client-side session close — no container restart needed
+        
+        // workerB should eventually acquire leadership after workerA's session expires
+        var workerBResult: String? = null
+        await().atMost(Duration.ofSeconds(30)).untilAsserted {
+            workerBResult = clientB.runIfLeader(lockName, basePath = "/test/t8") { "B-acquired" }
+            workerBResult shouldBeEqualTo "B-acquired"
+        }
+        
+        workerAThread.interrupt()  // release workerA from sleep
+        workerADoneLatch.await(5, TimeUnit.SECONDS)
+    }
+    ```
+  - **타이밍**: ZK session 만료는 `sessionTimeoutMs` 기반 (기본 60초 → 너무 길면 테스트용 `sessionTimeoutMs=3000`으로 단축 가능). `Awaitility.await().atMost(30.seconds)` 사용.
+  - **Extension 함수 사용**: `clientA.runIfLeader(...)` — `ZooKeeperLeaderElectorExtensions.kt`의 extension 함수 사용 가능. 또는 `ZooKeeperLeaderElector(clientA, basePath, options).runIfLeader(lockName)` 직접 생성도 가능.
+- **English KDoc**: T8 isolation 정당성 (standalone, no AbstractLeaderZookeeperTest inheritance); R16 client-side session close approach vs container restart pitfall
+- **검증**: 통과; 타이밍 문제 시 `sessionTimeoutMs` 조정
+- **의존**: T-MOD-2 (Testcontainers), T-CFG-1 (elector type for extension function)
+- **참고**: `clientA.zookeeperClient.zooKeeper.close()`는 `org.apache.zookeeper.ZooKeeper` 직접 접근 — ZooKeeper 세션을 ZK 서버 측에서 종료시켜 Ephemeral Node 삭제를 트리거. 이는 네트워크 파티션/프로세스 크래시 시나리오와 동일한 결과를 만듦.
+
+#### T-T9: LeaderZookeeperPropertiesValidationTest — complexity: low
+- **파일**: `.../LeaderZookeeperPropertiesValidationTest.kt`
+- **내용**: CLAUDE.md "Parameter validation tasks present" 체크 — `requireNotBlank`/`requirePositiveNumber` 검증
+  - extends `AbstractLeaderZookeeperTest` (ZK 컨테이너 불필요하지만 base 클래스 컨벤션 유지, 또는 독립 클래스)
+  - `@Test blank basePath throws IllegalArgumentException`:
+    ```kotlin
+    assertFailsWith<IllegalArgumentException> {
+        LeaderZookeeperProperties(basePath = "")
+    }
+    ```
+  - `@Test zero groupMaxLeaders throws IllegalArgumentException`:
+    ```kotlin
+    assertFailsWith<IllegalArgumentException> {
+        LeaderZookeeperProperties(groupMaxLeaders = 0)
+    }
+    ```
+  - `@Test blank connectString throws IllegalArgumentException`:
+    ```kotlin
+    assertFailsWith<IllegalArgumentException> {
+        LeaderZookeeperProperties(zookeeper = LeaderZookeeperProperties.ZooKeeperConfig(connectString = ""))
+    }
+    ```
+- **English KDoc**: T9 목적 (parameter validation contract verification)
+- **검증**: 통과
+- **의존**: T-PROPS-1
 
 ### Phase 4 — 문서
 
@@ -403,6 +533,7 @@ Apache Curator 기반 `bluetape4k-leader-zookeeper:0.2.1` 라이브러리를 워
   6. **Production Considerations**: ACL/TLS/SASL 권장사항 + sessionTimeoutMs 튜닝
   7. **Dependency instructions**: 카탈로그 alias 사용법, BOM 참조
   8. Cross-link: `leader/leader-election/` (Redis 비교)
+  9. **Spring Boot compatibility**: "Verified with Spring Boot 4.0.6. Spring Boot 3.x users must update `spring.factories` / `AutoConfiguration.imports` paths." — explicit compat statement required in README header.
 - **검증**: `git diff --check`, README 컨텐츠 영문 일관성 (CLAUDE.md 정책)
 - **의존**: T-MOD-1 (모듈 디렉터리 존재)
 
@@ -414,6 +545,18 @@ Apache Curator 기반 `bluetape4k-leader-zookeeper:0.2.1` 라이브러리를 워
 - **검증**: README.md와 섹션 1:1 대응 확인
 - **의존**: T-DOC-1
 
+#### T-DOC-3: docs/lessons 문서 작성 — complexity: low
+- **파일**: `docs/lessons/2026-05-25-leader-zookeeper.md` (feature worktree 내부, 브랜치에 커밋)
+- **내용** (Korean OK per CLAUDE.md `docs/lessons/` 언어 정책):
+  - R16 계약 시연 및 `autoExtend=true` WARN 처리
+  - `AbstractLeaderZookeeperTest` 단일 shared curator 패턴 (InterProcessMutex Thread-keyed 근거)
+  - T8: 클라이언트 측 세션 강제 종료 방식 채택 이유 (컨테이너 재시작 포트 문제)
+  - T4/T5 CountDownLatch 핸드쉐이크 패턴 (MultithreadingTester.run() blocking)
+  - T7 ListAppender 패턴: `detachAppender()` 필수 이유
+  - T-T6 extension function `options` vs `groupOptions` 오류 사례
+- **검증**: 파일 커밋 완료 (`git log` 확인)
+- **의존**: T-VRF-1 (구현 완료 후 작성)
+
 ### Phase 5 — 검증 (DoD)
 
 #### T-VRF-1: 전체 테스트 실행 + DoD 체크 — complexity: medium
@@ -423,7 +566,7 @@ Apache Curator 기반 `bluetape4k-leader-zookeeper:0.2.1` 라이브러리를 워
   ./gradlew :leader:leader-zookeeper:test
   ```
 - **DoD 통과 기준** (스펙 §7):
-  - [ ] T0~T8 9개 테스트 모두 통과
+  - [ ] T0~T9 10개 테스트 모두 통과 (T9: LeaderZookeeperPropertiesValidationTest 포함)
   - [ ] `compileKotlin` 0 errors, 0 unresolved deprecation
   - [ ] IDE diagnostics 0 errors (해당 시 `ide_diagnostics` 결과 첨부)
   - [ ] HIGH/CRITICAL code review 0 (`/oh-my-claudecode:code-reviewer` 실행)
@@ -432,7 +575,7 @@ Apache Curator 기반 `bluetape4k-leader-zookeeper:0.2.1` 라이브러리를 워
   - [ ] T4/T5 CountDownLatch 핸드쉐이크 + `peakConcurrent` 검증
   - [ ] T7 Logback ListAppender WARN 캡처
   - [ ] T8 세션 만료 시나리오 통과
-  - [ ] `@Scheduled` wrapper CancellationException 재throw 적용 (SVC-2, SVC-4)
+  - [ ] `@Scheduled` wrapper CancellationException 재throw 적용 (SVC-2, SVC-4) — 직접 호출 시 CancellationException 전파 확인 (단위 테스트)
 - **의존**: T-T0~T-T8, T-DOC-1, T-DOC-2
 
 #### T-VRF-2: 코드 리뷰 — complexity: medium
@@ -501,11 +644,13 @@ T-CAT-1 ─┐
 | 20 | T-T5 | high | Suspend Group |
 | 21 | T-T6 | medium | Extension 함수 |
 | 22 | T-T7 | high | Logback ListAppender (R16 WARN) |
-| 23 | T-T8 | high | 격리 ZK 컨테이너, 세션 만료 |
-| 24 | T-DOC-1 | medium | README.md (영) |
-| 25 | T-DOC-2 | low | README.ko.md |
-| 26 | T-VRF-1 | medium | DoD 체크 |
-| 27 | T-VRF-2 | medium | code-reviewer HIGH/CRITICAL 0 |
+| 23 | T-T8 | high | 격리 ZK 컨테이너, 세션 만료 (클라이언트 측 세션 강제 종료) |
+| 24 | T-T9 | low | Properties 검증 (requireNotBlank, requirePositiveNumber) |
+| 25 | T-DOC-1 | medium | README.md (영) |
+| 26 | T-DOC-2 | low | README.ko.md |
+| 27 | T-DOC-3 | low | docs/lessons 문서 |
+| 28 | T-VRF-1 | medium | DoD 체크 |
+| 29 | T-VRF-2 | medium | code-reviewer HIGH/CRITICAL 0 |
 
 ---
 
@@ -513,9 +658,9 @@ T-CAT-1 ─┐
 
 | ID | 위험 | 대응 |
 |---|---|---|
-| R-1 | T7 WARN 로그 캡처 실패 (실제 로그 레벨이 INFO일 가능성) | 구현 후 라이브러리 실제 로그 확인; 다를 경우 spec 업데이트 advisor 호출 |
+| R-1 | ~~T7 WARN 로그 캡처 실패~~ | **퇴역** — 라이브러리 소스 확인: `ZooKeeperLeaderElector.kt:110-115` WARN 레벨 확인. Korean 메시지에 ASCII `autoExtend` 포함 확인. |
 | R-2 | T6 라이브러리 extension 함수 시그니처 변경 (basePath default) | 컴파일 에러 시 라이브러리 소스 조회 후 인자 명시 |
-| R-3 | T8 세션 만료 타이밍 flake (CI 환경) | `sessionTimeoutMs=3000`, `Awaitility.atMost(15.seconds)` 시작값; flake 시 `@Tag("smoke")` 부여 검토 |
+| R-3 | T8 세션 만료 타이밍 (CI 환경) | `sessionTimeoutMs=3000` (테스트용 단축), `Awaitility.atMost(30.seconds)` 사용. 클라이언트 측 세션 강제 종료 방식 채택으로 포트 remapping 문제 제거됨. |
 | R-4 | `bluetape4k-leader-zookeeper` BOM 미포함 (1.1.3 검증) | T-CAT-1 직후 `./gradlew :leader:leader-zookeeper:dependencies` 로 0.2.1 해석 확인 |
 | R-5 | T-T0 `@DynamicPropertySource` 와 nested `zookeeper.connect-string` 바인딩 | 키는 `leader.zookeeper.zookeeper.connect-string` (이중 zookeeper) — application.yml과 동일 구조 |
 | R-6 | T7 ListAppender가 `logback-test.xml`의 ROOT logger 설정과 충돌 | `addAppender`만 사용하고 ROOT level 변경 금지; `@AfterEach`에서 반드시 `detachAppender` |

--- a/docs/superpowers/specs/2026-05-25-leader-zookeeper-design.md
+++ b/docs/superpowers/specs/2026-05-25-leader-zookeeper-design.md
@@ -1,0 +1,467 @@
+# leader/leader-zookeeper 워크숍 모듈 설계 스펙
+
+> 작성일: 2026-05-25  
+> 작업 브랜치: feat/leader-zookeeper  
+> 관련 이슈: #10 (bluetape4k-leader 예제 제작 Epic) — PR-B
+
+---
+
+## 1. 요약
+
+Apache Curator 기반 `bluetape4k-leader-zookeeper` 라이브러리를 활용한 분산 리더 선출 워크숍 예제 모듈을 신규 생성한다.
+기존 `leader/leader-election/` 모듈 (Lettuce/Redis 기반)과 동일한 Spring Boot 앱 구조를 따르면서,
+ZooKeeper 고유 특성(R16: 세션 기반, TTL 없음)을 명시적으로 시연하는 교육용 코드를 제공한다.
+
+---
+
+## 2. 배경 및 제약 사항
+
+### 2.1 라이브러리 가용성
+- `bluetape4k-leader-zookeeper:0.2.1` Maven Central 게시 확인 ✅
+- `bluetape4k-dependencies 1.1.3` BOM 포함 → 버전은 BOM 관리, 카탈로그에 버전 핀 금지
+- 워크숍 `gradle/libs.versions.toml`에 `bluetape4k-leader-zookeeper` alias 미등록 → **추가 필요**
+
+### 2.2 R16 — ZooKeeper has no TTL
+ZooKeeper는 세션 기반 Ephemeral Node를 사용한다. TTL 개념이 없으므로:
+- `LeaderElectionOptions.autoExtend = true` 설정 시 WARN 로그 후 무시
+- `LeaderLeaseAutoExtender`는 항상 `enabled=false`로 강제 실행
+- 모듈 설계에서 `leaseTime`/`autoExtend` 프로퍼티를 **의도적으로 노출하지 않음**
+
+### 2.3 의존 스택
+| 항목 | 값 |
+|---|---|
+| Kotlin | 2.3.21 |
+| Java | 25 (ZGC, `--enable-preview`) |
+| Spring Boot | 4.0.x |
+| bluetape4k-leader-zookeeper | 0.2.1 (BOM 관리) |
+| Apache Curator | 5.9.0 (transitive via leader-zookeeper) |
+| ZooKeeper Docker image | zookeeper:3.9 |
+| Testcontainer launcher | `ZooKeeperServer.Launcher.zookeeper` |
+
+---
+
+## 3. 설계 접근 방식
+
+### 3.1 비교 검토 (Brainstorming)
+
+**Option A: 단일 통합 서비스 (거절)**  
+모든 Elector를 하나의 서비스에서 노출하는 패턴.  
+- 장점: 파일 수 감소  
+- 단점: 각 Elector 타입별 API 차이(`suspend` vs blocking, group vs single)가 희석되어 교육 가치 손실. 거절.
+
+**Option B: 4개 전용 서비스 (채택)**  
+`ZooKeeperLeaderElector`, `ZooKeeperSuspendLeaderElector`, `ZooKeeperLeaderGroupElector`, `ZooKeeperSuspendLeaderGroupElector` 각각에 전용 서비스를 배치.  
+- 장점: API 타입별 특성을 명확히 시연; 각 서비스가 1가지 패턴에 집중  
+- 단점: 4개 서비스 파일 → 보일러플레이트 증가  
+- 결론: 워크숍 목적(展示)에 최적. **채택.**
+
+**Option C: ListeningLeaderElector 포함 (거절)**  
+`ListeningLeaderElector` 래퍼를 ZK 모듈에 포함.  
+- 라이브러리가 ZK 리스너 래퍼를 제공하지 않음. `leader-election`(Redis)에서만 가능. 거절. README에서 크로스링크만 제공.
+
+### 3.2 설계 위험 요소
+
+| 위험 | 설명 | 대응 |
+|---|---|---|
+| Curator thread-owner constraint | InterProcessMutex는 acquire/release가 **같은 스레드**여야 함 | `ZooKeeperSuspendLeaderElector`는 per-call single-thread dispatcher 사용 (라이브러리 내부에서 처리) |
+| 동시성 테스트 CuratorFramework 공유 | **InterProcessMutex는 Thread ID 기반 소유권** (ZK session ID 기반 아님). 따라서 하나의 CuratorFramework를 다른 스레드/코루틴에서 공유해도 상호 경쟁 정상 작동. 라이브러리 자체 `AbstractZooKeeperLeaderTest`도 단일 `curator` 공유 확인. | 테스트 기반 클래스에서 `companion object val curator by lazy { ... }` 단일 인스턴스 사용 (불필요한 per-worker 연결 생성 금지) |
+| blockUntilConnected 실패 시 리소스 누수 | `curator.start()` 호출 후 `blockUntilConnected` 실패 시 JVM에 background thread가 잔류할 수 있음 | timeout 전에 `client.close()` 명시적 호출 후 예외 throw |
+| ZK 세션 만료 (R16 핵심) | 세션 만료 시 Ephemeral Node가 사라지고 경쟁자가 자동 선출됨. `SUSPENDED`/`LOST` 상태에서 진행 중인 작업은 stale leadership 상태가 될 수 있음 | `ConnectionStateListener` 등록으로 SUSPENDED/LOST 상태 로깅 (교육 목적); T8 세션 손실 시나리오 테스트로 시연 |
+| ZK 연결 타임아웃 | 테스트 컨테이너 시작 지연 | `blockUntilConnected(10, SECONDS)` 사용; `ZooKeeperServer.Launcher` 싱글턴이 JVM 시작 시 한 번만 초기화 |
+| R16 autoExtend 노출 | 프로퍼티에 노출 시 사용자 혼란 | Properties 클래스에 필드 미선언; README R16 callout 명시 |
+
+---
+
+## 4. 모듈 구조
+
+```
+leader/leader-zookeeper/
+├── build.gradle.kts
+├── README.md
+├── README.ko.md
+└── src/
+    ├── main/
+    │   ├── kotlin/io/bluetape4k/workshop/leader/zookeeper/
+    │   │   ├── LeaderZookeeperApp.kt
+    │   │   ├── config/
+    │   │   │   ├── LeaderZookeeperProperties.kt
+    │   │   │   └── LeaderZookeeperConfig.kt
+    │   │   └── service/
+    │   │       ├── BlockingLeaderService.kt
+    │   │       ├── SuspendLeaderZkService.kt
+    │   │       ├── GroupLeaderService.kt
+    │   │       └── SuspendGroupLeaderService.kt
+    │   └── resources/
+    │       ├── application.yml
+    │       └── logback-spring.xml
+    └── test/
+        ├── kotlin/io/bluetape4k/workshop/leader/zookeeper/
+        │   ├── AbstractLeaderZookeeperTest.kt
+        │   ├── LeaderZookeeperContextTest.kt         (T0 - Spring context)
+        │   ├── BlockingSingleLeaderTest.kt            (T1 - runIfLeader + runAsyncIfLeader)
+        │   ├── ConcurrentBlockingLeaderTest.kt        (T2)
+        │   ├── SuspendSingleLeaderTest.kt             (T3)
+        │   ├── GroupLeaderTest.kt                     (T4)
+        │   ├── SuspendGroupLeaderTest.kt              (T5)
+        │   ├── ExtensionFunctionTest.kt               (T6)
+        │   ├── R16AutoExtendIgnoredTest.kt            (T7)
+        │   └── SessionLossFailoverTest.kt             (T8 - R16 session expiry demo)
+        └── resources/
+            ├── junit-platform.properties
+            └── logback-test.xml
+```
+
+---
+
+## 5. 컴포넌트 상세 설계
+
+### 5.1 LeaderZookeeperProperties
+
+```kotlin
+/**
+ * Configuration properties for the ZooKeeper-based leader election workshop module.
+ *
+ * ## Behavior / Contract (R16 — ZooKeeper has no TTL)
+ * ZooKeeper uses session-bound ephemeral znodes for leader election.
+ * Unlike Redis-based election:
+ * - There is no lease TTL; leadership is held until the ZooKeeper session expires or is explicitly closed.
+ * - `leaseTime` and `autoExtend` are intentionally absent from this class.
+ *   Setting `LeaderElectionOptions.autoExtend = true` emits a WARN log and is silently ignored.
+ * - Session expiry (e.g., due to network partition or process crash) automatically removes
+ *   the ephemeral election node, triggering re-election among competing candidates.
+ * - Tune [ZooKeeperConfig.sessionTimeoutMs] relative to your job interval for acceptable failover latency.
+ *
+ * ## Production Considerations
+ * - Default [ZooKeeperConfig.connectString] is `localhost:2181` (development only).
+ * - Default [ZooKeeperConfig.sessionTimeoutMs] is 60 000 ms — the failover window on hard crash.
+ * - ACL and TLS are omitted in this workshop; production deployments should configure an ACLProvider
+ *   and SASL/TLS via `CuratorFrameworkFactory.builder()`.
+ */
+@ConfigurationProperties(prefix = "leader.zookeeper")
+data class LeaderZookeeperProperties(
+    val zookeeper: ZooKeeperConfig = ZooKeeperConfig(),
+    val basePath: String = "/workshop/leader-zookeeper",
+    val waitTime: java.time.Duration = java.time.Duration.ofSeconds(2),
+    val groupMaxLeaders: Int = 2,
+    val jobFixedDelay: String = "PT10S",
+    val suspendJobFixedDelay: String = "PT12S",
+    val groupJobFixedDelay: String = "PT15S",
+    val suspendGroupJobFixedDelay: String = "PT18S",
+    // NOTE: leaseTime / autoExtend intentionally absent — R16: ZooKeeper has no TTL
+) : Serializable {
+    companion object : KLogging() {
+        private const val serialVersionUID = 1L
+    }
+    init {
+        basePath.requireNotBlank("basePath")
+        groupMaxLeaders.requirePositiveNumber("groupMaxLeaders")
+    }
+    
+    data class ZooKeeperConfig(
+        val connectString: String = "localhost:2181",
+        val sessionTimeoutMs: Int = 60_000,
+        val connectionTimeoutMs: Int = 15_000,
+        val blockUntilConnectedSeconds: Long = 10,
+    ) : Serializable {
+        companion object { private const val serialVersionUID = 1L }
+        init { connectString.requireNotBlank("connectString") }
+    }
+}
+```
+
+> **R16**: `leaseTime`, `autoExtend` 필드 없음 — ZK는 TTL 없는 세션 기반.  
+> KDoc의 `## Behavior / Contract` 섹션이 R16 계약을 API 사용자에게 명시함.
+
+### 5.2 LeaderZookeeperConfig
+
+CuratorFramework 빈의 destroy method는 `"close"` (CuratorFramework implements Closeable).
+
+**주의 (C2)**: `start()` 호출 후 `blockUntilConnected` 실패 시 반드시 `close()` 명시적 호출 후 throw.
+Spring `destroyMethod`는 빈 등록 성공 시에만 호출되므로 팩토리 내에서 실패 경로를 직접 처리해야 함.
+
+```kotlin
+@Bean(destroyMethod = "close")
+fun curatorFramework(props: LeaderZookeeperProperties): CuratorFramework {
+    val cfg = props.zookeeper
+    val client = CuratorFrameworkFactory.newClient(
+        cfg.connectString,
+        cfg.sessionTimeoutMs,
+        cfg.connectionTimeoutMs,
+        ExponentialBackoffRetry(1000, 3)
+    )
+    client.start()
+    // Add a ConnectionStateListener to observe SUSPENDED / LOST for operational awareness
+    client.connectionStateListenable.addListener { _, newState ->
+        when (newState) {
+            ConnectionState.SUSPENDED -> log.warn { "ZooKeeper connection SUSPENDED — leadership uncertain" }
+            ConnectionState.LOST -> log.error { "ZooKeeper session LOST — ephemeral nodes removed; re-election will occur" }
+            ConnectionState.RECONNECTED -> log.info { "ZooKeeper session RECONNECTED" }
+            else -> log.debug { "ZooKeeper connection state: $newState" }
+        }
+    }
+    if (!client.blockUntilConnected(cfg.blockUntilConnectedSeconds, TimeUnit.SECONDS)) {
+        client.close()  // explicit close to prevent background thread leak
+        error("ZooKeeper connection timeout after ${cfg.blockUntilConnectedSeconds}s (connectString=${cfg.connectString}). " +
+              "Check that ZooKeeper is running and accessible.")
+    }
+    return client
+    // NOTE: OPEN_ACL_UNSAFE default — production deployments should use
+    // CuratorFrameworkFactory.builder().aclProvider(DigestACLProvider(...)) for access control.
+}
+```
+```
+
+basePath 분리:
+- single: `${basePath}/single`
+- single-suspend: `${basePath}/single-suspend`
+- group: `${basePath}/group`
+- group-suspend: `${basePath}/group-suspend`
+
+### 5.3 Services
+
+각 서비스 공통 패턴:
+- `companion object : KLogging()` (coroutine 서비스는 `KLoggingChannel()`)
+- `executionCount: AtomicInteger` for test verification
+- `@Scheduled(fixedDelayString = "...")` entry point
+- runBlocking은 coroutine 서비스의 `@Scheduled` 진입점에서만 사용
+
+#### BlockingLeaderService
+```kotlin
+@Service
+class BlockingLeaderService(
+    private val elector: ZooKeeperLeaderElector,
+    private val props: LeaderZookeeperProperties,
+) {
+    companion object : KLogging()
+    val executionCount = AtomicInteger()
+    
+    fun runLeaderWork(lockName: String = "workshop:blocking-job"): String? =
+        elector.runIfLeader(lockName) {
+            executionCount.incrementAndGet()
+            log.debug { "[LEADER] BlockingLeaderService running work" }
+            "done"
+        }.also {
+            if (it == null) log.debug { "[SKIPPED] BlockingLeaderService not the elected leader" }
+        }
+    
+    @Scheduled(fixedDelayString = "\${leader.zookeeper.job-fixed-delay:PT10S}")
+    fun runScheduled() {
+        try {
+            runLeaderWork()
+        } catch (e: Exception) {
+            log.warn(e) { "Scheduled leader work failed" }
+        }
+    }
+}
+```
+
+#### SuspendLeaderZkService
+- `KLoggingChannel()` companion
+- `suspend fun runLeaderWork(lockName: String): String?`
+- `@Scheduled` 진입점은 반드시 `CancellationException` 재throw 포함:
+```kotlin
+@Scheduled(fixedDelayString = "\${leader.zookeeper.suspend-job-fixed-delay:PT12S}")
+fun runScheduled() {
+    try {
+        runBlocking { runLeaderWork() }
+    } catch (e: CancellationException) {
+        throw e  // MUST rethrow — CLAUDE.md: never swallow CancellationException
+    } catch (e: Exception) {
+        log.warn(e) { "Scheduled suspend leader work failed" }
+    }
+}
+```
+
+#### GroupLeaderService
+- `ZooKeeperLeaderGroupElector` 주입
+- `inspectState(lockName): LeaderGroupState` — 테스트에서 `activeCount`/`availableSlots` 검증에 활용
+- `@Scheduled` wrapper: `try { runLeaderWork() } catch (e: Exception) { log.warn(e) { "Scheduled group leader work failed" } }`
+
+#### SuspendGroupLeaderService
+- `ZooKeeperSuspendLeaderGroupElector` 주입
+- suspend version
+- `@Scheduled` wrapper: 반드시 `CancellationException` rethrow 포함 (SuspendLeaderZkService와 동일 패턴)
+
+### 5.4 AbstractLeaderZookeeperTest
+
+**설계 근거**: `InterProcessMutex`는 ZK session ID가 아닌 `Thread.currentThread()`를 소유권 키로 사용한다.
+따라서 여러 스레드/코루틴이 동일한 `CuratorFramework`를 공유해도 상호 배제가 정상 작동한다.
+라이브러리 자체 `AbstractZooKeeperLeaderTest`도 단일 `companion object val curator by lazy {...}` 패턴을 사용함.
+→ per-call `newCurator()` 팩토리는 불필요한 ZK 세션/스레드풀 생성이므로 사용 금지.
+
+```kotlin
+/**
+ * Abstract base for library-lane ZooKeeper leader election tests.
+ *
+ * Uses a single shared [CuratorFramework] in the companion object (initialized lazily once per JVM).
+ * InterProcessMutex ownership is keyed on Thread, not ZooKeeper session, so all workers
+ * competing via the same [curator] instance will correctly contend for the lock.
+ *
+ * Lazy initialization ensures the ZooKeeper container is started before the first test accesses it.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+abstract class AbstractLeaderZookeeperTest {
+    companion object : KLogging() {
+        val zookeeper: ZooKeeperServer = ZooKeeperServer.Launcher.zookeeper
+        
+        /** Shared CuratorFramework — safe to share across threads/coroutines (InterProcessMutex is Thread-keyed). */
+        val curator: CuratorFramework by lazy {
+            ZooKeeperServer.Launcher.getCuratorFramework(zookeeper).also {
+                it.start()
+                it.blockUntilConnected(10, TimeUnit.SECONDS)
+                ShutdownQueue.register { it.close() }
+            }
+        }
+    }
+    
+    // waitTime = 500ms: provides margin for CI timing jitter (200ms was too tight)
+    fun newElector(basePath: String = "/test/single") =
+        ZooKeeperLeaderElector(curator, basePath, LeaderElectionOptions(waitTime = 500.milliseconds))
+    
+    fun newSuspendElector(basePath: String = "/test/single-suspend") =
+        ZooKeeperSuspendLeaderElector(curator, basePath, LeaderElectionOptions(waitTime = 500.milliseconds))
+    
+    fun newGroupElector(maxLeaders: Int = 2, basePath: String = "/test/group") =
+        ZooKeeperLeaderGroupElector(curator, LeaderGroupElectionOptions(maxLeaders, waitTime = 500.milliseconds), basePath)
+    
+    fun newSuspendGroupElector(maxLeaders: Int = 2, basePath: String = "/test/group-suspend") =
+        ZooKeeperSuspendLeaderGroupElector(curator, LeaderGroupElectionOptions(maxLeaders, waitTime = 500.milliseconds), basePath)
+    
+    fun randomLockName(prefix: String = "t") = "$prefix:${UUID.randomUUID()}"
+}
+```
+
+**T8 `SessionLossFailoverTest`용 독립 curator**: 세션 만료 시나리오(T8)에서는 ZK 컨테이너를 일시 중단하므로
+별도의 독립 `CuratorFramework` 인스턴스를 사용해야 한다. T8 테스트 클래스에서 `newIndependentCurator()` 헬퍼 제공:
+```kotlin
+// Used only in T8 — T8 needs an isolated session to simulate expiry
+fun newIndependentCurator(): CuratorFramework =
+    ZooKeeperServer.Launcher.getCuratorFramework(zookeeper).also {
+        it.start()
+        it.blockUntilConnected(10, TimeUnit.SECONDS)
+        // Caller is responsible for close() in @AfterEach
+    }
+```
+
+### 5.5 테스트 커버리지 매트릭스
+
+| ID | 테스트 클래스 | 커버 사항 | 핵심 assertion |
+|---|---|---|---|
+| T0 | LeaderZookeeperContextTest | Spring 빈 와이어링 | 4 elector beans + 4 service beans not null |
+| T1 | BlockingSingleLeaderTest | `runIfLeader` 단일 실행 + `runAsyncIfLeader` CompletableFuture | `runIfLeader` result == "done"; `runAsyncIfLeader` future.join() == 42 |
+| T2 | ConcurrentBlockingLeaderTest | 8-worker `MultithreadingTester`, shared curator, peakConcurrent ≤ 1 | `peakConcurrent.get() shouldBeLessOrEqualTo 1`; `executed.get() > 0` |
+| T3 | SuspendSingleLeaderTest | `SuspendedJobTester` 8-coroutine 경쟁, shared curator | exactly 1 winner per lock round; `peakConcurrent ≤ 1` |
+| T4 | GroupLeaderTest | `maxLeaders=2`, `MultithreadingTester` 4-worker, shared curator | action body calls `Thread.sleep(600ms)` (> waitTime=500ms) to hold slot; `CountDownLatch(maxLeaders)` entered before sampling; `peakConcurrent.get() shouldBeEqualTo 2` |
+| T5 | SuspendGroupLeaderTest | `SuspendedJobTester` 4-coroutine group | same as T4 with `delay(600.milliseconds)`; `CountDownLatch` + `peakConcurrent == 2` |
+| T6 | ExtensionFunctionTest | `CuratorFramework` extension functions: `leaderElector(basePath)`, `suspendLeaderElector(basePath)`, `leaderGroupElector(basePath, options)`, `suspendLeaderGroupElector(basePath, options)` | each extension returns non-null elector; `runIfLeader` / `suspend runIfLeader` returns result successfully |
+| T7 | R16AutoExtendIgnoredTest | `LeaderElectionOptions(autoExtend=true)` 전달 시 WARN 발생 + action 정상 실행 | Logback `ListAppender<ILoggingEvent>` attached to `io.bluetape4k.leader.zookeeper` logger; assert `appender.list.any { it.level == Level.WARN && "autoExtend" in it.message }`; action result == "r16-done" |
+| T8 | SessionLossFailoverTest | R16 세션 만료 시 Ephemeral Node 소멸 + 경쟁자 자동 선출 | workerA acquires leadership via `newIndependentCurator()`; ZK Testcontainer restarted (or session forcibly closed); workerB (separate curator) acquires within `sessionTimeoutMs + waitTime`; assert workerB result non-null |
+
+**T4/T5 CountDownLatch 패턴 (6T1 해결)**:
+```kotlin
+// T4 GroupLeaderTest 핵심 패턴
+val enteredLatch = CountDownLatch(maxLeaders)  // 2 workers entered simultaneously
+val releaseLatch = CountDownLatch(1)            // signal to release all
+val peakConcurrent = AtomicInteger(0)
+val current = AtomicInteger(0)
+
+MultithreadingTester().workers(4).add {
+    groupElector.runIfLeader(lockName) {
+        val c = current.incrementAndGet()
+        peakConcurrent.updateAndGet { max(it, c) }
+        enteredLatch.countDown()
+        releaseLatch.await(3, TimeUnit.SECONDS)  // hold slot while sampling
+        current.decrementAndGet()
+    }
+}
+// Sampling happens INSIDE the action, not after MultithreadingTester.run() completes.
+// Assert: peakConcurrent.get() shouldBeEqualTo maxLeaders
+```
+
+**T7 Logback ListAppender 패턴 (D4/6T2 해결)**:
+```kotlin
+// T7 R16AutoExtendIgnoredTest
+@BeforeEach
+fun setupLogCapture() {
+    val logger = LoggerFactory.getLogger("io.bluetape4k.leader.zookeeper") as ch.qos.logback.classic.Logger
+    appender = ListAppender<ILoggingEvent>().also { it.start() }
+    logger.addAppender(appender)
+}
+@AfterEach fun teardownLogCapture() { appender.stop() }
+
+@Test fun `autoExtend option is silently ignored with WARN log`() {
+    val elector = ZooKeeperLeaderElector(
+        curator, "/test/r16",
+        LeaderElectionOptions(autoExtend = true, waitTime = 500.milliseconds)
+    )
+    val result = elector.runIfLeader(randomLockName()) { "r16-done" }
+    result shouldBeEqualTo "r16-done"
+    val warnEvents = appender.list.filter { it.level == Level.WARN && "autoExtend" in it.formattedMessage }
+    warnEvents shouldHaveSize 1  // exactly 1 WARN emitted on construction/first use
+}
+```
+
+---
+
+## 6. 카탈로그 변경사항
+
+`gradle/libs.versions.toml` line 208 이후에 추가:
+```toml
+bluetape4k-leader-zookeeper = { module = "io.github.bluetape4k.leader:bluetape4k-leader-zookeeper" }
+```
+
+버전은 `bluetape4k-dependencies` BOM 1.1.3이 관리. 별도 버전 핀 금지.
+
+---
+
+## 7. DoD (Definition of Done)
+
+- [ ] 모든 9개 테스트 (T0~T8) 통과
+- [ ] `./gradlew :leader:leader-zookeeper:compileKotlin` 오류 없음
+- [ ] IDE diagnostics 0 errors
+- [ ] Step 6-R Tier 1-6 code review 완료; HIGH/CRITICAL 0
+- [ ] README.md (영어) + README.ko.md 작성 완료
+  - [ ] `## R16 — ZooKeeper has no TTL` callout 포함
+  - [ ] Single-leader (`runIfLeader`) 와 group-leader (`maxLeaders=2`) side-by-side 코드 예제 포함
+  - [ ] ACL/TLS `## Production Considerations` 섹션 포함
+- [ ] English KDoc on all public classes/services/config
+  - [ ] `LeaderZookeeperProperties`: R16 `## Behavior / Contract` KDoc ✅ (§5.1에 설계됨)
+  - [ ] `LeaderZookeeperConfig.curatorFramework`: ConnectionStateListener + ACL 주석 ✅ (§5.2에 설계됨)
+  - [ ] 4개 service 클래스 English KDoc
+- [ ] T4/T5 `CountDownLatch` 핸드쉐이크 패턴으로 `peakConcurrent` 검증 ✅ (§5.5에 설계됨)
+- [ ] T7 Logback `ListAppender` WARN 로그 캡처 ✅ (§5.5에 설계됨)
+- [ ] T8 세션 만료 → Ephemeral Node 소멸 → 경쟁자 선출 시나리오 시연 ✅ (§5.5에 설계됨)
+- [ ] `@Scheduled` wrapper에 `CancellationException` rethrow ✅ (§5.3에 설계됨)
+
+---
+
+## Appendix: 리뷰 이터레이션 로그
+
+| Round | Reviewer | CRITICAL/HIGH/MEDIUM/LOW | 적용 Commit |
+|---|---|---|---|
+| 1 | 6-tier advisor | 0/2/4/2 | - |
+| 1 | User/Caller perspective | 0/3/2/0 | - |
+| 1 | Developer perspective (a2babd54) | 0/2/3/0 | - |
+| 1 | Developer perspective (a4a5456) | 0/2/3/0 → CRITICAL C1/C2 발굴 | - |
+| 1 | Security perspective | 0/0/2/1 | - |
+| 1 | Ops/SRE perspective | 0/3/3/0 | - |
+| 1 | Phase-2 Opus Critic | 통합: 0/10/8/1 → disposition 후 0/9/8/1 | - |
+| 1 | 통합 적용 후 최종 | D1 reject(라이브러리 증거), 나머지 HIGH 모두 spec에 반영 | (pending commit) |
+
+**Round 1 주요 발견 및 해결:**
+
+| ID | 심각도 | 내용 | 해결 방법 |
+|---|---|---|---|
+| D1 | HIGH → **REJECT** | per-worker 독립 CuratorFramework 필요 주장 | 라이브러리 소스 확인: InterProcessMutex는 Thread-keyed. 단일 shared curator 사용으로 수정 (§5.4) |
+| C1 | CRITICAL | `newCurator()` per-call 팩토리가 JVM 종료까지 연결 누수 | §5.4: companion object `curator by lazy` 패턴으로 교체 |
+| C2 | CRITICAL | `blockUntilConnected` 실패 시 `start()`된 client 누수 | §5.2: `client.close()` 명시적 호출 후 throw |
+| D2 | HIGH | Korean log messages (CLAUDE.md 위반) | §5.3: 모든 로그 English로 수정 |
+| O6 | HIGH | `@Scheduled` wrapper에서 CancellationException 삼킴 | §5.3: SuspendLeaderZkService + SuspendGroupLeaderService에 rethrow 추가 |
+| U1 | HIGH | LeaderZookeeperProperties R16 KDoc 없음 | §5.1: `## Behavior / Contract` KDoc 추가 |
+| O2 | HIGH→MEDIUM | ConnectionStateListener 없음 | §5.2: SUSPENDED/LOST/RECONNECTED 로깅 리스너 추가 (교육 목적) |
+| 6T1 | HIGH | T4/T5 activeCount peak 검증 race condition | §5.5: CountDownLatch 핸드쉐이크 패턴 명시 |
+| D4/6T2 | HIGH | T7 WARN log 캡처 메커니즘 미정의 | §5.5: Logback ListAppender 패턴 명시 |
+| O1 | HIGH | 세션 만료 시나리오 미테스트 | §5.5: T8 `SessionLossFailoverTest` 추가 |
+| U4/T1 | HIGH | `runAsyncIfLeader` 미커버 | §5.5 T1: `runAsyncIfLeader` CompletableFuture 검증 추가 |
+| 6T6 | HIGH | T6 extension 함수 범위 미정의 | §5.5 T6: 4개 extension 함수 명시적 열거 |
+| U2 | HIGH | README side-by-side 예제 미정의 | §7 DoD: README 요구사항에 명시 |

--- a/docs/superpowers/specs/2026-05-25-leader-zookeeper-design.md
+++ b/docs/superpowers/specs/2026-05-25-leader-zookeeper-design.md
@@ -308,7 +308,9 @@ abstract class AbstractLeaderZookeeperTest {
         val curator: CuratorFramework by lazy {
             ZooKeeperServer.Launcher.getCuratorFramework(zookeeper).also {
                 it.start()
-                it.blockUntilConnected(10, TimeUnit.SECONDS)
+                check(it.blockUntilConnected(10, TimeUnit.SECONDS)) {
+                    "Test curator could not connect to ZooKeeper within 10s (url=${zookeeper.url})"
+                }
                 ShutdownQueue.register { it.close() }
             }
         }
@@ -331,24 +333,45 @@ abstract class AbstractLeaderZookeeperTest {
 }
 ```
 
-**T8 `SessionLossFailoverTest` 격리 전략**: 세션 만료 시나리오(T8)는 ZK 컨테이너를 중단하므로
-싱글턴 `ZooKeeperServer.Launcher.zookeeper`를 절대 사용하면 안 됨.
-T8는 자체 격리된 컨테이너를 사용:
+**T8 `SessionLossFailoverTest` 격리 전략**:
+
+**설계 결정**: 컨테이너 재시작 방식은 사용하지 않는다.
+- `ZooKeeperServer(reuse=true)` 기본값으로 `stop()`/`start()` 시 포트가 변경되어 기존 curator 클라이언트가 stale 상태가 됨 (deterministic failure).
+- 대신 **클라이언트 측 세션 강제 종료** (`clientA.zookeeperClient.zooKeeper.close()`)를 사용하여 ZK 서버에서 세션 만료를 트리거함.
+
+T8는 `AbstractLeaderZookeeperTest`를 상속하지 않는 standalone 클래스:
 ```kotlin
-// T8 uses its own ZK container — NEVER use Launcher singleton (would break other tests)
+/**
+ * Demonstrates R16: ZooKeeper session expiry triggers ephemeral node removal and re-election.
+ *
+ * ## Isolation Strategy
+ * This test does NOT extend AbstractLeaderZookeeperTest — inheriting it would expose
+ * the shared Launcher singleton curator through companion object methods.
+ *
+ * Uses client-side session close (NOT container restart) to simulate session expiry:
+ * `clientA.zookeeperClient.zooKeeper.close()` forces ZK server to expire the session
+ * and remove ephemeral nodes, mimicking a network partition or process crash.
+ */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class SessionLossFailoverTest : AbstractLeaderZookeeperTest() {
+class SessionLossFailoverTest {
+    companion object : KLogging()
+    
     private lateinit var isolatedZk: ZooKeeperServer
     private lateinit var clientA: CuratorFramework
     private lateinit var clientB: CuratorFramework
 
+    fun randomLockName(prefix: String = "t8") = "$prefix:${UUID.randomUUID()}"
+
     @BeforeAll fun startIsolatedZk() {
-        isolatedZk = ZooKeeperServer().also { it.start() }
-        clientA = ZooKeeperServer.Launcher.getCuratorFramework(isolatedZk).also { 
-            it.start(); it.blockUntilConnected(10, TimeUnit.SECONDS) 
+        // reuse=false: ensures stop()/start() actually restarts the container if needed
+        isolatedZk = ZooKeeperServer(reuse = false).also { it.start() }
+        clientA = ZooKeeperServer.Launcher.getCuratorFramework(isolatedZk).also {
+            it.start()
+            check(it.blockUntilConnected(10, TimeUnit.SECONDS)) { "clientA connection timeout" }
         }
-        clientB = ZooKeeperServer.Launcher.getCuratorFramework(isolatedZk).also { 
-            it.start(); it.blockUntilConnected(10, TimeUnit.SECONDS) 
+        clientB = ZooKeeperServer.Launcher.getCuratorFramework(isolatedZk).also {
+            it.start()
+            check(it.blockUntilConnected(10, TimeUnit.SECONDS)) { "clientB connection timeout" }
         }
     }
 
@@ -357,7 +380,41 @@ class SessionLossFailoverTest : AbstractLeaderZookeeperTest() {
         runCatching { clientB.close() }
         runCatching { isolatedZk.stop() }
     }
-    // Test: workerA acquires → isolatedZk.stop() → session expires → isolatedZk.start() → workerB acquires
+
+    @Test fun `session loss causes leadership failover`() {
+        val lockName = randomLockName()
+        val workerAHoldingLatch = CountDownLatch(1)  // synchronize: workerA holds lock before session close
+        val workerADoneLatch = CountDownLatch(1)
+
+        // workerA acquires in background thread
+        val workerAThread = Thread {
+            clientA.runIfLeader(lockName, basePath = "/test/t8") {
+                workerAHoldingLatch.countDown()  // signal: "I am now leader"
+                Thread.sleep(60_000)              // hold until session closes
+                "A-done"
+            }
+            workerADoneLatch.countDown()
+        }
+        workerAThread.start()
+
+        // Wait for workerA to actually hold the lock
+        check(workerAHoldingLatch.await(10, TimeUnit.SECONDS)) {
+            "workerA did not acquire leadership within 10s"
+        }
+
+        // Simulate session expiry — no container restart needed
+        clientA.zookeeperClient.zooKeeper.close()
+
+        // workerB should acquire leadership after ephemeral node is removed
+        var workerBResult: String? = null
+        await().atMost(Duration.ofSeconds(30)).untilAsserted {
+            workerBResult = clientB.runIfLeader(lockName, basePath = "/test/t8") { "B-acquired" }
+            workerBResult shouldBeEqualTo "B-acquired"
+        }
+
+        workerAThread.interrupt()
+        workerADoneLatch.await(5, TimeUnit.SECONDS)
+    }
 }
 ```
 
@@ -371,7 +428,7 @@ class SessionLossFailoverTest : AbstractLeaderZookeeperTest() {
 | T3 | SuspendSingleLeaderTest | `SuspendedJobTester` 8-coroutine 경쟁, shared curator | exactly 1 winner per lock round; `peakConcurrent ≤ 1` |
 | T4 | GroupLeaderTest | `maxLeaders=2`, `MultithreadingTester` 4-worker, shared curator | action body calls `Thread.sleep(600ms)` (> waitTime=500ms) to hold slot; `CountDownLatch(maxLeaders)` entered before sampling; `peakConcurrent.get() shouldBeEqualTo 2` |
 | T5 | SuspendGroupLeaderTest | `SuspendedJobTester` 4-coroutine group | same as T4 with `delay(600.milliseconds)`; `CountDownLatch` + `peakConcurrent == 2` |
-| T6 | ExtensionFunctionTest | `CuratorFramework` extension functions: `leaderElector(basePath)`, `suspendLeaderElector(basePath)`, `leaderGroupElector(basePath, options)`, `suspendLeaderGroupElector(basePath, options)` | each extension returns non-null elector; `runIfLeader` / `suspend runIfLeader` returns result successfully |
+| T6 | ExtensionFunctionTest | `CuratorFramework` extension functions: `runIfLeader`, `runAsyncIfLeader`, `suspendRunIfLeader`, `runIfLeaderGroup(lockName, options=..., basePath=...)`, `suspendRunIfLeaderGroup(lockName, options=..., basePath=...)` | Each extension returns expected result. **NOTE**: `runIfLeaderGroup` param is named `options` (NOT `groupOptions`) — confirmed from `ZooKeeperLeaderGroupElector.kt:181` |
 | T7 | R16AutoExtendIgnoredTest | `LeaderElectionOptions(autoExtend=true)` 전달 시 WARN 발생 + action 정상 실행 | Logback `ListAppender<ILoggingEvent>` attached to `io.bluetape4k.leader.zookeeper` logger; assert `appender.list.any { it.level == Level.WARN && "autoExtend" in it.message }`; action result == "r16-done" |
 | T8 | SessionLossFailoverTest | R16 세션 만료 시 Ephemeral Node 소멸 + 경쟁자 자동 선출 | **독립 ZK 컨테이너 사용** (싱글턴 파괴 방지): `ZooKeeperServer()` 인스턴스를 `@BeforeAll`에서 직접 시작; workerA acquires leadership; container stopped → workerB acquires after session expires; `@AfterAll`에서 컨테이너 정리 |
 
@@ -412,7 +469,11 @@ fun setupLogCapture() {
     appender = ListAppender<ILoggingEvent>().also { it.start() }
     logger.addAppender(appender)
 }
-@AfterEach fun teardownLogCapture() { appender.stop() }
+@AfterEach fun teardownLogCapture() {
+    // MUST detachAppender BEFORE stop() — stop() alone does NOT remove the appender from the logger
+    (LoggerFactory.getLogger("io.bluetape4k.leader.zookeeper") as Logger).detachAppender(appender)
+    appender.stop()
+}
 
 @Test fun `autoExtend option is silently ignored with WARN log`() {
     val elector = ZooKeeperLeaderElector(
@@ -491,3 +552,18 @@ bluetape4k-leader-zookeeper = { module = "io.github.bluetape4k.leader:bluetape4k
 | U4/T1 | HIGH | `runAsyncIfLeader` 미커버 | §5.5 T1: `runAsyncIfLeader` CompletableFuture 검증 추가 |
 | 6T6 | HIGH | T6 extension 함수 범위 미정의 | §5.5 T6: 4개 extension 함수 명시적 열거 |
 | U2 | HIGH | README side-by-side 예제 미정의 | §7 DoD: README 요구사항에 명시 |
+
+**Round 2 (Step 3-R):**
+
+| ID | 심각도 | 내용 | 해결 방법 |
+|---|---|---|---|
+| T2-2/T6-2 | CRITICAL | T8 컨테이너 `stop()`/`start()`으로 포트 변경 → curator stale | §5.4 T8: 클라이언트 측 세션 강제 종료로 교체; standalone 클래스로 분리 |
+| T5-1 | CRITICAL (escalated) | T4/T5 CountDownLatch 오케스트레이터 순서 미명시 → deadlock 위험 | §5.5 T4: 오케스트레이터를 `MultithreadingTester.run()` 이전에 시작 명시 |
+| T3-1 | CRITICAL | ZooKeeperLeaderGroupElector 생성자 파라미터 순서 오류 (plan prose) | Plan T-CFG-1: `(client, options, basePath)` 순서 명시적 코드로 교체 |
+| T3-2/C2 | CRITICAL | T-T6 `groupOptions` 파라미터명 오류 (compile error) | Plan T-T6 + §5.5 T6: `options=` 으로 수정; source-confirmed |
+| T2-1 | HIGH | test base `blockUntilConnected` return value 미확인 | §5.4: `check(it.blockUntilConnected(...))` 추가 |
+| T5-4/H3 | HIGH | T7 `@AfterEach` `detachAppender` 누락 | §5.5 T7: `detachAppender` 추가 |
+| H1 | HIGH | T8 `AbstractLeaderZookeeperTest` 상속 → singleton 접근 위험 | §5.4 T8: standalone 클래스로 교체 |
+| H5 | HIGH | PropertiesValidationTest 누락 | Plan: T-T9 추가 (blanks/zero 검증) |
+| H7 | HIGH | lessons 문서 task 누락 | Plan: T-DOC-3 추가 |
+| H8 | HIGH | README Spring Boot 4.x compat 미명시 | Plan T-DOC-1: compat statement 추가 |

--- a/docs/superpowers/specs/2026-05-25-leader-zookeeper-design.md
+++ b/docs/superpowers/specs/2026-05-25-leader-zookeeper-design.md
@@ -31,8 +31,8 @@ ZooKeeper는 세션 기반 Ephemeral Node를 사용한다. TTL 개념이 없으�
 | 항목 | 값 |
 |---|---|
 | Kotlin | 2.3.21 |
-| Java | 25 (ZGC, `--enable-preview`) |
-| Spring Boot | 4.0.x |
+| Java | 21 (JVM toolchain: `JavaLanguageVersion.of(21)`, `jvmToolchain(21)`) |
+| Spring Boot | 4.0.6 |
 | bluetape4k-leader-zookeeper | 0.2.1 (BOM 관리) |
 | Apache Curator | 5.9.0 (transitive via leader-zookeeper) |
 | ZooKeeper Docker image | zookeeper:3.9 |
@@ -189,8 +189,7 @@ fun curatorFramework(props: LeaderZookeeperProperties): CuratorFramework {
         cfg.connectionTimeoutMs,
         ExponentialBackoffRetry(1000, 3)
     )
-    client.start()
-    // Add a ConnectionStateListener to observe SUSPENDED / LOST for operational awareness
+    // Register listener BEFORE start() to avoid missing early transitions
     client.connectionStateListenable.addListener { _, newState ->
         when (newState) {
             ConnectionState.SUSPENDED -> log.warn { "ZooKeeper connection SUSPENDED — leadership uncertain" }
@@ -199,6 +198,7 @@ fun curatorFramework(props: LeaderZookeeperProperties): CuratorFramework {
             else -> log.debug { "ZooKeeper connection state: $newState" }
         }
     }
+    client.start()
     if (!client.blockUntilConnected(cfg.blockUntilConnectedSeconds, TimeUnit.SECONDS)) {
         client.close()  // explicit close to prevent background thread leak
         error("ZooKeeper connection timeout after ${cfg.blockUntilConnectedSeconds}s (connectString=${cfg.connectString}). " +
@@ -331,16 +331,34 @@ abstract class AbstractLeaderZookeeperTest {
 }
 ```
 
-**T8 `SessionLossFailoverTest`용 독립 curator**: 세션 만료 시나리오(T8)에서는 ZK 컨테이너를 일시 중단하므로
-별도의 독립 `CuratorFramework` 인스턴스를 사용해야 한다. T8 테스트 클래스에서 `newIndependentCurator()` 헬퍼 제공:
+**T8 `SessionLossFailoverTest` 격리 전략**: 세션 만료 시나리오(T8)는 ZK 컨테이너를 중단하므로
+싱글턴 `ZooKeeperServer.Launcher.zookeeper`를 절대 사용하면 안 됨.
+T8는 자체 격리된 컨테이너를 사용:
 ```kotlin
-// Used only in T8 — T8 needs an isolated session to simulate expiry
-fun newIndependentCurator(): CuratorFramework =
-    ZooKeeperServer.Launcher.getCuratorFramework(zookeeper).also {
-        it.start()
-        it.blockUntilConnected(10, TimeUnit.SECONDS)
-        // Caller is responsible for close() in @AfterEach
+// T8 uses its own ZK container — NEVER use Launcher singleton (would break other tests)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class SessionLossFailoverTest : AbstractLeaderZookeeperTest() {
+    private lateinit var isolatedZk: ZooKeeperServer
+    private lateinit var clientA: CuratorFramework
+    private lateinit var clientB: CuratorFramework
+
+    @BeforeAll fun startIsolatedZk() {
+        isolatedZk = ZooKeeperServer().also { it.start() }
+        clientA = ZooKeeperServer.Launcher.getCuratorFramework(isolatedZk).also { 
+            it.start(); it.blockUntilConnected(10, TimeUnit.SECONDS) 
+        }
+        clientB = ZooKeeperServer.Launcher.getCuratorFramework(isolatedZk).also { 
+            it.start(); it.blockUntilConnected(10, TimeUnit.SECONDS) 
+        }
     }
+
+    @AfterAll fun stopIsolatedZk() {
+        runCatching { clientA.close() }
+        runCatching { clientB.close() }
+        runCatching { isolatedZk.stop() }
+    }
+    // Test: workerA acquires → isolatedZk.stop() → session expires → isolatedZk.start() → workerB acquires
+}
 ```
 
 ### 5.5 테스트 커버리지 매트릭스
@@ -355,7 +373,7 @@ fun newIndependentCurator(): CuratorFramework =
 | T5 | SuspendGroupLeaderTest | `SuspendedJobTester` 4-coroutine group | same as T4 with `delay(600.milliseconds)`; `CountDownLatch` + `peakConcurrent == 2` |
 | T6 | ExtensionFunctionTest | `CuratorFramework` extension functions: `leaderElector(basePath)`, `suspendLeaderElector(basePath)`, `leaderGroupElector(basePath, options)`, `suspendLeaderGroupElector(basePath, options)` | each extension returns non-null elector; `runIfLeader` / `suspend runIfLeader` returns result successfully |
 | T7 | R16AutoExtendIgnoredTest | `LeaderElectionOptions(autoExtend=true)` 전달 시 WARN 발생 + action 정상 실행 | Logback `ListAppender<ILoggingEvent>` attached to `io.bluetape4k.leader.zookeeper` logger; assert `appender.list.any { it.level == Level.WARN && "autoExtend" in it.message }`; action result == "r16-done" |
-| T8 | SessionLossFailoverTest | R16 세션 만료 시 Ephemeral Node 소멸 + 경쟁자 자동 선출 | workerA acquires leadership via `newIndependentCurator()`; ZK Testcontainer restarted (or session forcibly closed); workerB (separate curator) acquires within `sessionTimeoutMs + waitTime`; assert workerB result non-null |
+| T8 | SessionLossFailoverTest | R16 세션 만료 시 Ephemeral Node 소멸 + 경쟁자 자동 선출 | **독립 ZK 컨테이너 사용** (싱글턴 파괴 방지): `ZooKeeperServer()` 인스턴스를 `@BeforeAll`에서 직접 시작; workerA acquires leadership; container stopped → workerB acquires after session expires; `@AfterAll`에서 컨테이너 정리 |
 
 **T4/T5 CountDownLatch 패턴 (6T1 해결)**:
 ```kotlin
@@ -369,11 +387,18 @@ MultithreadingTester().workers(4).add {
     groupElector.runIfLeader(lockName) {
         val c = current.incrementAndGet()
         peakConcurrent.updateAndGet { max(it, c) }
-        enteredLatch.countDown()
-        releaseLatch.await(3, TimeUnit.SECONDS)  // hold slot while sampling
-        current.decrementAndGet()
+        try {
+            enteredLatch.countDown()
+            // Wait up to 3s for all maxLeaders to enter simultaneously
+            check(releaseLatch.await(3, TimeUnit.SECONDS)) { "releaseLatch timeout — CI may be too slow" }
+        } finally {
+            current.decrementAndGet()
+        }
     }
 }
+// IMPORTANT: releaseLatch.countDown() must be called AFTER enteredLatch fires
+// in the test setup to avoid deadlock when fewer than maxLeaders acquire.
+// Pattern: awaitility/assertSoon that enteredLatch.count == 0, then releaseLatch.countDown()
 // Sampling happens INSIDE the action, not after MultithreadingTester.run() completes.
 // Assert: peakConcurrent.get() shouldBeEqualTo maxLeaders
 ```
@@ -397,7 +422,7 @@ fun setupLogCapture() {
     val result = elector.runIfLeader(randomLockName()) { "r16-done" }
     result shouldBeEqualTo "r16-done"
     val warnEvents = appender.list.filter { it.level == Level.WARN && "autoExtend" in it.formattedMessage }
-    warnEvents shouldHaveSize 1  // exactly 1 WARN emitted on construction/first use
+    warnEvents.shouldNotBeEmpty()  // at least 1 WARN emitted (exact count may vary by version)
 }
 ```
 
@@ -446,7 +471,8 @@ bluetape4k-leader-zookeeper = { module = "io.github.bluetape4k.leader:bluetape4k
 | 1 | Security perspective | 0/0/2/1 | - |
 | 1 | Ops/SRE perspective | 0/3/3/0 | - |
 | 1 | Phase-2 Opus Critic | 통합: 0/10/8/1 → disposition 후 0/9/8/1 | - |
-| 1 | 통합 적용 후 최종 | D1 reject(라이브러리 증거), 나머지 HIGH 모두 spec에 반영 | (pending commit) |
+| 1 | 통합 적용 후 최종 | D1 reject(라이브러리 증거), 나머지 HIGH 모두 spec에 반영 | e3d360e3 |
+| 1 | Codex Phase-3 (독립) | 0/3/6/2 → Java 21 fix, T8 isolation, ConnectionStateListener before start() | (pending commit) |
 
 **Round 1 주요 발견 및 해결:**
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -206,6 +206,7 @@ bluetape4k-kafka = { module = "io.github.bluetape4k:bluetape4k-kafka" }
 bluetape4k-lettuce = { module = "io.github.bluetape4k:bluetape4k-lettuce" }
 bluetape4k-leader-core = { module = "io.github.bluetape4k.leader:bluetape4k-leader-core" }
 bluetape4k-leader-redis-lettuce = { module = "io.github.bluetape4k.leader:bluetape4k-leader-redis-lettuce" }
+bluetape4k-leader-zookeeper = { module = "io.github.bluetape4k.leader:bluetape4k-leader-zookeeper" }
 bluetape4k-javers-core = { module = "io.github.bluetape4k.javers:javers-core" }
 bluetape4k-javers-persistence-redis = { module = "io.github.bluetape4k.javers:javers-persistence-redis" }
 bluetape4k-javers-persistence-kafka = { module = "io.github.bluetape4k.javers:javers-persistence-kafka" }

--- a/leader/leader-zookeeper/README.ko.md
+++ b/leader/leader-zookeeper/README.ko.md
@@ -1,0 +1,208 @@
+# Leader ZooKeeper 워크숍
+
+ZooKeeper 기반의 **분산 리더 선출(Distributed Leader Election)** 워크숍 예제입니다.
+`bluetape4k-leader-zookeeper` 라이브러리(Apache Curator 5.9)를 사용하여,
+멀티 인스턴스(multi-pod) 환경에서 스케줄링된 작업을 안전하게 실행하는 방법을 보여줍니다.
+
+> English README: [README.md](README.md)
+
+## 개요
+
+멀티 인스턴스(멀티 Pod) 배포 환경에서 스케줄된 백그라운드 작업은 **정확히 하나의 인스턴스**
+(Single-Leader) 또는 **최대 N개 인스턴스**(Group-Leader)가 동시에 실행되어야 합니다.
+이 모듈은 `bluetape4k-leader-zookeeper`(Apache Curator 5.9)를 사용하여
+ZooKeeper 에페메랄 노드 기반으로 정확한 동시 실행을 보장하는 방법을 시연합니다.
+
+## 아키텍처
+
+여러 앱 인스턴스가 [Apache Curator](https://curator.apache.org/)의
+`InterProcessMutex`(단일 리더) / `InterProcessSemaphoreV2`(그룹 리더)로 ZooKeeper 잠금을 경쟁합니다.
+**선출된 리더**만 각 스케줄 작업을 실행합니다.
+
+```
+인스턴스-1  ──┐
+인스턴스-2  ──┼──►  CuratorFramework  ──►  ZooKeeper 앙상블
+인스턴스-3  ──┘           (에페메랄 znode)
+                │
+                └──  InterProcessMutex / InterProcessSemaphoreV2
+                       (단일 리더 / 그룹 리더)
+```
+
+## ⚠️ R16 — ZooKeeper는 TTL이 없습니다 (Redis와의 핵심 차이점)
+
+ZooKeeper는 **세션 기반 에페메랄 znode**를 사용하여 리더 선출을 구현합니다:
+
+- 리더십은 ZooKeeper **세션이 만료**되거나 명시적으로 해제될 때까지 유지됩니다.
+- **리스 TTL이 없습니다.** `LeaderElectionOptions.autoExtend = true` 를 설정하면
+  `WARN` 로그가 출력되고 자동으로 무시됩니다.
+- 프로세스 크래시나 네트워크 파티션 발생 시, ZooKeeper 세션이 타임아웃되면
+  (`sessionTimeoutMs`, 기본 60초) 에페메랄 znode가 자동 삭제되어 재선출이 시작됩니다.
+
+**실용적 가이드:**
+- `leaseTime` / `autoExtend` 는 `LeaderZookeeperProperties` 에 의도적으로 없습니다.
+- 허용 가능한 페일오버 지연 시간을 고려해 `sessionTimeoutMs` 를 조정하세요.
+- `waitTime` 으로 잠금 획득 대기 시간을 제한하세요.
+
+## 사용된 Bluetape4k 기능
+
+| 기능 | Artifact | 용도 |
+|---------|----------|-------|
+| `bluetape4k-leader-zookeeper` | `bluetape4k.leader.zookeeper` | `ZooKeeperLeaderElector`, `ZooKeeperSuspendLeaderElector`, `ZooKeeperLeaderGroupElector`, `ZooKeeperSuspendLeaderGroupElector` |
+| `bluetape4k-logging` | `bluetape4k.logging` | `KLogging` / `KLoggingChannel` + 람다 로깅 |
+| `bluetape4k-junit5` | `bluetape4k.junit5` | `MultithreadingTester`, `SuspendedJobTester` 동시성 테스트 |
+| `bluetape4k-testcontainers` | `bluetape4k.testcontainers` | `ZooKeeperServer.Launcher.zookeeper` 싱글턴 패턴 |
+| `bluetape4k-assertions` | `bluetape4k.assertions` | `shouldBeEqualTo`, `shouldBeTrue`, `assertFailsWith` |
+
+## 핵심 패턴
+
+### 1. 블로킹 단일 리더 선출
+
+```kotlin
+@Scheduled(fixedDelayString = "\${leader.zookeeper.job-fixed-delay}")
+fun scheduledJob() {
+    val result = leaderElector.runIfLeader("my-job") {
+        // 선출된 리더 인스턴스에서만 실행
+        doWork()
+    }
+    // result == null  →  이 인스턴스는 리더가 아님 (건너뜀)
+    // result != null  →  이 인스턴스가 선출되어 실행됨
+}
+```
+
+### 2. 서스펜드 단일 리더 선출 (코루틴)
+
+```kotlin
+@Scheduled(fixedDelayString = "\${leader.zookeeper.suspend-job-fixed-delay}")
+fun scheduledSuspendJob() {
+    runBlocking {
+        suspendLeaderElector.runIfLeader("my-suspend-job") {
+            delay(100)   // ZK 획득은 Dispatchers.IO에서 실행
+            doWork()
+        }
+    }
+}
+```
+
+### 3. 그룹 리더 선출 (최대 N개 동시 홀더)
+
+```kotlin
+@Scheduled(fixedDelayString = "\${leader.zookeeper.group-job-fixed-delay}")
+fun scheduledGroupJob() {
+    // 최대 `groupMaxLeaders` 개 인스턴스가 동시에 실행
+    groupElector.runIfLeader("group-job") {
+        doGroupWork()
+    }
+}
+```
+
+### 4. Bean 설정
+
+```kotlin
+@Bean
+fun zookeeperLeaderElector(curator: CuratorFramework, props: LeaderZookeeperProperties) =
+    ZooKeeperLeaderElector(
+        client = curator,
+        basePath = "${props.basePath}/single",
+        options = LeaderElectionOptions(waitTime = props.waitTime.toKotlinDuration()),
+    )
+
+@Bean
+fun zookeeperGroupElector(curator: CuratorFramework, props: LeaderZookeeperProperties) =
+    ZooKeeperLeaderGroupElector(
+        client = curator,
+        basePath = "${props.basePath}/group",
+        options = LeaderGroupElectionOptions(
+            maxLeaders = props.groupMaxLeaders,
+            waitTime = props.waitTime.toKotlinDuration(),
+        ),
+    )
+```
+
+### 5. CuratorFramework 설정
+
+```kotlin
+@Bean
+fun curatorFramework(props: LeaderZookeeperProperties): CuratorFramework {
+    val client = CuratorFrameworkFactory.newClient(
+        props.zookeeper.connectString,
+        props.zookeeper.sessionTimeoutMs,
+        props.zookeeper.connectionTimeoutMs,
+        ExponentialBackoffRetry(1000, 3),
+    )
+    // start() 이전에 ConnectionStateListener 등록
+    client.connectionStateListenable.addListener(ConnectionStateListener { _, newState ->
+        log.info { "ZooKeeper 연결 상태 변경: $newState" }
+    })
+    client.start()
+    check(client.blockUntilConnected(props.zookeeper.blockUntilConnectedSeconds, TimeUnit.SECONDS)) {
+        "ZooKeeper에 연결할 수 없습니다. (${props.zookeeper.blockUntilConnectedSeconds}초 초과)"
+    }
+    return client
+}
+```
+
+## 설정
+
+```yaml
+leader:
+  zookeeper:
+    zookeeper:
+      connect-string: localhost:2181          # ZooKeeper 연결 문자열
+      session-timeout-ms: 60000              # 크래시 시 페일오버 대기 시간 (ms)
+      connection-timeout-ms: 15000           # 초기 연결 타임아웃 (ms)
+      block-until-connected-seconds: 10      # 시작 시 연결 대기 최대 시간 (초)
+    base-path: /workshop/leader-zookeeper    # 모든 선출 znode의 기본 경로
+    wait-time: 2s                            # 잠금 획득 최대 대기 시간
+    group-max-leaders: 2                     # 그룹 리더 동시 최대 홀더 수
+    job-fixed-delay: PT10S                   # 블로킹 단일 리더 작업 주기
+    suspend-job-fixed-delay: PT12S           # 서스펜드 단일 리더 작업 주기
+    group-job-fixed-delay: PT15S             # 블로킹 그룹 리더 작업 주기
+    suspend-group-job-fixed-delay: PT18S     # 서스펜드 그룹 리더 작업 주기
+```
+
+> **참고:** `leaseTime` 과 `autoExtend` 는 의도적으로 없습니다 — [R16 참고](#️-r16--zookeeper는-ttl이-없습니다-redis와의-핵심-차이점).
+
+## 실행
+
+### 애플리케이션 시작
+
+```bash
+# ZooKeeper가 localhost:2181에서 실행 중이어야 합니다
+./gradlew :leader-leader-zookeeper:bootRun
+```
+
+### 테스트 실행
+
+```bash
+# 모든 테스트 실행 (기본적으로 smoke 태그 제외)
+./gradlew :leader-leader-zookeeper:test
+
+# 명시적 태그 필터 설정
+./gradlew :leader-leader-zookeeper:test -Djunit.jupiter.execution.exclude.tags=
+```
+
+## 테스트 커버리지
+
+| 테스트 | 클래스 | 설명 |
+|------|-------|-------------|
+| T0 | `LeaderZookeeperContextTest` | Spring Boot 컨텍스트 로드; 4개 elector 빈 검증 |
+| T1 | `BlockingSingleLeaderTest` | 블로킹 단일 리더: `runIfLeader`, `runAsyncIfLeader`, 예외 격리 |
+| T2 | `ConcurrentBlockingLeaderTest` | 8개 스레드 경쟁; `waitTime=500ms` 내 3회 이상 실행 검증 |
+| T3 | `SuspendSingleLeaderTest` | 서스펜드 단일 리더: 결과 반환 + 8개 코루틴 직렬 실행 검증 |
+| T4 | `GroupLeaderTest` | `maxLeaders=2`로 정확히 2개 블로킹 홀더 동시 허용 (`MultithreadingTester`) |
+| T5 | `SuspendGroupLeaderTest` | `maxLeaders=2`로 정확히 2개 코루틴 홀더 동시 허용 (`SuspendedJobTester`) |
+| T6 | `ExtensionFunctionTest` | 확장 API: `runBlockingIfLeader`, `runAsyncIfLeader`, `runSuspendIfLeader`, `runGroupIfLeader` |
+| T7 | `R16AutoExtendIgnoredTest` | `autoExtend=true` 시 WARN 로그 출력 후 무시 (R16 계약 검증) |
+| T8 | `SessionLossFailoverTest` | `zookeeperClient.zooKeeper.close()`로 세션 소실 시뮬레이션; 재연결 후 재선출 성공 |
+| T9 | `LeaderZookeeperPropertiesValidationTest` | 빈 `basePath`, `groupMaxLeaders=0`, 빈 `connectString` 검증 실패 테스트 |
+
+## 프로덕션 고려사항
+
+| 항목 | 가이드 |
+|---------|----------|
+| **ACL** | 프로덕션에서 `CuratorFrameworkFactory.builder().aclProvider(...)` 설정 필요 |
+| **TLS / SASL** | `ZooKeeperTls.setZKTLSConfig(...)` 및 `javax.net.ssl` 속성 설정 필요 |
+| **앙상블** | 고가용성을 위해 `host1:2181,host2:2181,host3:2181` 형태로 설정 |
+| **세션 타임아웃** | 불필요한 재선출 방지를 위해 `sessionTimeoutMs`를 작업 주기의 3~5배로 설정 |
+| **스레드 안전성** | `CuratorFramework` 및 모든 elector 인스턴스는 스레드 세이프하며 공유 가능 |
+| **Spring Boot 버전** | Spring Boot 4.x 및 Java 21 이상 호환 |

--- a/leader/leader-zookeeper/README.md
+++ b/leader/leader-zookeeper/README.md
@@ -1,0 +1,209 @@
+# Leader ZooKeeper Workshop
+
+A Spring Boot workshop example demonstrating **ZooKeeper-based distributed leader election**
+for scheduled jobs in multi-instance deployments, using the `bluetape4k-leader-zookeeper` library.
+
+> 한국어 README: [README.ko.md](README.ko.md)
+
+## Overview
+
+In a multi-instance (multi-pod) deployment, scheduled background jobs must run on **exactly one
+instance** at a time (single-leader) or up to **N instances** simultaneously (group-leader).
+This module demonstrates how to use `bluetape4k-leader-zookeeper` (Apache Curator 5.9) to
+guarantee correct concurrent execution via ZooKeeper ephemeral nodes.
+
+## Architecture
+
+Multiple app instances compete for ZooKeeper locks backed by
+[Apache Curator](https://curator.apache.org/) `InterProcessMutex` (single-leader) and
+`InterProcessSemaphoreV2` (group-leader). Only the **elected leader(s)** execute each
+scheduled job.
+
+```
+Instance-1  ──┐
+Instance-2  ──┼──►  CuratorFramework  ──►  ZooKeeper Ensemble
+Instance-3  ──┘           (Ephemeral znodes)
+                │
+                └──  InterProcessMutex / InterProcessSemaphoreV2
+                       (single-leader / group-leader)
+```
+
+## ⚠️ R16 — ZooKeeper Has No TTL (Critical Difference from Redis)
+
+ZooKeeper uses **session-bound ephemeral znodes** for leader election:
+
+- Leadership is held until the ZooKeeper **session expires** or is explicitly released.
+- There is **no lease TTL**. Setting `LeaderElectionOptions.autoExtend = true` emits a `WARN`
+  log and is silently ignored.
+- On process crash or network partition, the ZooKeeper session times out
+  (`sessionTimeoutMs`, default 60 s), then the ephemeral znode is automatically deleted,
+  triggering re-election.
+
+**Practical guidance:**
+- `leaseTime` / `autoExtend` are intentionally absent from `LeaderZookeeperProperties`.
+- Tune `sessionTimeoutMs` relative to your job interval for acceptable failover latency.
+- Use `waitTime` to bound how long a candidate waits before giving up on lock acquisition.
+
+## Used Bluetape4k Features
+
+| Feature | Artifact | Usage |
+|---------|----------|-------|
+| `bluetape4k-leader-zookeeper` | `bluetape4k.leader.zookeeper` | `ZooKeeperLeaderElector`, `ZooKeeperSuspendLeaderElector`, `ZooKeeperLeaderGroupElector`, `ZooKeeperSuspendLeaderGroupElector` |
+| `bluetape4k-logging` | `bluetape4k.logging` | `KLogging` / `KLoggingChannel` + lambda logging |
+| `bluetape4k-junit5` | `bluetape4k.junit5` | `MultithreadingTester`, `SuspendedJobTester` for concurrent tests |
+| `bluetape4k-testcontainers` | `bluetape4k.testcontainers` | `ZooKeeperServer.Launcher.zookeeper` singleton pattern |
+| `bluetape4k-assertions` | `bluetape4k.assertions` | `shouldBeEqualTo`, `shouldBeTrue`, `assertFailsWith` |
+
+## Key Patterns
+
+### 1. Blocking Single-Leader Election
+
+```kotlin
+@Scheduled(fixedDelayString = "\${leader.zookeeper.job-fixed-delay}")
+fun scheduledJob() {
+    val result = leaderElector.runIfLeader("my-job") {
+        // runs only on the elected leader instance
+        doWork()
+    }
+    // result == null  →  this instance is not the leader (skipped)
+    // result != null  →  this instance was elected and executed the action
+}
+```
+
+### 2. Suspend Single-Leader Election (Coroutines)
+
+```kotlin
+@Scheduled(fixedDelayString = "\${leader.zookeeper.suspend-job-fixed-delay}")
+fun scheduledSuspendJob() {
+    runBlocking {
+        suspendLeaderElector.runIfLeader("my-suspend-job") {
+            delay(100)   // ZK acquire is done in Dispatchers.IO
+            doWork()
+        }
+    }
+}
+```
+
+### 3. Group-Leader Election (up to N simultaneous holders)
+
+```kotlin
+@Scheduled(fixedDelayString = "\${leader.zookeeper.group-job-fixed-delay}")
+fun scheduledGroupJob() {
+    // Up to `groupMaxLeaders` instances run concurrently
+    groupElector.runIfLeader("group-job") {
+        doGroupWork()
+    }
+}
+```
+
+### 4. Bean Configuration
+
+```kotlin
+@Bean
+fun zookeeperLeaderElector(curator: CuratorFramework, props: LeaderZookeeperProperties) =
+    ZooKeeperLeaderElector(
+        client = curator,
+        basePath = "${props.basePath}/single",
+        options = LeaderElectionOptions(waitTime = props.waitTime.toKotlinDuration()),
+    )
+
+@Bean
+fun zookeeperGroupElector(curator: CuratorFramework, props: LeaderZookeeperProperties) =
+    ZooKeeperLeaderGroupElector(
+        client = curator,
+        basePath = "${props.basePath}/group",
+        options = LeaderGroupElectionOptions(
+            maxLeaders = props.groupMaxLeaders,
+            waitTime = props.waitTime.toKotlinDuration(),
+        ),
+    )
+```
+
+### 5. CuratorFramework Setup
+
+```kotlin
+@Bean
+fun curatorFramework(props: LeaderZookeeperProperties): CuratorFramework {
+    val client = CuratorFrameworkFactory.newClient(
+        props.zookeeper.connectString,
+        props.zookeeper.sessionTimeoutMs,
+        props.zookeeper.connectionTimeoutMs,
+        ExponentialBackoffRetry(1000, 3),
+    )
+    // Register connection state listener BEFORE start()
+    client.connectionStateListenable.addListener(ConnectionStateListener { _, newState ->
+        log.info { "ZooKeeper connection state changed: $newState" }
+    })
+    client.start()
+    check(client.blockUntilConnected(props.zookeeper.blockUntilConnectedSeconds, TimeUnit.SECONDS)) {
+        "Could not connect to ZooKeeper within ${props.zookeeper.blockUntilConnectedSeconds}s"
+    }
+    return client
+}
+```
+
+## Configuration
+
+```yaml
+leader:
+  zookeeper:
+    zookeeper:
+      connect-string: localhost:2181          # ZooKeeper connection string
+      session-timeout-ms: 60000              # Failover window on hard crash
+      connection-timeout-ms: 15000           # Initial connection timeout
+      block-until-connected-seconds: 10      # Startup readiness timeout
+    base-path: /workshop/leader-zookeeper    # ZooKeeper base path for all election znodes
+    wait-time: 2s                            # Max wait time to acquire the lock
+    group-max-leaders: 2                     # Max simultaneous group-leader holders
+    job-fixed-delay: PT10S                   # Blocking single-leader job interval
+    suspend-job-fixed-delay: PT12S           # Suspend single-leader job interval
+    group-job-fixed-delay: PT15S             # Blocking group-leader job interval
+    suspend-group-job-fixed-delay: PT18S     # Suspend group-leader job interval
+```
+
+> **Note:** `leaseTime` and `autoExtend` are intentionally absent — see [R16 note](#️-r16--zookeeper-has-no-ttl-critical-difference-from-redis).
+
+## Running
+
+### Start the application
+
+```bash
+# Requires ZooKeeper running on localhost:2181
+./gradlew :leader-leader-zookeeper:bootRun
+```
+
+### Run tests
+
+```bash
+# Run all tests (smoke tests excluded by default)
+./gradlew :leader-leader-zookeeper:test
+
+# Run with explicit tag filter
+./gradlew :leader-leader-zookeeper:test -Djunit.jupiter.execution.exclude.tags=
+```
+
+## Test Coverage
+
+| Test | Class | Description |
+|------|-------|-------------|
+| T0 | `LeaderZookeeperContextTest` | Spring Boot context loads; all 4 elector beans present |
+| T1 | `BlockingSingleLeaderTest` | Single blocking leader: `runIfLeader`, `runAsyncIfLeader`, exception isolation |
+| T2 | `ConcurrentBlockingLeaderTest` | 8 threads compete; at least 3 executions within `waitTime=500ms` |
+| T3 | `SuspendSingleLeaderTest` | Suspend single leader: result returned + 8 coroutines serialize correctly |
+| T4 | `GroupLeaderTest` | `maxLeaders=2` admits exactly 2 simultaneous blocking holders (`MultithreadingTester`) |
+| T5 | `SuspendGroupLeaderTest` | `maxLeaders=2` admits exactly 2 simultaneous coroutine holders (`SuspendedJobTester`) |
+| T6 | `ExtensionFunctionTest` | Extension API: `runBlockingIfLeader`, `runAsyncIfLeader`, `runSuspendIfLeader`, `runGroupIfLeader` |
+| T7 | `R16AutoExtendIgnoredTest` | `autoExtend=true` emits WARN and is silently ignored (R16 contract) |
+| T8 | `SessionLossFailoverTest` | Session loss via `zookeeperClient.zooKeeper.close()`; re-election succeeds after reconnect |
+| T9 | `LeaderZookeeperPropertiesValidationTest` | Blank `basePath`, zero `groupMaxLeaders`, blank `connectString` fail validation |
+
+## Production Considerations
+
+| Concern | Guidance |
+|---------|----------|
+| **ACL** | Use `CuratorFrameworkFactory.builder().aclProvider(...)` in production |
+| **TLS / SASL** | Configure `ZooKeeperTls.setZKTLSConfig(...)` and appropriate `javax.net.ssl` properties |
+| **Ensemble** | Use `host1:2181,host2:2181,host3:2181` for high availability |
+| **Session timeout** | Set `sessionTimeoutMs` to 3–5× your job interval to avoid spurious re-elections |
+| **Thread safety** | `CuratorFramework` and all elector instances are thread-safe and safe to share |
+| **Spring Boot version** | Compatible with Spring Boot 4.x and Java 21+ |

--- a/leader/leader-zookeeper/build.gradle.kts
+++ b/leader/leader-zookeeper/build.gradle.kts
@@ -1,0 +1,48 @@
+plugins {
+    alias(libs.plugins.kotlin.spring)
+    alias(libs.plugins.spring.boot)
+}
+
+springBoot {
+    mainClass.set("io.bluetape4k.workshop.leader.zookeeper.LeaderZookeeperAppKt")
+}
+
+configurations {
+    testImplementation.get().extendsFrom(compileOnly.get(), runtimeOnly.get())
+}
+
+tasks.test {
+    useJUnitPlatform {
+        // Exclude @Tag("smoke") from the default test run.
+        excludeTags("smoke")
+    }
+}
+
+dependencies {
+    // bluetape4k-leader-zookeeper (Apache Curator 5.9.0 transitive)
+    implementation(libs.bluetape4k.leader.zookeeper)
+
+    implementation(libs.bluetape4k.logging)
+
+    // Spring Boot
+    implementation(libs.spring.boot.autoconfigure.lib)
+    implementation(libs.spring.boot.starter.actuator)
+    annotationProcessor(libs.spring.boot.autoconfigure.processor)
+    annotationProcessor(libs.spring.boot.configuration.processor)
+    runtimeOnly(libs.spring.boot.devtools)
+
+    // Test
+    testImplementation(project(":shared"))
+    testImplementation(libs.bluetape4k.coroutines)
+    testImplementation(libs.bluetape4k.junit5)
+    testImplementation(libs.kotlinx.coroutines.test.lib)
+    testImplementation(libs.bluetape4k.testcontainers)
+    testImplementation(libs.bluetape4k.assertions)
+    testImplementation(libs.spring.boot.starter.test) {
+        exclude(group = "junit", module = "junit")
+        exclude(group = "org.junit.vintage", module = "junit-vintage-engine")
+        exclude(module = "mockito-core")
+    }
+    testImplementation(libs.mockk)
+    // logback-classic for T7 ListAppender<ILoggingEvent> (provided via spring-boot-starter-test transitively)
+}

--- a/leader/leader-zookeeper/src/main/kotlin/io/bluetape4k/workshop/leader/zookeeper/LeaderZookeeperApp.kt
+++ b/leader/leader-zookeeper/src/main/kotlin/io/bluetape4k/workshop/leader/zookeeper/LeaderZookeeperApp.kt
@@ -1,0 +1,26 @@
+package io.bluetape4k.workshop.leader.zookeeper
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
+import org.springframework.scheduling.annotation.EnableScheduling
+
+/**
+ * Workshop application demonstrating ZooKeeper-based distributed leader election.
+ *
+ * ## Behavior / Contract
+ * Runs four scheduled services, each using a different [io.bluetape4k.leader.LeaderElector] variant:
+ * - [service.BlockingLeaderService] — blocking single-leader
+ * - [service.SuspendLeaderZkService] — coroutine single-leader
+ * - [service.GroupLeaderService] — blocking group-leader
+ * - [service.SuspendGroupLeaderService] — coroutine group-leader
+ *
+ * All electors share one [org.apache.curator.framework.CuratorFramework] bean.
+ * See [config.LeaderZookeeperConfig] for ZooKeeper connection lifecycle.
+ */
+@SpringBootApplication
+@EnableScheduling
+class LeaderZookeeperApp
+
+fun main(args: Array<String>) {
+    runApplication<LeaderZookeeperApp>(*args)
+}

--- a/leader/leader-zookeeper/src/main/kotlin/io/bluetape4k/workshop/leader/zookeeper/config/LeaderZookeeperConfig.kt
+++ b/leader/leader-zookeeper/src/main/kotlin/io/bluetape4k/workshop/leader/zookeeper/config/LeaderZookeeperConfig.kt
@@ -1,0 +1,139 @@
+package io.bluetape4k.workshop.leader.zookeeper.config
+
+import io.bluetape4k.leader.LeaderElectionOptions
+import io.bluetape4k.leader.LeaderGroupElectionOptions
+import io.bluetape4k.leader.zookeeper.ZooKeeperLeaderElector
+import io.bluetape4k.leader.zookeeper.ZooKeeperLeaderGroupElector
+import io.bluetape4k.leader.zookeeper.ZooKeeperSuspendLeaderElector
+import io.bluetape4k.leader.zookeeper.ZooKeeperSuspendLeaderGroupElector
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import io.bluetape4k.logging.error
+import io.bluetape4k.logging.info
+import io.bluetape4k.logging.warn
+import org.apache.curator.framework.CuratorFramework
+import org.apache.curator.framework.CuratorFrameworkFactory
+import org.apache.curator.framework.state.ConnectionState
+import org.apache.curator.retry.ExponentialBackoffRetry
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import java.util.concurrent.TimeUnit
+import kotlin.time.toKotlinDuration
+
+/**
+ * Spring configuration for ZooKeeper-based leader election beans.
+ *
+ * ## Behavior / Contract
+ * Creates a single shared [CuratorFramework] bean and four [io.bluetape4k.leader.LeaderElector] beans.
+ * The [CuratorFramework] bean registers a [org.apache.curator.framework.state.ConnectionStateListener]
+ * **before** `start()` to capture early connection transitions.
+ *
+ * ## Resource Lifecycle
+ * If `blockUntilConnected` times out, `client.close()` is called explicitly to prevent
+ * background thread leaks (Spring `destroyMethod` only fires on successfully registered beans).
+ *
+ * ## ACL Note
+ * Default `OPEN_ACL_UNSAFE` — production deployments should configure
+ * `CuratorFrameworkFactory.builder().aclProvider(DigestACLProvider(...))`.
+ */
+@Configuration
+@EnableConfigurationProperties(LeaderZookeeperProperties::class)
+class LeaderZookeeperConfig {
+
+    companion object : KLogging()
+
+    /**
+     * Creates and starts a [CuratorFramework] connected to the configured ZooKeeper ensemble.
+     *
+     * Registers a [org.apache.curator.framework.state.ConnectionStateListener] before `start()`
+     * so that SUSPENDED/LOST/RECONNECTED events are never missed.
+     */
+    @Bean(destroyMethod = "close")
+    fun curatorFramework(props: LeaderZookeeperProperties): CuratorFramework {
+        val cfg = props.zookeeper
+        val client = CuratorFrameworkFactory.newClient(
+            cfg.connectString,
+            cfg.sessionTimeoutMs,
+            cfg.connectionTimeoutMs,
+            ExponentialBackoffRetry(1000, 3)
+        )
+
+        // Register BEFORE start() to avoid missing early transitions
+        client.connectionStateListenable.addListener { _, newState ->
+            when (newState) {
+                ConnectionState.SUSPENDED ->
+                    log.warn { "ZooKeeper connection SUSPENDED — leadership uncertain" }
+                ConnectionState.LOST ->
+                    log.error { "ZooKeeper session LOST — ephemeral nodes removed; re-election will occur" }
+                ConnectionState.RECONNECTED ->
+                    log.info { "ZooKeeper session RECONNECTED" }
+                else ->
+                    log.debug { "ZooKeeper connection state: $newState" }
+            }
+        }
+
+        client.start()
+
+        if (!client.blockUntilConnected(cfg.blockUntilConnectedSeconds.toInt(), TimeUnit.SECONDS)) {
+            client.close() // explicit close to prevent background thread leak
+            error(
+                "ZooKeeper connection timeout after ${cfg.blockUntilConnectedSeconds}s " +
+                    "(connectString=${cfg.connectString}). Check that ZooKeeper is running and accessible."
+            )
+        }
+
+        // NOTE: OPEN_ACL_UNSAFE default — production: use CuratorFrameworkFactory.builder().aclProvider(...)
+        return client
+    }
+
+    @Bean
+    fun leaderElector(
+        curator: CuratorFramework,
+        props: LeaderZookeeperProperties,
+    ): ZooKeeperLeaderElector =
+        ZooKeeperLeaderElector(
+            client = curator,
+            basePath = "${props.basePath}/single",
+            options = LeaderElectionOptions(waitTime = props.waitTime.toKotlinDuration())
+        )
+
+    @Bean
+    fun suspendLeaderElector(
+        curator: CuratorFramework,
+        props: LeaderZookeeperProperties,
+    ): ZooKeeperSuspendLeaderElector =
+        ZooKeeperSuspendLeaderElector(
+            client = curator,
+            basePath = "${props.basePath}/single-suspend",
+            options = LeaderElectionOptions(waitTime = props.waitTime.toKotlinDuration())
+        )
+
+    @Bean
+    fun leaderGroupElector(
+        curator: CuratorFramework,
+        props: LeaderZookeeperProperties,
+    ): ZooKeeperLeaderGroupElector =
+        ZooKeeperLeaderGroupElector(
+            client = curator,
+            options = LeaderGroupElectionOptions(
+                maxLeaders = props.groupMaxLeaders,
+                waitTime = props.waitTime.toKotlinDuration()
+            ),
+            basePath = "${props.basePath}/group"
+        )
+
+    @Bean
+    fun suspendLeaderGroupElector(
+        curator: CuratorFramework,
+        props: LeaderZookeeperProperties,
+    ): ZooKeeperSuspendLeaderGroupElector =
+        ZooKeeperSuspendLeaderGroupElector(
+            client = curator,
+            options = LeaderGroupElectionOptions(
+                maxLeaders = props.groupMaxLeaders,
+                waitTime = props.waitTime.toKotlinDuration()
+            ),
+            basePath = "${props.basePath}/group-suspend"
+        )
+}

--- a/leader/leader-zookeeper/src/main/kotlin/io/bluetape4k/workshop/leader/zookeeper/config/LeaderZookeeperProperties.kt
+++ b/leader/leader-zookeeper/src/main/kotlin/io/bluetape4k/workshop/leader/zookeeper/config/LeaderZookeeperProperties.kt
@@ -1,0 +1,73 @@
+package io.bluetape4k.workshop.leader.zookeeper.config
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.support.requireNotBlank
+import io.bluetape4k.support.requirePositiveNumber
+import org.springframework.boot.context.properties.ConfigurationProperties
+import java.io.Serializable
+import java.time.Duration
+
+/**
+ * Configuration properties for the ZooKeeper-based leader election workshop module.
+ *
+ * ## Behavior / Contract (R16 — ZooKeeper has no TTL)
+ * ZooKeeper uses session-bound ephemeral znodes for leader election.
+ * Unlike Redis-based election:
+ * - There is no lease TTL; leadership is held until the ZooKeeper session expires or is explicitly closed.
+ * - `leaseTime` and `autoExtend` are intentionally absent from this class.
+ *   Setting `LeaderElectionOptions.autoExtend = true` emits a WARN log and is silently ignored.
+ * - Session expiry (e.g., due to network partition or process crash) automatically removes
+ *   the ephemeral election node, triggering re-election among competing candidates.
+ * - Tune [ZooKeeperConfig.sessionTimeoutMs] relative to your job interval for acceptable failover latency.
+ *
+ * ## Production Considerations
+ * - Default [ZooKeeperConfig.connectString] is `localhost:2181` (development only).
+ * - Default [ZooKeeperConfig.sessionTimeoutMs] is 60 000 ms — the failover window on hard crash.
+ * - ACL and TLS are omitted in this workshop; production deployments should configure an ACLProvider
+ *   and SASL/TLS via `CuratorFrameworkFactory.builder()`.
+ */
+@ConfigurationProperties(prefix = "leader.zookeeper")
+data class LeaderZookeeperProperties(
+    val zookeeper: ZooKeeperConfig = ZooKeeperConfig(),
+    val basePath: String = "/workshop/leader-zookeeper",
+    val waitTime: Duration = Duration.ofSeconds(2),
+    val groupMaxLeaders: Int = 2,
+    val jobFixedDelay: String = "PT10S",
+    val suspendJobFixedDelay: String = "PT12S",
+    val groupJobFixedDelay: String = "PT15S",
+    val suspendGroupJobFixedDelay: String = "PT18S",
+    // NOTE: leaseTime / autoExtend intentionally absent — R16: ZooKeeper has no TTL
+) : Serializable {
+    companion object : KLogging() {
+        private const val serialVersionUID = 1L
+    }
+
+    init {
+        basePath.requireNotBlank("basePath")
+        groupMaxLeaders.requirePositiveNumber("groupMaxLeaders")
+        // connectString validated inside ZooKeeperConfig.init
+    }
+
+    /**
+     * ZooKeeper connection configuration.
+     *
+     * @property connectString ZooKeeper connection string (host:port or host:port,host:port,...).
+     * @property sessionTimeoutMs ZooKeeper session timeout in milliseconds. Controls failover latency on crash.
+     * @property connectionTimeoutMs ZooKeeper connection establishment timeout in milliseconds.
+     * @property blockUntilConnectedSeconds Maximum seconds to wait for initial ZooKeeper connection.
+     */
+    data class ZooKeeperConfig(
+        val connectString: String = "localhost:2181",
+        val sessionTimeoutMs: Int = 60_000,
+        val connectionTimeoutMs: Int = 15_000,
+        val blockUntilConnectedSeconds: Long = 10,
+    ) : Serializable {
+        companion object {
+            private const val serialVersionUID = 1L
+        }
+
+        init {
+            connectString.requireNotBlank("connectString")
+        }
+    }
+}

--- a/leader/leader-zookeeper/src/main/kotlin/io/bluetape4k/workshop/leader/zookeeper/config/LeaderZookeeperProperties.kt
+++ b/leader/leader-zookeeper/src/main/kotlin/io/bluetape4k/workshop/leader/zookeeper/config/LeaderZookeeperProperties.kt
@@ -68,6 +68,9 @@ data class LeaderZookeeperProperties(
 
         init {
             connectString.requireNotBlank("connectString")
+            sessionTimeoutMs.requirePositiveNumber("sessionTimeoutMs")
+            connectionTimeoutMs.requirePositiveNumber("connectionTimeoutMs")
+            blockUntilConnectedSeconds.requirePositiveNumber("blockUntilConnectedSeconds")
         }
     }
 }

--- a/leader/leader-zookeeper/src/main/kotlin/io/bluetape4k/workshop/leader/zookeeper/service/BlockingLeaderService.kt
+++ b/leader/leader-zookeeper/src/main/kotlin/io/bluetape4k/workshop/leader/zookeeper/service/BlockingLeaderService.kt
@@ -1,0 +1,60 @@
+package io.bluetape4k.workshop.leader.zookeeper.service
+
+import io.bluetape4k.leader.zookeeper.ZooKeeperLeaderElector
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import io.bluetape4k.logging.info
+import io.bluetape4k.logging.warn
+import io.bluetape4k.workshop.leader.zookeeper.config.LeaderZookeeperProperties
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Service
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Blocking single-leader workshop service backed by [ZooKeeperLeaderElector].
+ *
+ * ## Behavior / Contract
+ * - [runLeaderWork] returns the action result when this instance is elected, or `null` when skipped.
+ * - The `@Scheduled` entry point logs and swallows non-cancellation exceptions to avoid
+ *   killing the Spring scheduler thread.
+ * - [executionCount] is exposed for testing; not for production use.
+ */
+@Service
+class BlockingLeaderService(
+    private val elector: ZooKeeperLeaderElector,
+    @Suppress("unused") private val props: LeaderZookeeperProperties,
+) {
+    companion object : KLogging() {
+        const val LOCK_NAME = "workshop:blocking-job"
+    }
+
+    /** Number of times this instance was elected and executed the leader action. */
+    val executionCount = AtomicInteger(0)
+
+    /**
+     * Acquires leadership for [lockName] and executes the work body if elected.
+     *
+     * @return `"done"` when this instance won the lock, `null` when skipped.
+     */
+    fun runLeaderWork(lockName: String = LOCK_NAME): String? =
+        elector.runIfLeader(lockName) {
+            executionCount.incrementAndGet()
+            log.info { "[LEADER] BlockingLeaderService running work (total=${executionCount.get()})" }
+            "done"
+        }.also {
+            if (it == null) log.debug { "[SKIPPED] BlockingLeaderService not the elected leader" }
+        }
+
+    /**
+     * Scheduled entry point. Catches non-cancellation exceptions so the Spring
+     * scheduler thread remains healthy across invocations.
+     */
+    @Scheduled(fixedDelayString = "\${leader.zookeeper.job-fixed-delay:PT10S}")
+    fun runScheduled() {
+        try {
+            runLeaderWork()
+        } catch (e: Exception) {
+            log.warn(e) { "Scheduled leader work failed" }
+        }
+    }
+}

--- a/leader/leader-zookeeper/src/main/kotlin/io/bluetape4k/workshop/leader/zookeeper/service/GroupLeaderService.kt
+++ b/leader/leader-zookeeper/src/main/kotlin/io/bluetape4k/workshop/leader/zookeeper/service/GroupLeaderService.kt
@@ -1,0 +1,71 @@
+package io.bluetape4k.workshop.leader.zookeeper.service
+
+import io.bluetape4k.leader.LeaderGroupState
+import io.bluetape4k.leader.zookeeper.ZooKeeperLeaderGroupElector
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import io.bluetape4k.logging.info
+import io.bluetape4k.logging.warn
+import io.bluetape4k.workshop.leader.zookeeper.config.LeaderZookeeperProperties
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Service
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Blocking group-leader workshop service backed by [ZooKeeperLeaderGroupElector].
+ *
+ * ## Behavior / Contract
+ * - Up to `maxLeaders` instances may simultaneously execute the action body.
+ * - [runLeaderWork] returns the action result when this instance entered a slot, or `null`
+ *   when all slots were taken within the wait time.
+ * - [inspectState] returns the current [LeaderGroupState] for a lock — useful in tests
+ *   to verify `activeCount` and `availableSlots`.
+ * - [executionCount] is exposed for testing; not for production use.
+ */
+@Service
+class GroupLeaderService(
+    private val elector: ZooKeeperLeaderGroupElector,
+    @Suppress("unused") private val props: LeaderZookeeperProperties,
+) {
+    companion object : KLogging() {
+        const val LOCK_NAME = "workshop:group-job"
+    }
+
+    /** Number of times this instance entered a leader slot. */
+    val executionCount = AtomicInteger(0)
+
+    /**
+     * Attempts to enter a leader slot for [lockName] and executes the work body if admitted.
+     *
+     * @return `"done"` when this instance entered a slot, `null` when no slot was available.
+     */
+    fun runLeaderWork(lockName: String = LOCK_NAME): String? =
+        elector.runIfLeader(lockName) {
+            executionCount.incrementAndGet()
+            log.info { "[GROUP-LEADER] GroupLeaderService entered slot (total=${executionCount.get()})" }
+            "done"
+        }.also {
+            if (it == null) log.debug { "[SKIPPED] GroupLeaderService — no slot available" }
+        }
+
+    /**
+     * Inspects the current group-election state for [lockName].
+     *
+     * Surfaces `activeCount` and `availableSlots` for tests and operational dashboards.
+     */
+    fun inspectState(lockName: String = LOCK_NAME): LeaderGroupState =
+        elector.state(lockName)
+
+    /**
+     * Scheduled entry point. Catches non-cancellation exceptions so the Spring
+     * scheduler thread remains healthy across invocations.
+     */
+    @Scheduled(fixedDelayString = "\${leader.zookeeper.group-job-fixed-delay:PT15S}")
+    fun runScheduled() {
+        try {
+            runLeaderWork()
+        } catch (e: Exception) {
+            log.warn(e) { "Scheduled group leader work failed" }
+        }
+    }
+}

--- a/leader/leader-zookeeper/src/main/kotlin/io/bluetape4k/workshop/leader/zookeeper/service/SuspendGroupLeaderService.kt
+++ b/leader/leader-zookeeper/src/main/kotlin/io/bluetape4k/workshop/leader/zookeeper/service/SuspendGroupLeaderService.kt
@@ -1,0 +1,72 @@
+package io.bluetape4k.workshop.leader.zookeeper.service
+
+import io.bluetape4k.leader.zookeeper.ZooKeeperSuspendLeaderGroupElector
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.logging.debug
+import io.bluetape4k.logging.info
+import io.bluetape4k.logging.warn
+import io.bluetape4k.workshop.leader.zookeeper.config.LeaderZookeeperProperties
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Service
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Coroutine-native group-leader workshop service backed by [ZooKeeperSuspendLeaderGroupElector].
+ *
+ * ## Behavior / Contract
+ * - Up to `maxLeaders` instances may simultaneously execute the action body.
+ * - [runLeaderWork] suspends while waiting for an available slot; no thread is blocked.
+ * - Returns the action result when admitted, `null` when no slot was available within wait time.
+ * - The `@Scheduled` entry point bridges Spring's blocking scheduler thread into a coroutine
+ *   via `runBlocking { ... }` and **MUST** rethrow [CancellationException] so cooperative
+ *   cancellation propagates to the scheduler.
+ * - [executionCount] is exposed for testing; not for production use.
+ */
+@Service
+class SuspendGroupLeaderService(
+    private val elector: ZooKeeperSuspendLeaderGroupElector,
+    @Suppress("unused") private val props: LeaderZookeeperProperties,
+) {
+    companion object : KLoggingChannel() {
+        const val LOCK_NAME = "workshop:suspend-group-job"
+    }
+
+    /** Number of times this instance entered a leader slot. */
+    val executionCount = AtomicInteger(0)
+
+    /**
+     * Suspending group-leader work — safe to call from `runTest { ... }` in tests.
+     *
+     * @return `"done"` when this instance entered a slot, `null` when no slot was available.
+     */
+    suspend fun runLeaderWork(lockName: String = LOCK_NAME): String? =
+        elector.runIfLeader(lockName) {
+            executionCount.incrementAndGet()
+            log.info { "[GROUP-LEADER] SuspendGroupLeaderService entered slot" }
+            delay(20) // simulate async I/O without blocking a thread
+            log.info { "[GROUP-LEADER] SuspendGroupLeaderService slot work complete (total=${executionCount.get()})" }
+            "done"
+        }.also {
+            if (it == null) log.debug { "[SKIPPED] SuspendGroupLeaderService — no slot available" }
+        }
+
+    /**
+     * Scheduled entry point.
+     *
+     * Rethrows [CancellationException] (CLAUDE.md: never swallow cancellation) and
+     * logs other exceptions so the scheduler thread survives transient failures.
+     */
+    @Scheduled(fixedDelayString = "\${leader.zookeeper.suspend-group-job-fixed-delay:PT18S}")
+    fun runScheduled() {
+        try {
+            runBlocking { runLeaderWork() }
+        } catch (e: CancellationException) {
+            throw e // MUST rethrow — CLAUDE.md: never swallow CancellationException
+        } catch (e: Exception) {
+            log.warn(e) { "Scheduled suspend group leader work failed" }
+        }
+    }
+}

--- a/leader/leader-zookeeper/src/main/kotlin/io/bluetape4k/workshop/leader/zookeeper/service/SuspendLeaderZkService.kt
+++ b/leader/leader-zookeeper/src/main/kotlin/io/bluetape4k/workshop/leader/zookeeper/service/SuspendLeaderZkService.kt
@@ -1,0 +1,71 @@
+package io.bluetape4k.workshop.leader.zookeeper.service
+
+import io.bluetape4k.leader.zookeeper.ZooKeeperSuspendLeaderElector
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.logging.debug
+import io.bluetape4k.logging.info
+import io.bluetape4k.logging.warn
+import io.bluetape4k.workshop.leader.zookeeper.config.LeaderZookeeperProperties
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Service
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Coroutine-native single-leader workshop service backed by [ZooKeeperSuspendLeaderElector].
+ *
+ * ## Behavior / Contract
+ * - [runLeaderWork] suspends while waiting for the ZooKeeper lock; no thread is blocked.
+ * - Returns the action result when elected, `null` when skipped.
+ * - The `@Scheduled` entry point bridges Spring's blocking scheduler thread into a coroutine
+ *   via `runBlocking { ... }` and **MUST** rethrow [CancellationException] so cooperative
+ *   cancellation propagates to the scheduler.
+ * - [executionCount] is exposed for testing; not for production use.
+ */
+@Service
+class SuspendLeaderZkService(
+    private val elector: ZooKeeperSuspendLeaderElector,
+    @Suppress("unused") private val props: LeaderZookeeperProperties,
+) {
+    companion object : KLoggingChannel() {
+        const val LOCK_NAME = "workshop:suspend-job"
+    }
+
+    /** Number of times this instance was elected and executed the leader action. */
+    val executionCount = AtomicInteger(0)
+
+    /**
+     * Suspending leader work — safe to call from `runTest { ... }` in tests.
+     *
+     * @return `"done"` when this instance won the lock, `null` when skipped.
+     */
+    suspend fun runLeaderWork(lockName: String = LOCK_NAME): String? =
+        elector.runIfLeader(lockName) {
+            executionCount.incrementAndGet()
+            log.info { "[LEADER] SuspendLeaderZkService coroutine work started" }
+            delay(20) // simulate async I/O without blocking a thread
+            log.info { "[LEADER] SuspendLeaderZkService coroutine work complete (total=${executionCount.get()})" }
+            "done"
+        }.also {
+            if (it == null) log.debug { "[SKIPPED] SuspendLeaderZkService not the elected leader" }
+        }
+
+    /**
+     * Scheduled entry point.
+     *
+     * Rethrows [CancellationException] (CLAUDE.md: never swallow cancellation) and
+     * logs other exceptions so the scheduler thread survives transient failures.
+     */
+    @Scheduled(fixedDelayString = "\${leader.zookeeper.suspend-job-fixed-delay:PT12S}")
+    fun runScheduled() {
+        try {
+            runBlocking { runLeaderWork() }
+        } catch (e: CancellationException) {
+            throw e // MUST rethrow — CLAUDE.md: never swallow CancellationException
+        } catch (e: Exception) {
+            log.warn(e) { "Scheduled suspend leader work failed" }
+        }
+    }
+}

--- a/leader/leader-zookeeper/src/main/resources/application.yml
+++ b/leader/leader-zookeeper/src/main/resources/application.yml
@@ -1,0 +1,29 @@
+spring:
+  application:
+    name: leader-zookeeper
+
+leader:
+  zookeeper:
+    zookeeper:
+      connect-string: localhost:2181
+      session-timeout-ms: 60000
+      connection-timeout-ms: 15000
+      block-until-connected-seconds: 10
+    base-path: /workshop/leader-zookeeper
+    wait-time: 2s
+    group-max-leaders: 2
+    job-fixed-delay: PT10S
+    suspend-job-fixed-delay: PT12S
+    group-job-fixed-delay: PT15S
+    suspend-group-job-fixed-delay: PT18S
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info
+
+logging:
+  level:
+    io.bluetape4k.workshop.leader.zookeeper: INFO
+    io.bluetape4k.leader.zookeeper: DEBUG

--- a/leader/leader-zookeeper/src/main/resources/logback-spring.xml
+++ b/leader/leader-zookeeper/src/main/resources/logback-spring.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+    <!-- @formatter:off -->
+    <springProperty scope="context" name="APP_NAME" source="spring.application.name"/>
+
+    <property name="CONSOLE_LOG_PATTERN"
+              value="%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %highlight(${LOG_LEVEL_PATTERN:-%5p}) %clr(${PID:- }){magenta} %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}"/>
+
+    <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>DEBUG</level>
+        </filter>
+        <encoder>
+            <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+            <charset>utf8</charset>
+        </encoder>
+    </appender>
+    <!-- @formatter:on -->
+
+    <logger name="io.bluetape4k.workshop.leader.zookeeper" level="INFO"/>
+    <logger name="io.bluetape4k.leader.zookeeper" level="DEBUG"/>
+
+    <root level="INFO">
+        <appender-ref ref="console"/>
+    </root>
+</configuration>

--- a/leader/leader-zookeeper/src/test/kotlin/io/bluetape4k/workshop/leader/zookeeper/AbstractLeaderZookeeperTest.kt
+++ b/leader/leader-zookeeper/src/test/kotlin/io/bluetape4k/workshop/leader/zookeeper/AbstractLeaderZookeeperTest.kt
@@ -1,0 +1,67 @@
+package io.bluetape4k.workshop.leader.zookeeper
+
+import io.bluetape4k.leader.LeaderElectionOptions
+import io.bluetape4k.leader.LeaderGroupElectionOptions
+import io.bluetape4k.leader.zookeeper.ZooKeeperLeaderElector
+import io.bluetape4k.leader.zookeeper.ZooKeeperLeaderGroupElector
+import io.bluetape4k.leader.zookeeper.ZooKeeperSuspendLeaderElector
+import io.bluetape4k.leader.zookeeper.ZooKeeperSuspendLeaderGroupElector
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.testcontainers.infra.ZooKeeperServer
+import io.bluetape4k.utils.ShutdownQueue
+import org.apache.curator.framework.CuratorFramework
+import org.junit.jupiter.api.TestInstance
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+import kotlin.time.Duration.Companion.milliseconds
+
+/**
+ * Abstract base for ZooKeeper leader election tests.
+ *
+ * Uses a single shared [CuratorFramework] in the companion object (initialized lazily once per JVM).
+ * InterProcessMutex ownership is keyed on Thread, not ZooKeeper session, so all workers
+ * competing via the same [curator] instance will correctly contend for the lock.
+ *
+ * Lazy initialization ensures the ZooKeeper container is started before the first test accesses it.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+abstract class AbstractLeaderZookeeperTest {
+
+    companion object : KLogging() {
+        val zookeeper: ZooKeeperServer = ZooKeeperServer.Launcher.zookeeper
+
+        /** Shared CuratorFramework — safe to share across threads/coroutines (InterProcessMutex is Thread-keyed). */
+        val curator: CuratorFramework by lazy {
+            ZooKeeperServer.Launcher.getCuratorFramework(zookeeper).also {
+                it.start()
+                check(it.blockUntilConnected(10, TimeUnit.SECONDS)) {
+                    "Test curator could not connect to ZooKeeper within 10s (url=${zookeeper.url})"
+                }
+                ShutdownQueue.register { it.close() }
+            }
+        }
+    }
+
+    // waitTime = 500ms: provides margin for CI timing jitter
+    fun newElector(basePath: String = "/test/single") =
+        ZooKeeperLeaderElector(curator, basePath, LeaderElectionOptions(waitTime = 500.milliseconds))
+
+    fun newSuspendElector(basePath: String = "/test/single-suspend") =
+        ZooKeeperSuspendLeaderElector(curator, basePath, LeaderElectionOptions(waitTime = 500.milliseconds))
+
+    fun newGroupElector(maxLeaders: Int = 2, basePath: String = "/test/group") =
+        ZooKeeperLeaderGroupElector(
+            client = curator,
+            options = LeaderGroupElectionOptions(maxLeaders = maxLeaders, waitTime = 500.milliseconds),
+            basePath = basePath
+        )
+
+    fun newSuspendGroupElector(maxLeaders: Int = 2, basePath: String = "/test/group-suspend") =
+        ZooKeeperSuspendLeaderGroupElector(
+            client = curator,
+            options = LeaderGroupElectionOptions(maxLeaders = maxLeaders, waitTime = 500.milliseconds),
+            basePath = basePath
+        )
+
+    fun randomLockName(prefix: String = "t") = "$prefix:${UUID.randomUUID()}"
+}

--- a/leader/leader-zookeeper/src/test/kotlin/io/bluetape4k/workshop/leader/zookeeper/BlockingSingleLeaderTest.kt
+++ b/leader/leader-zookeeper/src/test/kotlin/io/bluetape4k/workshop/leader/zookeeper/BlockingSingleLeaderTest.kt
@@ -1,0 +1,76 @@
+package io.bluetape4k.workshop.leader.zookeeper
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.concurrent.virtualthread.VirtualThreadExecutor
+import io.bluetape4k.leader.LeaderElectionOptions
+import io.bluetape4k.leader.zookeeper.ZooKeeperLeaderElector
+import org.junit.jupiter.api.Test
+import java.util.concurrent.CompletableFuture
+import kotlin.time.Duration.Companion.milliseconds
+
+/**
+ * T1: Single-instance leader election test for the blocking [ZooKeeperLeaderElector].
+ *
+ * ## Behavior verified
+ * - `runIfLeader` returns the action result when a single instance acquires the lock.
+ * - `runAsyncIfLeader` returns a [CompletableFuture] whose value matches the action result.
+ * - `runIfLeader` returns `null` when a second elector cannot acquire the lock within
+ *   its `waitTime` because the first elector is holding it.
+ */
+class BlockingSingleLeaderTest : AbstractLeaderZookeeperTest() {
+
+    @Test
+    fun `runIfLeader returns done when a single elector acquires the lock`() {
+        val elector = newElector()
+
+        val result = elector.runIfLeader(randomLockName()) { "done" }
+
+        result.shouldNotBeNull() shouldBeEqualTo "done"
+    }
+
+    @Test
+    fun `runAsyncIfLeader returns 42 via the CompletableFuture`() {
+        val elector = newElector()
+        val executor = VirtualThreadExecutor
+
+        val future: CompletableFuture<Int?> = elector.runAsyncIfLeader(
+            lockName = randomLockName(),
+            executor = executor,
+        ) {
+            CompletableFuture.completedFuture(42)
+        }
+
+        future.join().shouldNotBeNull() shouldBeEqualTo 42
+    }
+
+    @Test
+    fun `runIfLeader returns null when the lock is held by another elector`() {
+        val lockName = randomLockName()
+        // Two distinct electors competing for the same lock.
+        // elector1 (on the main test thread) holds the lock; elector2 has waitTime = 0ms.
+        // InterProcessMutex ownership is keyed on Thread.currentThread(), so elector2
+        // MUST run on a different thread or it would be granted the lock reentrantly.
+        val elector1: ZooKeeperLeaderElector = newElector()
+        val elector2 = ZooKeeperLeaderElector(
+            curator,
+            "/test/single",
+            LeaderElectionOptions(waitTime = 0.milliseconds)
+        )
+
+        val result2Ref = java.util.concurrent.atomic.AtomicReference<String?>("not-set")
+        val result1 = elector1.runIfLeader(lockName) {
+            // Run elector2 on a separate thread so it does NOT reentrantly own elector1's lock.
+            val follower = Thread {
+                result2Ref.set(elector2.runIfLeader(lockName) { "follower" })
+            }
+            follower.start()
+            follower.join()
+            "leader"
+        }
+
+        result1.shouldNotBeNull() shouldBeEqualTo "leader"
+        result2Ref.get().shouldBeNull()
+    }
+}

--- a/leader/leader-zookeeper/src/test/kotlin/io/bluetape4k/workshop/leader/zookeeper/ConcurrentBlockingLeaderTest.kt
+++ b/leader/leader-zookeeper/src/test/kotlin/io/bluetape4k/workshop/leader/zookeeper/ConcurrentBlockingLeaderTest.kt
@@ -1,0 +1,58 @@
+package io.bluetape4k.workshop.leader.zookeeper
+
+import io.bluetape4k.assertions.shouldBeGreaterThan
+import io.bluetape4k.assertions.shouldBeLessOrEqualTo
+import io.bluetape4k.junit5.concurrency.MultithreadingTester
+import org.junit.jupiter.api.Test
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.math.max
+
+/**
+ * T2: Concurrent blocking leader election — at most one worker inside the action body.
+ *
+ * 8 workers compete for a single shared [io.bluetape4k.leader.zookeeper.ZooKeeperLeaderElector]
+ * using the shared curator from [AbstractLeaderZookeeperTest].
+ *
+ * ## Behavior verified
+ * - `peakConcurrent` (the maximum number of workers simultaneously inside the action body)
+ *   never exceeds 1 — i.e., the lock provides strict mutual exclusion.
+ * - At least 3 of the 8 workers eventually execute the action successfully (proving that
+ *   the lock is released between workers and that the wait window admits multiple wins).
+ *
+ * Uses [MultithreadingTester] (bluetape4k-junit5) — raw Thread/Executors/CyclicBarrier forbidden.
+ */
+class ConcurrentBlockingLeaderTest : AbstractLeaderZookeeperTest() {
+
+    @Test
+    fun `peakConcurrent never exceeds 1 across 8 concurrent workers`() {
+        val lockName = randomLockName("t2")
+        // Shared single elector created ONCE outside the worker block — workers compete on it.
+        val elector = newElector()
+
+        val executed = AtomicInteger(0)
+        val current = AtomicInteger(0)
+        val peakConcurrent = AtomicInteger(0)
+
+        MultithreadingTester()
+            .workers(8)
+            .rounds(1)
+            .add {
+                elector.runIfLeader(lockName) {
+                    val c = current.incrementAndGet()
+                    peakConcurrent.updateAndGet { max(it, c) }
+                    try {
+                        executed.incrementAndGet()
+                        // Hold the lock briefly so other workers actually contend, but short
+                        // enough that several can serialize through within their 500ms waitTime.
+                        Thread.sleep(30)
+                    } finally {
+                        current.decrementAndGet()
+                    }
+                }
+            }
+            .run()
+
+        peakConcurrent.get() shouldBeLessOrEqualTo 1
+        executed.get() shouldBeGreaterThan 3
+    }
+}

--- a/leader/leader-zookeeper/src/test/kotlin/io/bluetape4k/workshop/leader/zookeeper/ExtensionFunctionTest.kt
+++ b/leader/leader-zookeeper/src/test/kotlin/io/bluetape4k/workshop/leader/zookeeper/ExtensionFunctionTest.kt
@@ -60,7 +60,7 @@ class ExtensionFunctionTest : AbstractLeaderZookeeperTest() {
     }
 
     @Test
-    fun `suspendRunIfLeader extension returns the suspending action result`() = runTest {
+    fun `suspendRunIfLeader extension returns the suspending action result`(): Unit = runTest {
         val result = curator.suspendRunIfLeader(
             lockName = randomLockName("t6-suspend"),
             basePath = "/test/ext-suspend",

--- a/leader/leader-zookeeper/src/test/kotlin/io/bluetape4k/workshop/leader/zookeeper/ExtensionFunctionTest.kt
+++ b/leader/leader-zookeeper/src/test/kotlin/io/bluetape4k/workshop/leader/zookeeper/ExtensionFunctionTest.kt
@@ -1,0 +1,87 @@
+package io.bluetape4k.workshop.leader.zookeeper
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.concurrent.virtualthread.VirtualThreadExecutor
+import io.bluetape4k.leader.LeaderElectionOptions
+import io.bluetape4k.leader.LeaderGroupElectionOptions
+import io.bluetape4k.leader.zookeeper.runAsyncIfLeader
+import io.bluetape4k.leader.zookeeper.runIfLeader
+import io.bluetape4k.leader.zookeeper.runIfLeaderGroup
+import io.bluetape4k.leader.zookeeper.suspendRunIfLeader
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import java.util.concurrent.CompletableFuture
+import kotlin.time.Duration.Companion.milliseconds
+
+/**
+ * T6: [org.apache.curator.framework.CuratorFramework] extension functions exposed by the
+ * `io.bluetape4k.leader.zookeeper` package.
+ *
+ * ## Behavior verified
+ * - `runIfLeader` extension acquires leadership and returns the action result.
+ * - `runAsyncIfLeader` extension returns a [CompletableFuture] whose value matches the action result.
+ * - `suspendRunIfLeader` extension returns the suspending action result.
+ * - `runIfLeaderGroup` extension acquires a group slot and returns the action result.
+ *   The parameter is named `options=` (NOT `groupOptions=`), confirmed from the library source.
+ *
+ * Each extension call uses a unique `basePath` to avoid cross-test path collisions
+ * with other tests in this suite.
+ */
+class ExtensionFunctionTest : AbstractLeaderZookeeperTest() {
+
+    private val singleOptions = LeaderElectionOptions(waitTime = 500.milliseconds)
+
+    @Test
+    fun `runIfLeader extension returns the action result`() {
+        val result = curator.runIfLeader(
+            lockName = randomLockName("t6-run"),
+            basePath = "/test/ext-single",
+            options = singleOptions,
+        ) {
+            "done"
+        }
+
+        result.shouldNotBeNull() shouldBeEqualTo "done"
+    }
+
+    @Test
+    fun `runAsyncIfLeader extension returns the action result via CompletableFuture`() {
+        val future: CompletableFuture<String?> = curator.runAsyncIfLeader(
+            lockName = randomLockName("t6-async"),
+            executor = VirtualThreadExecutor,
+            basePath = "/test/ext-async",
+            options = singleOptions,
+        ) {
+            CompletableFuture.completedFuture("async-done")
+        }
+
+        future.join().shouldNotBeNull() shouldBeEqualTo "async-done"
+    }
+
+    @Test
+    fun `suspendRunIfLeader extension returns the suspending action result`() = runTest {
+        val result = curator.suspendRunIfLeader(
+            lockName = randomLockName("t6-suspend"),
+            basePath = "/test/ext-suspend",
+            options = singleOptions,
+        ) {
+            "suspend-done"
+        }
+
+        result.shouldNotBeNull() shouldBeEqualTo "suspend-done"
+    }
+
+    @Test
+    fun `runIfLeaderGroup extension acquires a slot and returns the action result`() {
+        val result = curator.runIfLeaderGroup(
+            lockName = randomLockName("t6-group"),
+            options = LeaderGroupElectionOptions(maxLeaders = 2, waitTime = 500.milliseconds),
+            basePath = "/test/ext-group",
+        ) {
+            "done"
+        }
+
+        result.shouldNotBeNull() shouldBeEqualTo "done"
+    }
+}

--- a/leader/leader-zookeeper/src/test/kotlin/io/bluetape4k/workshop/leader/zookeeper/GroupLeaderTest.kt
+++ b/leader/leader-zookeeper/src/test/kotlin/io/bluetape4k/workshop/leader/zookeeper/GroupLeaderTest.kt
@@ -1,0 +1,70 @@
+package io.bluetape4k.workshop.leader.zookeeper
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.junit5.concurrency.MultithreadingTester
+import org.junit.jupiter.api.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.math.max
+
+/**
+ * T4 — Verifies that the ZooKeeper group-leader elector admits exactly [maxLeaders] simultaneous
+ * holders under concurrent contention.
+ *
+ * ## Behavior / Contract
+ * - Uses a `CountDownLatch(maxLeaders)` handshake to assert peak concurrency *inside* the action body.
+ *   Sampling after `MultithreadingTester.run()` returns is too late — by then all holders have released.
+ * - The orchestrator thread MUST start BEFORE `MultithreadingTester.run()` (which is blocking).
+ *   If it starts after `run()`, workers would block forever on `releaseLatch.await` since
+ *   `run()` only returns after every worker finishes — classic deadlock.
+ * - `peakConcurrent` is updated via `AtomicInteger.updateAndGet(max(...))` to safely sample the
+ *   maximum across worker threads.
+ */
+class GroupLeaderTest: AbstractLeaderZookeeperTest() {
+
+    companion object: io.bluetape4k.logging.KLogging() {
+        private const val MAX_LEADERS = 2
+        private const val WORKERS = 4
+    }
+
+    @Test
+    fun `maxLeaders=2 admits exactly 2 simultaneous holders`() {
+        val groupElector = newGroupElector(MAX_LEADERS)
+        val lockName = randomLockName("t4")
+        val enteredLatch = CountDownLatch(MAX_LEADERS)
+        val releaseLatch = CountDownLatch(1)
+        val peakConcurrent = AtomicInteger(0)
+        val current = AtomicInteger(0)
+
+        // CRITICAL: orchestrator MUST start BEFORE MultithreadingTester.run() (which is blocking).
+        // Otherwise workers would block forever on releaseLatch.await, causing deadlock.
+        val orchestrator = Thread {
+            check(enteredLatch.await(5, TimeUnit.SECONDS)) {
+                "Not enough workers entered — CI too slow or maxLeaders not reached"
+            }
+            releaseLatch.countDown()
+        }
+        orchestrator.start()
+
+        MultithreadingTester()
+            .workers(WORKERS)
+            .rounds(1)
+            .add {
+                groupElector.runIfLeader(lockName) {
+                    val c = current.incrementAndGet()
+                    peakConcurrent.updateAndGet { max(it, c) }
+                    try {
+                        enteredLatch.countDown()
+                        check(releaseLatch.await(3, TimeUnit.SECONDS)) { "releaseLatch timeout" }
+                    } finally {
+                        current.decrementAndGet()
+                    }
+                }
+            }
+            .run()
+
+        orchestrator.join(6_000)
+        peakConcurrent.get() shouldBeEqualTo MAX_LEADERS
+    }
+}

--- a/leader/leader-zookeeper/src/test/kotlin/io/bluetape4k/workshop/leader/zookeeper/LeaderServiceBehaviorTest.kt
+++ b/leader/leader-zookeeper/src/test/kotlin/io/bluetape4k/workshop/leader/zookeeper/LeaderServiceBehaviorTest.kt
@@ -1,0 +1,69 @@
+package io.bluetape4k.workshop.leader.zookeeper
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.workshop.leader.zookeeper.config.LeaderZookeeperProperties
+import io.bluetape4k.workshop.leader.zookeeper.service.BlockingLeaderService
+import io.bluetape4k.workshop.leader.zookeeper.service.GroupLeaderService
+import org.junit.jupiter.api.Test
+
+/**
+ * Behavioral tests for [BlockingLeaderService] and [GroupLeaderService].
+ *
+ * Constructs service instances directly (no Spring context) using the shared [curator]
+ * from [AbstractLeaderZookeeperTest]. Verifies that each service correctly delegates
+ * to the underlying elector and updates its [BlockingLeaderService.executionCount].
+ */
+class LeaderServiceBehaviorTest : AbstractLeaderZookeeperTest() {
+
+    companion object : KLogging()
+
+    private val defaultProps = LeaderZookeeperProperties()
+
+    @Test
+    fun `BlockingLeaderService runLeaderWork returns done and increments executionCount`() {
+        val elector = newElector(basePath = "/test/svc/blocking")
+        val service = BlockingLeaderService(elector, defaultProps)
+
+        val result = service.runLeaderWork(randomLockName("svc-blocking"))
+
+        result shouldBeEqualTo "done"
+        service.executionCount.get() shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `BlockingLeaderService runLeaderWork increments executionCount on repeated calls`() {
+        val elector = newElector(basePath = "/test/svc/blocking-repeat")
+        val service = BlockingLeaderService(elector, defaultProps)
+        val lockName = randomLockName("svc-blocking-repeat")
+
+        repeat(3) { service.runLeaderWork(lockName) }
+
+        service.executionCount.get() shouldBeEqualTo 3
+    }
+
+    @Test
+    fun `GroupLeaderService runLeaderWork returns done and increments executionCount`() {
+        val elector = newGroupElector(maxLeaders = 1, basePath = "/test/svc/group")
+        val service = GroupLeaderService(elector, defaultProps)
+
+        val result = service.runLeaderWork(randomLockName("svc-group"))
+
+        result shouldBeEqualTo "done"
+        service.executionCount.get() shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `GroupLeaderService inspectState returns non-null LeaderGroupState`() {
+        val elector = newGroupElector(maxLeaders = 2, basePath = "/test/svc/group-state")
+        val service = GroupLeaderService(elector, defaultProps)
+        val lockName = randomLockName("svc-state")
+
+        // Acquire a slot so state is non-trivially populated
+        service.runLeaderWork(lockName)
+
+        val state = service.inspectState(lockName)
+        state.shouldNotBeNull()
+    }
+}

--- a/leader/leader-zookeeper/src/test/kotlin/io/bluetape4k/workshop/leader/zookeeper/LeaderZookeeperContextTest.kt
+++ b/leader/leader-zookeeper/src/test/kotlin/io/bluetape4k/workshop/leader/zookeeper/LeaderZookeeperContextTest.kt
@@ -1,0 +1,65 @@
+package io.bluetape4k.workshop.leader.zookeeper
+
+import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.leader.zookeeper.ZooKeeperLeaderElector
+import io.bluetape4k.leader.zookeeper.ZooKeeperLeaderGroupElector
+import io.bluetape4k.leader.zookeeper.ZooKeeperSuspendLeaderElector
+import io.bluetape4k.leader.zookeeper.ZooKeeperSuspendLeaderGroupElector
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.testcontainers.infra.ZooKeeperServer
+import io.bluetape4k.workshop.leader.zookeeper.service.BlockingLeaderService
+import io.bluetape4k.workshop.leader.zookeeper.service.GroupLeaderService
+import io.bluetape4k.workshop.leader.zookeeper.service.SuspendGroupLeaderService
+import io.bluetape4k.workshop.leader.zookeeper.service.SuspendLeaderZkService
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+
+/**
+ * T0: Spring Boot context loading test for the leader-zookeeper workshop module.
+ *
+ * Verifies that all 4 elector beans and 4 leader service beans are wired correctly.
+ * Catches `@Component`/`@Bean` omissions, type mismatches, and configuration property
+ * binding failures at runtime before they reach production.
+ *
+ * Uses `@DynamicPropertySource` to inject the Testcontainers ZooKeeper URL.
+ *
+ * NOTE: The Spring property key is `leader.zookeeper.zookeeper.connect-string`
+ * (the outer `leader.zookeeper` prefix + the inner nested `zookeeper.connectString` field).
+ */
+@SpringBootTest
+class LeaderZookeeperContextTest(
+    @Autowired val leaderElector: ZooKeeperLeaderElector,
+    @Autowired val suspendLeaderElector: ZooKeeperSuspendLeaderElector,
+    @Autowired val leaderGroupElector: ZooKeeperLeaderGroupElector,
+    @Autowired val suspendLeaderGroupElector: ZooKeeperSuspendLeaderGroupElector,
+    @Autowired val blockingLeaderService: BlockingLeaderService,
+    @Autowired val suspendLeaderService: SuspendLeaderZkService,
+    @Autowired val groupLeaderService: GroupLeaderService,
+    @Autowired val suspendGroupLeaderService: SuspendGroupLeaderService,
+) {
+    companion object : KLogging() {
+        val zookeeper: ZooKeeperServer = ZooKeeperServer.Launcher.zookeeper
+
+        @JvmStatic
+        @DynamicPropertySource
+        fun zkProperties(registry: DynamicPropertyRegistry) {
+            registry.add("leader.zookeeper.zookeeper.connect-string") { zookeeper.url }
+        }
+    }
+
+    @Test
+    fun `Spring context loads all 4 electors and 4 services`() {
+        leaderElector.shouldNotBeNull()
+        suspendLeaderElector.shouldNotBeNull()
+        leaderGroupElector.shouldNotBeNull()
+        suspendLeaderGroupElector.shouldNotBeNull()
+
+        blockingLeaderService.shouldNotBeNull()
+        suspendLeaderService.shouldNotBeNull()
+        groupLeaderService.shouldNotBeNull()
+        suspendGroupLeaderService.shouldNotBeNull()
+    }
+}

--- a/leader/leader-zookeeper/src/test/kotlin/io/bluetape4k/workshop/leader/zookeeper/LeaderZookeeperPropertiesValidationTest.kt
+++ b/leader/leader-zookeeper/src/test/kotlin/io/bluetape4k/workshop/leader/zookeeper/LeaderZookeeperPropertiesValidationTest.kt
@@ -1,8 +1,8 @@
 package io.bluetape4k.workshop.leader.zookeeper
 
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.workshop.leader.zookeeper.config.LeaderZookeeperProperties
 import org.junit.jupiter.api.Test
-import kotlin.test.assertFailsWith
 
 /**
  * T9: [LeaderZookeeperProperties] `init {}` validation tests.

--- a/leader/leader-zookeeper/src/test/kotlin/io/bluetape4k/workshop/leader/zookeeper/LeaderZookeeperPropertiesValidationTest.kt
+++ b/leader/leader-zookeeper/src/test/kotlin/io/bluetape4k/workshop/leader/zookeeper/LeaderZookeeperPropertiesValidationTest.kt
@@ -1,0 +1,38 @@
+package io.bluetape4k.workshop.leader.zookeeper
+
+import io.bluetape4k.workshop.leader.zookeeper.config.LeaderZookeeperProperties
+import org.junit.jupiter.api.Test
+import kotlin.test.assertFailsWith
+
+/**
+ * T9: [LeaderZookeeperProperties] `init {}` validation tests.
+ *
+ * Pure unit tests — no Spring context, no ZooKeeper container. Verifies that the
+ * constructor rejects invalid configurations early so misconfiguration cannot reach
+ * production.
+ */
+class LeaderZookeeperPropertiesValidationTest {
+
+    @Test
+    fun `blank basePath throws IllegalArgumentException`() {
+        assertFailsWith<IllegalArgumentException> {
+            LeaderZookeeperProperties(basePath = "")
+        }
+    }
+
+    @Test
+    fun `zero groupMaxLeaders throws IllegalArgumentException`() {
+        assertFailsWith<IllegalArgumentException> {
+            LeaderZookeeperProperties(groupMaxLeaders = 0)
+        }
+    }
+
+    @Test
+    fun `blank connectString throws IllegalArgumentException`() {
+        assertFailsWith<IllegalArgumentException> {
+            LeaderZookeeperProperties(
+                zookeeper = LeaderZookeeperProperties.ZooKeeperConfig(connectString = "")
+            )
+        }
+    }
+}

--- a/leader/leader-zookeeper/src/test/kotlin/io/bluetape4k/workshop/leader/zookeeper/R16AutoExtendIgnoredTest.kt
+++ b/leader/leader-zookeeper/src/test/kotlin/io/bluetape4k/workshop/leader/zookeeper/R16AutoExtendIgnoredTest.kt
@@ -1,0 +1,73 @@
+package io.bluetape4k.workshop.leader.zookeeper
+
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldNotBeEmpty
+import io.bluetape4k.leader.LeaderElectionOptions
+import io.bluetape4k.leader.zookeeper.ZooKeeperLeaderElector
+import io.bluetape4k.logging.KLogging
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.slf4j.LoggerFactory
+import kotlin.time.Duration.Companion.milliseconds
+
+/**
+ * T7 — Verifies R16 (ZooKeeper has no TTL) by asserting that setting
+ * [LeaderElectionOptions.autoExtend] = `true` emits a WARN log and is then silently ignored
+ * while the action still executes successfully.
+ *
+ * ## Behavior / Contract
+ * - Attaches a Logback [ListAppender] to the library logger `io.bluetape4k.leader.zookeeper`
+ *   to capture WARN events emitted by [ZooKeeperLeaderElector].
+ * - The WARN message is localized in Korean but contains the ASCII token `"autoExtend"` verbatim,
+ *   so the assertion checks for that substring in `formattedMessage`. Do NOT change this substring.
+ * - In `@AfterEach`, the appender MUST be detached from the logger BEFORE `stop()`; otherwise
+ *   the stopped appender leaks into subsequent tests sharing the same logger.
+ */
+class R16AutoExtendIgnoredTest: AbstractLeaderZookeeperTest() {
+
+    companion object: KLogging() {
+        private const val LIBRARY_LOGGER_NAME = "io.bluetape4k.leader.zookeeper"
+    }
+
+    private lateinit var appender: ListAppender<ILoggingEvent>
+
+    @BeforeEach
+    fun setupLogCapture() {
+        val logger = LoggerFactory.getLogger(LIBRARY_LOGGER_NAME) as Logger
+        appender = ListAppender<ILoggingEvent>().also { it.start() }
+        logger.addAppender(appender)
+    }
+
+    @AfterEach
+    fun teardownLogCapture() {
+        // MUST detachAppender BEFORE stop() — stop() alone does NOT remove the appender from
+        // the logger, leaking the stopped appender into subsequent tests.
+        val logger = LoggerFactory.getLogger(LIBRARY_LOGGER_NAME) as Logger
+        logger.detachAppender(appender)
+        appender.stop()
+    }
+
+    @Test
+    fun `autoExtend option is silently ignored with WARN log`() {
+        val elector = ZooKeeperLeaderElector(
+            curator,
+            "/test/r16",
+            LeaderElectionOptions(autoExtend = true, waitTime = 500.milliseconds)
+        )
+
+        val result = elector.runIfLeader(randomLockName("t7")) { "r16-done" }
+
+        result shouldBeEqualTo "r16-done"
+        // WARN message is in Korean but contains ASCII token "autoExtend" verbatim — source-confirmed
+        // from ZooKeeperLeaderElector.kt:111-113. Do NOT change this substring.
+        val warnEvents = appender.list.filter {
+            it.level == Level.WARN && "autoExtend" in it.formattedMessage
+        }
+        warnEvents.shouldNotBeEmpty()
+    }
+}

--- a/leader/leader-zookeeper/src/test/kotlin/io/bluetape4k/workshop/leader/zookeeper/SessionLossFailoverTest.kt
+++ b/leader/leader-zookeeper/src/test/kotlin/io/bluetape4k/workshop/leader/zookeeper/SessionLossFailoverTest.kt
@@ -1,0 +1,122 @@
+package io.bluetape4k.workshop.leader.zookeeper
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.leader.LeaderElectionOptions
+import io.bluetape4k.leader.zookeeper.ZooKeeperLeaderElector
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.testcontainers.infra.ZooKeeperServer
+import org.apache.curator.framework.CuratorFramework
+import org.awaitility.kotlin.atMost
+import org.awaitility.kotlin.await
+import org.awaitility.kotlin.untilAsserted
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.time.Duration
+import java.util.UUID
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlin.time.Duration.Companion.milliseconds
+
+/**
+ * T8 — Demonstrates R16: ZooKeeper session expiry triggers ephemeral node removal and re-election.
+ *
+ * ## Isolation Strategy
+ *
+ * This test does NOT extend [AbstractLeaderZookeeperTest] — inheriting it would expose the shared
+ * Launcher singleton curator through companion-object methods and accidentally coupling other tests
+ * to client-side session closure performed here.
+ *
+ * Uses client-side ZooKeeper session close (NOT container restart) to simulate session expiry:
+ * `clientA.zookeeperClient.zooKeeper.close()` forces the ZK server to mark the session expired
+ * and remove ephemeral nodes — equivalent to a network partition or process crash. Container
+ * `stop()`/`start()` is avoided because `ZooKeeperServer(reuse=true)` remaps the host port,
+ * leaving any existing Curator client in a stale state.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class SessionLossFailoverTest {
+
+    companion object: KLogging() {
+        private const val BASE_PATH = "/test/t8"
+        private val WAIT_TIME_SHORT = 500.milliseconds
+        private val WAIT_TIME_LONG = 10_000.milliseconds
+    }
+
+    private lateinit var isolatedZk: ZooKeeperServer
+    private lateinit var clientA: CuratorFramework
+    private lateinit var clientB: CuratorFramework
+
+    fun randomLockName(prefix: String = "t8") = "$prefix:${UUID.randomUUID()}"
+
+    @BeforeAll
+    fun startIsolatedZk() {
+        // reuse=false so the container lifecycle is fully owned by this test class.
+        isolatedZk = ZooKeeperServer(reuse = false).also { it.start() }
+        clientA = ZooKeeperServer.Launcher.getCuratorFramework(isolatedZk).also {
+            it.start()
+            check(it.blockUntilConnected(10, TimeUnit.SECONDS)) { "clientA connection timeout" }
+        }
+        clientB = ZooKeeperServer.Launcher.getCuratorFramework(isolatedZk).also {
+            it.start()
+            check(it.blockUntilConnected(10, TimeUnit.SECONDS)) { "clientB connection timeout" }
+        }
+    }
+
+    @AfterAll
+    fun stopIsolatedZk() {
+        runCatching { clientA.close() }
+        runCatching { clientB.close() }
+        runCatching { isolatedZk.stop() }
+    }
+
+    @Test
+    fun `session loss causes leadership failover`() {
+        val lockName = randomLockName()
+        val workerAHoldingLatch = CountDownLatch(1)
+        val workerADoneLatch = CountDownLatch(1)
+
+        // workerA acquires leadership in a background thread and holds it until interrupted.
+        val workerAThread = Thread {
+            val electorA = ZooKeeperLeaderElector(
+                client = clientA,
+                basePath = BASE_PATH,
+                options = LeaderElectionOptions(waitTime = WAIT_TIME_SHORT)
+            )
+            try {
+                electorA.runIfLeader(lockName) {
+                    workerAHoldingLatch.countDown()  // signal: "I now hold the lock"
+                    runCatching { Thread.sleep(60_000) }  // hold until session closed / interrupted
+                    "A-done"
+                }
+            } finally {
+                workerADoneLatch.countDown()
+            }
+        }
+        workerAThread.start()
+
+        // Wait until workerA holds the lock before triggering session loss.
+        check(workerAHoldingLatch.await(10, TimeUnit.SECONDS)) {
+            "workerA did not acquire leadership within 10s"
+        }
+
+        // Simulate session expiry via client-side ZooKeeper close — forces ZK server to expire
+        // the session and remove ephemeral nodes; no container restart needed.
+        clientA.zookeeperClient.zooKeeper.close()
+
+        // workerB should be able to acquire leadership once workerA's session is expired
+        // and the ephemeral node is removed.
+        val electorB = ZooKeeperLeaderElector(
+            client = clientB,
+            basePath = BASE_PATH,
+            options = LeaderElectionOptions(waitTime = WAIT_TIME_LONG)
+        )
+        await atMost Duration.ofSeconds(30) untilAsserted {
+            val workerBResult = electorB.runIfLeader(lockName) { "B-acquired" }
+            workerBResult shouldBeEqualTo "B-acquired"
+        }
+
+        workerAThread.interrupt()
+        workerADoneLatch.await(5, TimeUnit.SECONDS)
+    }
+}

--- a/leader/leader-zookeeper/src/test/kotlin/io/bluetape4k/workshop/leader/zookeeper/SuspendGroupLeaderTest.kt
+++ b/leader/leader-zookeeper/src/test/kotlin/io/bluetape4k/workshop/leader/zookeeper/SuspendGroupLeaderTest.kt
@@ -1,0 +1,74 @@
+package io.bluetape4k.workshop.leader.zookeeper
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.junit5.coroutines.SuspendedJobTester
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.math.max
+
+/**
+ * T5 — Suspend variant of [GroupLeaderTest].
+ *
+ * Verifies that [io.bluetape4k.leader.zookeeper.ZooKeeperSuspendLeaderGroupElector] admits exactly
+ * `maxLeaders` simultaneous coroutine holders.
+ *
+ * ## Behavior / Contract
+ * - Same CountDownLatch handshake as T4, but workers run as coroutines via [SuspendedJobTester].
+ * - Orchestrator thread MUST start BEFORE `SuspendedJobTester.run()` — `run()` is blocking
+ *   from the calling thread's perspective (the suspend builder is wrapped in `runBlocking`).
+ * - `CountDownLatch` is safe to use from inside coroutines too — it does not require structured
+ *   suspension and provides a deterministic synchronization barrier.
+ */
+class SuspendGroupLeaderTest: AbstractLeaderZookeeperTest() {
+
+    companion object: KLoggingChannel() {
+        private const val MAX_LEADERS = 2
+        private const val WORKERS = 4
+    }
+
+    @Test
+    fun `maxLeaders=2 admits exactly 2 simultaneous suspend holders`(): Unit = runBlocking {
+        val groupElector = newSuspendGroupElector(MAX_LEADERS)
+        val lockName = randomLockName("t5")
+        val enteredLatch = CountDownLatch(MAX_LEADERS)
+        val releaseLatch = CountDownLatch(1)
+        val peakConcurrent = AtomicInteger(0)
+        val current = AtomicInteger(0)
+
+        // CRITICAL: orchestrator MUST start BEFORE SuspendedJobTester.run().
+        // Same deadlock risk as T4: workers would block forever on releaseLatch.await.
+        val orchestrator = Thread {
+            check(enteredLatch.await(5, TimeUnit.SECONDS)) {
+                "Not enough coroutines entered — CI too slow or maxLeaders not reached"
+            }
+            releaseLatch.countDown()
+        }
+        orchestrator.start()
+
+        SuspendedJobTester()
+            .workers(WORKERS)
+            .rounds(MAX_LEADERS)
+            .add {
+                groupElector.runIfLeader(lockName) {
+                    val c = current.incrementAndGet()
+                    peakConcurrent.updateAndGet { max(it, c) }
+                    try {
+                        enteredLatch.countDown()
+                        // CountDownLatch.await blocks the carrier thread; acceptable inside the action
+                        // because the underlying coroutine is dispatched to a dedicated thread.
+                        check(releaseLatch.await(3, TimeUnit.SECONDS)) { "releaseLatch timeout" }
+                    } finally {
+                        current.decrementAndGet()
+                    }
+                }
+            }
+            .run()
+
+        orchestrator.join(6_000)
+        peakConcurrent.get() shouldBeEqualTo MAX_LEADERS
+    }
+}

--- a/leader/leader-zookeeper/src/test/kotlin/io/bluetape4k/workshop/leader/zookeeper/SuspendSingleLeaderTest.kt
+++ b/leader/leader-zookeeper/src/test/kotlin/io/bluetape4k/workshop/leader/zookeeper/SuspendSingleLeaderTest.kt
@@ -1,0 +1,70 @@
+package io.bluetape4k.workshop.leader.zookeeper
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeGreaterThan
+import io.bluetape4k.assertions.shouldBeLessOrEqualTo
+import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.junit5.coroutines.SuspendedJobTester
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.math.max
+
+/**
+ * T3: Single-coroutine and concurrent suspend leader election tests for
+ * [io.bluetape4k.leader.zookeeper.ZooKeeperSuspendLeaderElector].
+ *
+ * ## Behavior verified
+ * - A single suspending caller wins leadership and the action returns `"done"`.
+ * - When 8 coroutines compete via [SuspendedJobTester] using a shared elector,
+ *   `peakConcurrent` never exceeds 1 (strict mutual exclusion) and at least 3
+ *   coroutines eventually execute the action body.
+ *
+ * NOTE: The concurrent test uses `runBlocking` (NOT `runTest`) because real ZooKeeper
+ * network I/O does not cooperate with the test virtual-time scheduler used by `runTest`.
+ */
+class SuspendSingleLeaderTest : AbstractLeaderZookeeperTest() {
+
+    @Test
+    fun `runIfLeader returns done for a single suspending caller`() = runTest {
+        val elector = newSuspendElector()
+
+        val result = elector.runIfLeader(randomLockName("t3-single")) { "done" }
+
+        result.shouldNotBeNull() shouldBeEqualTo "done"
+    }
+
+    @Test
+    fun `peakConcurrent never exceeds 1 across 8 concurrent coroutines`(): Unit = runBlocking {
+        val lockName = randomLockName("t3-concurrent")
+        // Shared single suspend elector created ONCE outside the worker block.
+        val elector = newSuspendElector()
+
+        val executed = AtomicInteger(0)
+        val current = AtomicInteger(0)
+        val peakConcurrent = AtomicInteger(0)
+
+        SuspendedJobTester()
+            .workers(8)
+            .rounds(8)
+            .add {
+                elector.runIfLeader(lockName) {
+                    val c = current.incrementAndGet()
+                    peakConcurrent.updateAndGet { max(it, c) }
+                    try {
+                        executed.incrementAndGet()
+                        // Hold briefly so workers contend yet several can serialize through.
+                        delay(30)
+                    } finally {
+                        current.decrementAndGet()
+                    }
+                }
+            }
+            .run()
+
+        peakConcurrent.get() shouldBeLessOrEqualTo 1
+        executed.get() shouldBeGreaterThan 3
+    }
+}

--- a/leader/leader-zookeeper/src/test/resources/junit-platform.properties
+++ b/leader/leader-zookeeper/src/test/resources/junit-platform.properties
@@ -1,0 +1,13 @@
+junit.jupiter.extensions.autodetection.enabled=true
+junit.jupiter.testinstance.lifecycle.default=per_class
+
+# Enable constructor autowiring for @SpringBootTest classes (Spring Framework 5.2+)
+spring.test.constructor.autowire.mode=all
+
+junit.jupiter.execution.parallel.enabled=false
+junit.jupiter.execution.parallel.mode.default=same_thread
+junit.jupiter.execution.parallel.mode.classes.default=concurrent
+
+# Exclude @Tag("smoke") from default test run — flaky timing-dependent tests
+# Run smoke tests separately in nightly or via: ./gradlew test -Djunit.jupiter.execution.exclude.tags=
+junit.jupiter.execution.exclude.tags=smoke

--- a/leader/leader-zookeeper/src/test/resources/logback-test.xml
+++ b/leader/leader-zookeeper/src/test/resources/logback-test.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+    <!-- @formatter:off -->
+    <property name="CONSOLE_LOG_PATTERN"
+              value="%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %highlight(${LOG_LEVEL_PATTERN:-%5p}) %magenta(${PID:- }) %clr(---){faint} %clr([%25.25t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}"/>
+
+    <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>DEBUG</level>
+        </filter>
+        <encoder>
+            <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+            <charset>utf8</charset>
+        </encoder>
+    </appender>
+    <!-- @formatter:on -->
+
+    <logger name="io.bluetape4k.workshop.leader" level="DEBUG"/>
+    <logger name="io.bluetape4k.leader" level="TRACE"/>
+    <logger name="io.bluetape4k.leader.zookeeper" level="DEBUG" additivity="true"/>
+    <logger name="io.bluetape4k.workshop.leader.zookeeper" level="DEBUG" additivity="true"/>
+
+    <root level="INFO">
+        <appender-ref ref="console"/>
+    </root>
+</configuration>


### PR DESCRIPTION
## Summary

New `leader/leader-zookeeper` module demonstrating ZooKeeper-based distributed leader election using `bluetape4k-leader-zookeeper` (Apache Curator 5.9).

Closes part of #10 (PR-B: leader-zookeeper module).

---

## Changes

### New Module: `leader/leader-zookeeper`

**Main sources:**
- `LeaderZookeeperApp.kt` — Spring Boot 4 entry point with `@EnableScheduling`
- `config/LeaderZookeeperProperties.kt` — `@ConfigurationProperties`, R16-aware (no `leaseTime`/`autoExtend`)
- `config/LeaderZookeeperConfig.kt` — `CuratorFramework` bean + 4 elector beans (blocking/suspend × single/group)
- `service/BlockingLeaderService.kt` — single-leader blocking scheduled service
- `service/SuspendLeaderZkService.kt` — single-leader coroutine scheduled service
- `service/GroupLeaderService.kt` — group-leader blocking service with `inspectState()`
- `service/SuspendGroupLeaderService.kt` — group-leader coroutine service

**Test suite (22 tests, 0 failures):**

| Test | Description |
|------|-------------|
| T0 `LeaderZookeeperContextTest` | Spring context loads; all 4 elector beans present |
| T1 `BlockingSingleLeaderTest` | `runIfLeader`, `runAsyncIfLeader`, exception isolation |
| T2 `ConcurrentBlockingLeaderTest` | 8 threads, ≥3 executions within waitTime |
| T3 `SuspendSingleLeaderTest` | suspend single leader + 8-coroutine contention |
| T4 `GroupLeaderTest` | maxLeaders=2 exactly 2 simultaneous blocking holders |
| T5 `SuspendGroupLeaderTest` | maxLeaders=2 exactly 2 simultaneous coroutine holders |
| T6 `ExtensionFunctionTest` | all 4 extension functions |
| T7 `R16AutoExtendIgnoredTest` | autoExtend=true emits WARN and is silently ignored |
| T8 `SessionLossFailoverTest` | session loss via `zookeeperClient.zooKeeper.close()` |
| T9 `LeaderZookeeperPropertiesValidationTest` | blank/zero config validation |
| `LeaderServiceBehaviorTest` | service behavioral tests (Step 6-R addition) |

**Documentation:**
- `README.md` + `README.ko.md` with architecture, R16 callout, config reference, test coverage
- `docs/lessons/2026-05-25-leader-zookeeper.md`

---

## R16 — ZooKeeper Has No TTL

Key difference from Redis-based leader election:
- Leadership is held until session expiry — **no lease TTL**
- `leaseTime` / `autoExtend` intentionally absent from `LeaderZookeeperProperties`
- Setting `autoExtend=true` emits `WARN` and is silently ignored (verified by T7)
- Failover latency controlled by `sessionTimeoutMs` (default 60s)

---

## Key Lessons

1. **`SuspendedJobTester.rounds`**: `totalUnits = rounds × blockCount` (not workers × rounds). Use `rounds(N)` to get N total work units.
2. **`@Test `: Unit`**: Expression-body test functions over `runBlocking {}` must declare `: Unit` return type to avoid JUnit 5 silent exclusion.
3. **Session expiry simulation**: Use `client.zookeeperClient.zooKeeper.close()` — NOT container restart (port remapping with `reuse=true`).
4. **`ConnectionStateListener`**: Must be registered BEFORE `CuratorFramework.start()`.

---

## Test Results

```
./gradlew :leader-leader-zookeeper:test --rerun-tasks
BUILD SUCCESSFUL in 24s
22 tests completed, 0 failed
```

---

## Verification Commands

```bash
# Compile
./gradlew :leader-leader-zookeeper:compileKotlin compileTestKotlin

# Test
./gradlew :leader-leader-zookeeper:test --rerun-tasks
```