### PR TITLE
feat: add graph-knowledge-graph workshop module (#11)

### DIFF
--- a/graph/knowledge-graph/README.ko.md
+++ b/graph/knowledge-graph/README.ko.md
@@ -1,0 +1,173 @@
+# graph-knowledge-graph
+
+[bluetape4k-graph](https://github.com/bluetape4k/bluetape4k-graph) 라이브러리를 활용한 지식 그래프(knowledge graph) 구축 및 탐색 예제입니다.
+
+> **관련 이슈:** [bluetape4k-workshop #11](https://github.com/bluetape4k/bluetape4k-workshop/issues/11)
+
+[English](README.md) | 한국어
+
+## 개요
+
+이 모듈은 프로그래밍 언어, 프레임워크, 라이브러리, 런타임 플랫폼, 그리고 이들을 참조하는 문서를 모델링한 **기술 지식 그래프**를 구현합니다.
+
+주요 학습 내용:
+
+- `VertexLabel` / `EdgeLabel` 스키마 DSL로 이종 엔티티 타입 모델링
+- 문서가 어떤 엔티티를 언급하는지 기록 (`MENTIONS` 엣지 + confidence 점수)
+- 엔티티 간 의미 관계 표현 (`RELATED_TO` 엣지 + relationType)
+- 엔티티를 어휘 개념으로 분류 (`IS_A` 엣지)
+- 설정 가능한 hop 깊이로 그래프 탐색
+- 두 엔티티 사이의 연관 경로 추론 (깊이/건수 제한)
+- 동일한 서비스 로직을 여러 그래프 백엔드(TinkerGraph, Neo4j, Memgraph)에서 실행
+
+## 아키텍처
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                   graph-knowledge-graph                  │
+│                                                          │
+│  ┌─────────────┐    ┌─────────────────────────────────┐ │
+│  │   Schema    │    │           Services               │ │
+│  │─────────────│    │─────────────────────────────────│ │
+│  │ EntityLabel │    │ KnowledgeGraphService (동기)     │ │
+│  │ ConceptLabel│    │ KnowledgeGraphSuspendService     │ │
+│  │ DocumentLbl │    │           (코루틴)               │ │
+│  │ MentionsLbl │    └─────────────────────────────────┘ │
+│  │ RelatedToLbl│              │                          │
+│  │ IsALabel    │    ┌─────────▼─────────────────────┐   │
+│  └─────────────┘    │      GraphOperations           │   │
+│                     │  (bluetape4k-graph-core)       │   │
+│                     └────────────────────────────────┘   │
+│                                  │                        │
+│          ┌───────────────────────┼───────────────────┐   │
+│          ▼                       ▼                    ▼   │
+│   TinkerGraph               Neo4j               Memgraph  │
+│   (인메모리)            (Testcontainer)      (Testcontainer)│
+└─────────────────────────────────────────────────────────┘
+```
+
+## 도메인 모델
+
+시드 그래프는 **기술 도메인** 시나리오를 사용합니다:
+
+```
+Documents ──MENTIONS──► Entities ──RELATED_TO──► Entities
+                              │
+                           IS_A ▼
+                           Concepts
+```
+
+### 버텍스 타입
+
+| Label    | 키 프로퍼티 | 예시 값 |
+|----------|------------|---------|
+| Entity   | entityId   | Kotlin, Spring, JVM, Coroutines |
+| Concept  | conceptId  | Programming Language, Framework, Library, Platform |
+| Document | documentId | "Kotlin in Action", "Spring Boot Reference" |
+
+### 엣지 타입
+
+| Label      | 방향 | 프로퍼티 | 의미 |
+|------------|------|---------|------|
+| MENTIONS   | Doc → Entity | confidence (0–100) | 문서가 엔티티를 언급 |
+| RELATED_TO | Entity → Entity | relationType | 의미 관계 |
+| IS_A       | Entity → Concept | — | 엔티티가 개념으로 분류됨 |
+
+### 시드 토폴로지
+
+```
+doc-kotlin-guide  ──MENTIONS──► entity-kotlin   (confidence=95)
+doc-kotlin-guide  ──MENTIONS──► entity-jvm       (confidence=80)
+doc-spring-guide  ──MENTIONS──► entity-spring    (confidence=98)
+doc-spring-guide  ──MENTIONS──► entity-kotlin    (confidence=75)
+
+entity-kotlin     ──has-feature──►    entity-coroutines
+entity-coroutines ──integrates-with──► entity-spring
+entity-spring     ──runs-on──►        entity-jvm
+entity-kotlin     ──runs-on──►        entity-jvm
+
+entity-kotlin     ──IS_A──► concept-language
+entity-spring     ──IS_A──► concept-framework
+entity-coroutines ──IS_A──► concept-library
+entity-jvm        ──IS_A──► concept-platform
+```
+
+## 핵심 기능
+
+### 엔티티/개념/문서 관리
+
+```kotlin
+val service = KnowledgeGraphService(ops, "knowledge_graph")
+service.initialize()
+
+val paper = service.addDocument("doc-1", "Graph API Guide", "docs")
+val kotlin = service.addEntity("entity-kotlin", "Kotlin", "Language")
+val language = service.addConcept("concept-language", "Programming Language", "software")
+
+service.mention(paper.id, kotlin.id, confidence = 95)
+service.classify(kotlin.id, language.id)
+```
+
+### 그래프 탐색
+
+```kotlin
+// 문서가 어떤 엔티티를 언급하는가?
+val mentioned = service.findMentionedEntities(paper.id)
+
+// Kotlin과 관련된 엔티티는? (최대 2홉)
+val related = service.findRelatedEntities(kotlin.id, depth = 2)
+
+// Kotlin이 속한 개념은?
+val concepts = service.findConceptsForEntity(kotlin.id)
+
+// Kotlin에서 Spring까지의 관계 경로는?
+val paths = service.inferRelationshipPaths(kotlin.id, spring.id, maxDepth = 3, maxPaths = 5)
+```
+
+### 코루틴 변형
+
+```kotlin
+val service = KnowledgeGraphSuspendService(ops, "knowledge_graph")
+service.initialize()
+
+val mentioned: Flow<GraphVertex> = service.findMentionedEntities(paper.id)
+val related: Flow<GraphVertex> = service.findRelatedEntities(kotlin.id, depth = 2)
+val paths: Flow<GraphPath> = service.inferRelationshipPaths(kotlin.id, spring.id)
+```
+
+## 지원 백엔드
+
+| 백엔드      | 클래스                         | Docker 필요 | Gradle 태스크 |
+|-------------|-------------------------------|------------|--------------|
+| TinkerGraph | `TinkerGraphOperations`       | 불필요      | `test`       |
+| Neo4j       | `Neo4jGraphOperations`        | 필요        | `integrationTest` |
+| Memgraph    | `MemgraphGraphOperations`     | 필요        | `integrationTest` |
+
+## 테스트 실행
+
+```bash
+# 기본 테스트 — TinkerGraph만 (Docker 불필요)
+./gradlew :graph-knowledge-graph:test
+
+# 통합 테스트 — Docker 필요 (Neo4j + Memgraph)
+./gradlew :graph-knowledge-graph:integrationTest
+```
+
+## 의존성
+
+```kotlin
+// build.gradle.kts
+dependencies {
+    implementation(libs.bluetape4k.graph.core)
+    implementation(libs.bluetape4k.graph.tinkerpop)
+    compileOnly(libs.bluetape4k.graph.neo4j)
+    compileOnly(libs.bluetape4k.graph.memgraph)
+}
+```
+
+## 관련 문서
+
+- [bluetape4k-graph](https://github.com/bluetape4k/bluetape4k-graph) — 그래프 라이브러리 소스
+- [graph-social-network](../social-network/README.ko.md) — 소셜 네트워크 예제
+- [graph-abuser-detection](../abuser-detection/README.ko.md) — 어뷰저 탐지 예제
+- [bluetape4k-workshop #11](https://github.com/bluetape4k/bluetape4k-workshop/issues/11) — 추적 이슈

--- a/graph/knowledge-graph/README.md
+++ b/graph/knowledge-graph/README.md
@@ -1,0 +1,173 @@
+# graph-knowledge-graph
+
+A workshop example demonstrating knowledge graph construction and traversal using
+the [bluetape4k-graph](https://github.com/bluetape4k/bluetape4k-graph) library.
+
+> **Related issue:** [bluetape4k-workshop #11](https://github.com/bluetape4k/bluetape4k-workshop/issues/11)
+
+## Overview
+
+This module models a **technology knowledge graph** covering programming languages,
+frameworks, libraries, runtime platforms, and the documents that reference them.
+
+It shows how to:
+
+- Model heterogeneous entity types with `VertexLabel` and `EdgeLabel` schema objects
+- Record which documents mention which entities (`MENTIONS` edges with confidence scores)
+- Express semantic relationships between entities (`RELATED_TO` edges with typed relations)
+- Classify entities under vocabulary concepts (`IS_A` edges)
+- Traverse the graph at configurable hop depth
+- Infer association paths between distant entities with a bounded depth/count limit
+- Run the same service logic against multiple graph backends (TinkerGraph, Neo4j, Memgraph)
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                   graph-knowledge-graph                  │
+│                                                          │
+│  ┌─────────────┐    ┌─────────────────────────────────┐ │
+│  │   Schema    │    │           Services               │ │
+│  │─────────────│    │─────────────────────────────────│ │
+│  │ EntityLabel │    │ KnowledgeGraphService (blocking) │ │
+│  │ ConceptLabel│    │ KnowledgeGraphSuspendService     │ │
+│  │ DocumentLbl │    │           (coroutine)            │ │
+│  │ MentionsLbl │    └─────────────────────────────────┘ │
+│  │ RelatedToLbl│              │                          │
+│  │ IsALabel    │    ┌─────────▼─────────────────────┐   │
+│  └─────────────┘    │      GraphOperations           │   │
+│                     │  (bluetape4k-graph-core)       │   │
+│                     └────────────────────────────────┘   │
+│                                  │                        │
+│          ┌───────────────────────┼───────────────────┐   │
+│          ▼                       ▼                    ▼   │
+│   TinkerGraph               Neo4j               Memgraph  │
+│   (in-memory)          (Testcontainer)      (Testcontainer)│
+└─────────────────────────────────────────────────────────┘
+```
+
+## Domain Model
+
+The seed graph uses a **technology domain** scenario:
+
+```
+Documents ──MENTIONS──► Entities ──RELATED_TO──► Entities
+                              │
+                           IS_A ▼
+                           Concepts
+```
+
+### Vertex types
+
+| Label    | Key property | Example values |
+|----------|-------------|----------------|
+| Entity   | entityId    | Kotlin, Spring, JVM, Coroutines |
+| Concept  | conceptId   | Programming Language, Framework, Library, Platform |
+| Document | documentId  | "Kotlin in Action", "Spring Boot Reference" |
+
+### Edge types
+
+| Label      | Direction | Properties | Meaning |
+|------------|-----------|------------|---------|
+| MENTIONS   | Doc → Entity | confidence (0–100) | document mentions entity |
+| RELATED_TO | Entity → Entity | relationType | semantic relationship |
+| IS_A       | Entity → Concept | — | entity is classified under concept |
+
+### Seed topology
+
+```
+doc-kotlin-guide  ──MENTIONS──► entity-kotlin   (confidence=95)
+doc-kotlin-guide  ──MENTIONS──► entity-jvm       (confidence=80)
+doc-spring-guide  ──MENTIONS──► entity-spring    (confidence=98)
+doc-spring-guide  ──MENTIONS──► entity-kotlin    (confidence=75)
+
+entity-kotlin     ──has-feature──►    entity-coroutines
+entity-coroutines ──integrates-with──► entity-spring
+entity-spring     ──runs-on──►        entity-jvm
+entity-kotlin     ──runs-on──►        entity-jvm
+
+entity-kotlin     ──IS_A──► concept-language
+entity-spring     ──IS_A──► concept-framework
+entity-coroutines ──IS_A──► concept-library
+entity-jvm        ──IS_A──► concept-platform
+```
+
+## Core Features
+
+### Entity + concept + document management
+
+```kotlin
+val service = KnowledgeGraphService(ops, "knowledge_graph")
+service.initialize()
+
+val paper = service.addDocument("doc-1", "Graph API Guide", "docs")
+val kotlin = service.addEntity("entity-kotlin", "Kotlin", "Language")
+val language = service.addConcept("concept-language", "Programming Language", "software")
+
+service.mention(paper.id, kotlin.id, confidence = 95)
+service.classify(kotlin.id, language.id)
+```
+
+### Traversal
+
+```kotlin
+// Which entities does a document mention?
+val mentioned = service.findMentionedEntities(paper.id)
+
+// Which entities are related to Kotlin (up to 2 hops)?
+val related = service.findRelatedEntities(kotlin.id, depth = 2)
+
+// What concept is Kotlin classified under?
+val concepts = service.findConceptsForEntity(kotlin.id)
+
+// What are the relationship paths from Kotlin to Spring?
+val paths = service.inferRelationshipPaths(kotlin.id, spring.id, maxDepth = 3, maxPaths = 5)
+```
+
+### Coroutine variant
+
+```kotlin
+val service = KnowledgeGraphSuspendService(ops, "knowledge_graph")
+service.initialize()
+
+val mentioned: Flow<GraphVertex> = service.findMentionedEntities(paper.id)
+val related: Flow<GraphVertex> = service.findRelatedEntities(kotlin.id, depth = 2)
+val paths: Flow<GraphPath> = service.inferRelationshipPaths(kotlin.id, spring.id)
+```
+
+## Supported Backends
+
+| Backend     | Class                        | Docker required | Task        |
+|-------------|------------------------------|-----------------|-------------|
+| TinkerGraph | `TinkerGraphOperations`      | No              | `test`      |
+| Neo4j       | `Neo4jGraphOperations`       | Yes             | `integrationTest` |
+| Memgraph    | `MemgraphGraphOperations`    | Yes             | `integrationTest` |
+
+## Running Tests
+
+```bash
+# Default tests — TinkerGraph only (no Docker required)
+./gradlew :graph-knowledge-graph:test
+
+# Integration tests — requires Docker (Neo4j + Memgraph)
+./gradlew :graph-knowledge-graph:integrationTest
+```
+
+## Dependencies
+
+```kotlin
+// build.gradle.kts
+dependencies {
+    implementation(libs.bluetape4k.graph.core)
+    implementation(libs.bluetape4k.graph.tinkerpop)
+    compileOnly(libs.bluetape4k.graph.neo4j)
+    compileOnly(libs.bluetape4k.graph.memgraph)
+}
+```
+
+## See Also
+
+- [bluetape4k-graph](https://github.com/bluetape4k/bluetape4k-graph) — graph library source
+- [graph-social-network](../social-network/README.md) — social network example
+- [graph-abuser-detection](../abuser-detection/README.md) — fraud/abuse detection example
+- [bluetape4k-workshop #11](https://github.com/bluetape4k/bluetape4k-workshop/issues/11) — tracking issue

--- a/graph/knowledge-graph/build.gradle.kts
+++ b/graph/knowledge-graph/build.gradle.kts
@@ -1,0 +1,55 @@
+plugins {
+    alias(libs.plugins.kotlin.jvm)
+}
+
+configurations {
+    // Expose compileOnly and runtimeOnly dependencies to testImplementation via extendsFrom.
+    // This avoids duplicating neo4j/memgraph on both compileOnly and testImplementation.
+    testImplementation.get().extendsFrom(compileOnly.get(), runtimeOnly.get())
+}
+
+tasks.test {
+    useJUnitPlatform {
+        // Integration tests require running Docker containers — exclude from the default test task.
+        // Run them with: ./gradlew :graph-knowledge-graph:integrationTest
+        excludeTags("integration")
+    }
+}
+
+tasks.register<Test>("integrationTest") {
+    description = "Runs Neo4j and Memgraph integration tests (requires Docker)."
+    group = "verification"
+    useJUnitPlatform {
+        includeTags("integration")
+    }
+    // Inherit the same JVM args as the standard test task.
+    jvmArgs = tasks.test.get().jvmArgs
+}
+
+dependencies {
+    // Graph core + TinkerGraph (in-memory, no Docker needed for default tests)
+    // Version managed by bluetape4k-dependencies BOM
+    implementation(libs.bluetape4k.graph.core)
+    implementation(libs.bluetape4k.graph.tinkerpop)
+
+    // Neo4j and Memgraph backends — compileOnly so tests see them via extendsFrom
+    compileOnly(libs.bluetape4k.graph.neo4j)
+    compileOnly(libs.bluetape4k.graph.memgraph)
+
+    // Bluetape4k
+    implementation(libs.bluetape4k.logging)
+    implementation(libs.bluetape4k.coroutines)
+
+    // Coroutines
+    implementation(libs.kotlinx.coroutines.core.lib)
+    testImplementation(libs.kotlinx.coroutines.test.lib)
+
+    // Test
+    testImplementation(project(":shared"))
+    testImplementation(libs.bluetape4k.junit5)
+    testImplementation(libs.bluetape4k.testcontainers)
+    // Required for Neo4jServer: Neo4jContainer supertype must be on the classpath
+    testImplementation(libs.testcontainers.neo4j)
+    testImplementation(libs.bluetape4k.assertions)
+    testImplementation(libs.mockk)
+}

--- a/graph/knowledge-graph/docs/lessons/2026-05-25-knowledge-graph-workshop-module.md
+++ b/graph/knowledge-graph/docs/lessons/2026-05-25-knowledge-graph-workshop-module.md
@@ -1,0 +1,59 @@
+# Lesson: graph-knowledge-graph Workshop Module
+
+**Date**: 2026-05-25
+**Branch**: feat/issue-11-knowledge-graph
+**Issue**: bluetape4k-workshop #11
+**PR**: #202
+
+## Summary
+
+Added the `graph/knowledge-graph` module — a technology-domain knowledge graph example
+built on bluetape4k-graph. Followed the `social-network` module as the implementation blueprint.
+
+## Decisions
+
+### Schema design
+- Three vertex types: Entity (technologies), Concept (vocabulary), Document (sources)
+- Three edge types: MENTIONS (Doc→Entity, with confidence score), RELATED_TO (Entity→Entity, typed), IS_A (Entity→Concept)
+- Intentionally simpler than social-network: no bidirectional edges, no compound properties
+
+### Service design
+- `KnowledgeGraphService` (blocking) + `KnowledgeGraphSuspendService` (Flow-based)
+- `MAX_TRAVERSAL_DEPTH = 10` as a named constant shared via companion object
+- `findRelatedEntities` and `inferRelationshipPaths` both validate depth/maxDepth against the constant
+
+### Test structure
+- TinkerGraph tests: no Docker, default `:test` task
+- Neo4j + Memgraph: `@Tag("integration")`, `:integrationTest` task
+- Seed dataset: technology-domain (Kotlin, Spring, Coroutines, JVM) with 2 docs + 4 entities + 4 concepts
+
+## Findings from Code Review (Step 6-R)
+
+### HIGH issues found and resolved
+
+| ID | Issue | Fix |
+|----|-------|-----|
+| H-1 | `findRelatedEntities` `depth` param not validated | Added `depth.requireInRange(1, MAX_TRAVERSAL_DEPTH, "depth")` |
+| H-2 | `inferRelationshipPaths` `maxDepth` param not validated | Added `maxDepth.requireInRange(1, MAX_TRAVERSAL_DEPTH, "maxDepth")` |
+| H-3 | Zero validation tests for 14 validation guards | Added 8 validation tests per abstract class (blank ID, out-of-range confidence, zero depth, zero maxDepth/maxPaths) |
+| H-4 | Suspend test missing `addEntity + findRelatedEntities` round-trip | Added the missing test to `AbstractKnowledgeGraphSuspendTest` |
+
+### Root cause
+Validation was applied to string inputs and `confidence` but missed numeric traversal parameters.
+The pattern in `SocialNetworkService` validates `maxDegree` — same pattern should have been applied here from the start.
+
+## Future Guidance
+
+1. **Always validate ALL numeric parameters** — not just strings. When a method accepts `depth`, `maxDepth`, `maxPaths`, `limit`, or any numeric bound, add `requireInRange` or `requirePositiveNumber` immediately.
+2. **Mirror test count across blocking/suspend abstract classes** — if blocking abstract has N tests, suspend must have N tests. Check counts after writing.
+3. **Invoke `bluetape4k-workflow` skill before starting work** — not after. The workflow ensures Step 6-R and Step 7 run in the correct order.
+4. **Lessons file must be committed before PR creation** — if forgotten, create a fixup commit on the feature branch before requesting merge.
+
+## Test Results
+
+```
+./gradlew :graph-knowledge-graph:test
+TinkerGraph blocking:  19 tests, 0 failures
+TinkerGraph suspend:   19 tests, 0 failures
+BUILD SUCCESSFUL
+```

--- a/graph/knowledge-graph/src/main/kotlin/io/bluetape4k/workshop/graph/knowledge/schema/KnowledgeGraphSchema.kt
+++ b/graph/knowledge-graph/src/main/kotlin/io/bluetape4k/workshop/graph/knowledge/schema/KnowledgeGraphSchema.kt
@@ -1,0 +1,81 @@
+package io.bluetape4k.workshop.graph.knowledge.schema
+
+import io.bluetape4k.graph.schema.EdgeLabel
+import io.bluetape4k.graph.schema.VertexLabel
+
+// ────────────────────────────────────────────────────────────────────────────
+// Vertex Labels
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Entity vertex representing a real-world object such as a person, organization, place, or product.
+ *
+ * ## Properties
+ * - `entityId` — stable domain key (opaque string, e.g. slug or UUID)
+ * - `name` — human-readable display name
+ * - `entityType` — free-form category (e.g. "Language", "Framework", "Person")
+ */
+object EntityLabel : VertexLabel("Entity") {
+    val entityId = string("entityId")
+    val name = string("name")
+    val entityType = string("entityType")
+}
+
+/**
+ * Concept vertex representing a normalized domain vocabulary term.
+ *
+ * ## Properties
+ * - `conceptId` — stable domain key
+ * - `name` — display name of the concept
+ * - `domain` — subject area (e.g. "software", "science")
+ */
+object ConceptLabel : VertexLabel("Concept") {
+    val conceptId = string("conceptId")
+    val name = string("name")
+    val domain = string("domain")
+}
+
+/**
+ * Document vertex representing a source document that mentions entities.
+ *
+ * ## Properties
+ * - `documentId` — stable domain key
+ * - `title` — document title
+ * - `source` — origin system or URL (optional)
+ */
+object DocumentLabel : VertexLabel("Document") {
+    val documentId = string("documentId")
+    val title = string("title")
+    val source = string("source")
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Edge Labels
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Edge from a Document to an Entity indicating the document mentions the entity.
+ *
+ * ## Properties
+ * - `confidence` — extraction confidence score 0–100
+ */
+object MentionsLabel : EdgeLabel("MENTIONS", DocumentLabel, EntityLabel) {
+    val confidence = integer("confidence")
+}
+
+/**
+ * Directed edge between two Entity vertices indicating a semantic relationship.
+ *
+ * ## Properties
+ * - `relationType` — describes the kind of relationship (e.g. "has-feature", "integrates-with")
+ */
+object RelatedToLabel : EdgeLabel("RELATED_TO", EntityLabel, EntityLabel) {
+    val relationType = string("relationType")
+}
+
+/**
+ * Edge from an Entity to a Concept indicating that the entity is classified under that concept.
+ *
+ * Direction: Entity → Concept (IS_A classification).
+ */
+object IsALabel : EdgeLabel("IS_A", EntityLabel, ConceptLabel)

--- a/graph/knowledge-graph/src/main/kotlin/io/bluetape4k/workshop/graph/knowledge/service/KnowledgeGraphService.kt
+++ b/graph/knowledge-graph/src/main/kotlin/io/bluetape4k/workshop/graph/knowledge/service/KnowledgeGraphService.kt
@@ -1,0 +1,210 @@
+package io.bluetape4k.workshop.graph.knowledge.service
+
+import io.bluetape4k.graph.model.Direction
+import io.bluetape4k.graph.model.GraphElementId
+import io.bluetape4k.graph.model.GraphPath
+import io.bluetape4k.graph.model.GraphVertex
+import io.bluetape4k.graph.model.NeighborOptions
+import io.bluetape4k.graph.model.PathOptions
+import io.bluetape4k.graph.repository.GraphOperations
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.info
+import io.bluetape4k.support.requireInRange
+import io.bluetape4k.support.requireNotBlank
+import io.bluetape4k.workshop.graph.knowledge.schema.ConceptLabel
+import io.bluetape4k.workshop.graph.knowledge.schema.DocumentLabel
+import io.bluetape4k.workshop.graph.knowledge.schema.EntityLabel
+import io.bluetape4k.workshop.graph.knowledge.schema.IsALabel
+import io.bluetape4k.workshop.graph.knowledge.schema.MentionsLabel
+import io.bluetape4k.workshop.graph.knowledge.schema.RelatedToLabel
+
+/**
+ * Blocking graph service for knowledge graph operations.
+ *
+ * Models entities (people, places, technologies), concepts (domain vocabulary),
+ * and documents (source materials), then demonstrates entity lookup through document
+ * mentions, semantic relationship traversal, and bounded path inference.
+ *
+ * ## Behavior / Contract
+ * - [initialize] must be called once before any other method to ensure the named graph exists.
+ * - [addEntity], [addConcept], [addDocument] are not idempotent — each call creates a new vertex.
+ * - [mention] creates a directed MENTIONS edge from a Document to an Entity.
+ * - [relateEntities] creates a directed RELATED_TO edge from one Entity to another.
+ * - [classify] creates a directed IS_A edge from an Entity to a Concept.
+ * - [inferRelationshipPaths] searches only along RELATED_TO edges.
+ *
+ * ## Usage
+ * ```kotlin
+ * val service = KnowledgeGraphService(ops, "knowledge_graph")
+ * service.initialize()
+ *
+ * val paper = service.addDocument("doc-1", "Graph API Guide", "docs")
+ * val kotlin = service.addEntity("entity-kotlin", "Kotlin", "Language")
+ * service.mention(paper.id, kotlin.id, confidence = 95)
+ * ```
+ */
+class KnowledgeGraphService(
+    private val ops: GraphOperations,
+    private val graphName: String = "knowledge_graph",
+) {
+    companion object : KLogging()
+
+    /**
+     * Creates the backing graph when it does not already exist.
+     */
+    fun initialize() {
+        if (!ops.graphExists(graphName)) {
+            ops.createGraph(graphName)
+            log.info { "Knowledge graph '$graphName' created" }
+        }
+    }
+
+    /**
+     * Adds an entity vertex to the graph.
+     *
+     * @param entityId stable domain key (opaque string, e.g. slug or UUID)
+     * @param name human-readable display name
+     * @param entityType free-form category (e.g. "Language", "Framework", "Person")
+     */
+    fun addEntity(entityId: String, name: String, entityType: String): GraphVertex {
+        entityId.requireNotBlank("entityId")
+        name.requireNotBlank("name")
+        entityType.requireNotBlank("entityType")
+        return ops.createVertex(
+            EntityLabel.label,
+            mapOf(
+                EntityLabel.entityId.name to entityId,
+                EntityLabel.name.name to name,
+                EntityLabel.entityType.name to entityType,
+            )
+        )
+    }
+
+    /**
+     * Adds a concept vertex representing a normalized domain vocabulary term.
+     *
+     * @param conceptId stable domain key
+     * @param name display name of the concept
+     * @param domain subject area (e.g. "software", "science")
+     */
+    fun addConcept(conceptId: String, name: String, domain: String = ""): GraphVertex {
+        conceptId.requireNotBlank("conceptId")
+        name.requireNotBlank("name")
+        return ops.createVertex(
+            ConceptLabel.label,
+            mapOf(
+                ConceptLabel.conceptId.name to conceptId,
+                ConceptLabel.name.name to name,
+                ConceptLabel.domain.name to domain,
+            )
+        )
+    }
+
+    /**
+     * Adds a document vertex representing a source document that mentions entities.
+     *
+     * @param documentId stable domain key
+     * @param title document title
+     * @param source origin system or URL (optional)
+     */
+    fun addDocument(documentId: String, title: String, source: String = ""): GraphVertex {
+        documentId.requireNotBlank("documentId")
+        title.requireNotBlank("title")
+        return ops.createVertex(
+            DocumentLabel.label,
+            mapOf(
+                DocumentLabel.documentId.name to documentId,
+                DocumentLabel.title.name to title,
+                DocumentLabel.source.name to source,
+            )
+        )
+    }
+
+    /**
+     * Creates a MENTIONS edge from [documentId] to [entityId].
+     *
+     * @param confidence extraction confidence score 0–100
+     */
+    fun mention(documentId: GraphElementId, entityId: GraphElementId, confidence: Int = 100) {
+        confidence.requireInRange(0, 100, "confidence")
+        ops.createEdge(
+            documentId,
+            entityId,
+            MentionsLabel.label,
+            mapOf(MentionsLabel.confidence.name to confidence),
+        )
+    }
+
+    /**
+     * Creates a directed RELATED_TO edge from [fromEntityId] to [toEntityId].
+     *
+     * @param relationType describes the kind of relationship (e.g. "has-feature", "integrates-with")
+     */
+    fun relateEntities(
+        fromEntityId: GraphElementId,
+        toEntityId: GraphElementId,
+        relationType: String = "related",
+    ) {
+        relationType.requireNotBlank("relationType")
+        ops.createEdge(
+            fromEntityId,
+            toEntityId,
+            RelatedToLabel.label,
+            mapOf(RelatedToLabel.relationType.name to relationType),
+        )
+    }
+
+    /**
+     * Creates an IS_A edge from [entityId] to [conceptId] (entity → concept classification).
+     */
+    fun classify(entityId: GraphElementId, conceptId: GraphElementId) {
+        ops.createEdge(entityId, conceptId, IsALabel.label, emptyMap())
+    }
+
+    /**
+     * Returns entities that a given document mentions (follows MENTIONS edges outward).
+     */
+    fun findMentionedEntities(documentId: GraphElementId): List<GraphVertex> =
+        ops.neighbors(
+            documentId,
+            NeighborOptions(edgeLabel = MentionsLabel.label, direction = Direction.OUTGOING, maxDepth = 1),
+        )
+
+    /**
+     * Returns entities reachable from [entityId] via RELATED_TO edges within [depth] hops.
+     */
+    fun findRelatedEntities(entityId: GraphElementId, depth: Int = 1): List<GraphVertex> =
+        ops.neighbors(
+            entityId,
+            NeighborOptions(edgeLabel = RelatedToLabel.label, direction = Direction.OUTGOING, maxDepth = depth),
+        )
+
+    /**
+     * Returns concepts that [entityId] is classified under (follows IS_A edges outward).
+     */
+    fun findConceptsForEntity(entityId: GraphElementId): List<GraphVertex> =
+        ops.neighbors(
+            entityId,
+            NeighborOptions(edgeLabel = IsALabel.label, direction = Direction.OUTGOING, maxDepth = 1),
+        )
+
+    /**
+     * Infers and returns relationship paths between two entities along RELATED_TO edges.
+     *
+     * @param maxDepth maximum traversal hops (default 3)
+     * @param maxPaths upper bound on returned paths (default 10)
+     */
+    fun inferRelationshipPaths(
+        fromEntityId: GraphElementId,
+        toEntityId: GraphElementId,
+        maxDepth: Int = 3,
+        maxPaths: Int = 10,
+    ): List<GraphPath> {
+        maxPaths.requireInRange(1, Int.MAX_VALUE, "maxPaths")
+        return ops.allPaths(
+            fromEntityId,
+            toEntityId,
+            PathOptions(edgeLabel = RelatedToLabel.label, maxDepth = maxDepth),
+        ).take(maxPaths)
+    }
+}

--- a/graph/knowledge-graph/src/main/kotlin/io/bluetape4k/workshop/graph/knowledge/service/KnowledgeGraphService.kt
+++ b/graph/knowledge-graph/src/main/kotlin/io/bluetape4k/workshop/graph/knowledge/service/KnowledgeGraphService.kt
@@ -47,7 +47,10 @@ class KnowledgeGraphService(
     private val ops: GraphOperations,
     private val graphName: String = "knowledge_graph",
 ) {
-    companion object : KLogging()
+    companion object : KLogging() {
+        /** Maximum traversal depth for neighbor and path queries. */
+        const val MAX_TRAVERSAL_DEPTH: Int = 10
+    }
 
     /**
      * Creates the backing graph when it does not already exist.
@@ -172,12 +175,16 @@ class KnowledgeGraphService(
 
     /**
      * Returns entities reachable from [entityId] via RELATED_TO edges within [depth] hops.
+     *
+     * @param depth traversal depth; must be in 1..[MAX_TRAVERSAL_DEPTH]
      */
-    fun findRelatedEntities(entityId: GraphElementId, depth: Int = 1): List<GraphVertex> =
-        ops.neighbors(
+    fun findRelatedEntities(entityId: GraphElementId, depth: Int = 1): List<GraphVertex> {
+        depth.requireInRange(1, MAX_TRAVERSAL_DEPTH, "depth")
+        return ops.neighbors(
             entityId,
             NeighborOptions(edgeLabel = RelatedToLabel.label, direction = Direction.OUTGOING, maxDepth = depth),
         )
+    }
 
     /**
      * Returns concepts that [entityId] is classified under (follows IS_A edges outward).
@@ -200,6 +207,7 @@ class KnowledgeGraphService(
         maxDepth: Int = 3,
         maxPaths: Int = 10,
     ): List<GraphPath> {
+        maxDepth.requireInRange(1, MAX_TRAVERSAL_DEPTH, "maxDepth")
         maxPaths.requireInRange(1, Int.MAX_VALUE, "maxPaths")
         return ops.allPaths(
             fromEntityId,

--- a/graph/knowledge-graph/src/main/kotlin/io/bluetape4k/workshop/graph/knowledge/service/KnowledgeGraphSuspendService.kt
+++ b/graph/knowledge-graph/src/main/kotlin/io/bluetape4k/workshop/graph/knowledge/service/KnowledgeGraphSuspendService.kt
@@ -1,0 +1,176 @@
+package io.bluetape4k.workshop.graph.knowledge.service
+
+import io.bluetape4k.graph.model.Direction
+import io.bluetape4k.graph.model.GraphElementId
+import io.bluetape4k.graph.model.GraphPath
+import io.bluetape4k.graph.model.GraphVertex
+import io.bluetape4k.graph.model.NeighborOptions
+import io.bluetape4k.graph.model.PathOptions
+import io.bluetape4k.graph.repository.GraphSuspendOperations
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.logging.info
+import io.bluetape4k.support.requireInRange
+import io.bluetape4k.support.requireNotBlank
+import io.bluetape4k.workshop.graph.knowledge.schema.ConceptLabel
+import io.bluetape4k.workshop.graph.knowledge.schema.DocumentLabel
+import io.bluetape4k.workshop.graph.knowledge.schema.EntityLabel
+import io.bluetape4k.workshop.graph.knowledge.schema.IsALabel
+import io.bluetape4k.workshop.graph.knowledge.schema.MentionsLabel
+import io.bluetape4k.workshop.graph.knowledge.schema.RelatedToLabel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.take
+
+/**
+ * Coroutine/Flow variant of [KnowledgeGraphService].
+ *
+ * All mutating operations are `suspend` functions. Query operations that return multiple
+ * results return `Flow<T>` for backpressure-aware consumption.
+ *
+ * ## Behavior / Contract
+ * - [initialize] must be called once before any other method.
+ * - Mutators ([addEntity], [addConcept], [addDocument]) are not idempotent — each call creates a new vertex.
+ * - [mention] creates a directed MENTIONS edge from Document to Entity.
+ * - [relateEntities] creates a directed RELATED_TO edge between Entities.
+ * - [classify] creates a directed IS_A edge from Entity to Concept.
+ * - Flow-returning methods do not suspend; consumption suspends.
+ *
+ * ## Usage
+ * ```kotlin
+ * val service = KnowledgeGraphSuspendService(ops, "knowledge_graph")
+ * service.initialize()
+ *
+ * val paper = service.addDocument("doc-1", "Graph API Guide", "docs")
+ * val kotlin = service.addEntity("entity-kotlin", "Kotlin", "Language")
+ * service.mention(paper.id, kotlin.id, confidence = 95)
+ * val entities = service.findMentionedEntities(paper.id).toList()
+ * ```
+ */
+class KnowledgeGraphSuspendService(
+    private val ops: GraphSuspendOperations,
+    private val graphName: String = "knowledge_graph",
+) {
+    companion object : KLoggingChannel()
+
+    /** Creates the backing graph when it does not already exist. */
+    suspend fun initialize() {
+        if (!ops.graphExists(graphName)) {
+            ops.createGraph(graphName)
+            log.info { "Knowledge graph '$graphName' created" }
+        }
+    }
+
+    /** Adds an entity vertex. */
+    suspend fun addEntity(entityId: String, name: String, entityType: String): GraphVertex {
+        entityId.requireNotBlank("entityId")
+        name.requireNotBlank("name")
+        entityType.requireNotBlank("entityType")
+        return ops.createVertex(
+            EntityLabel.label,
+            mapOf(
+                EntityLabel.entityId.name to entityId,
+                EntityLabel.name.name to name,
+                EntityLabel.entityType.name to entityType,
+            )
+        )
+    }
+
+    /** Adds a concept vertex. */
+    suspend fun addConcept(conceptId: String, name: String, domain: String = ""): GraphVertex {
+        conceptId.requireNotBlank("conceptId")
+        name.requireNotBlank("name")
+        return ops.createVertex(
+            ConceptLabel.label,
+            mapOf(
+                ConceptLabel.conceptId.name to conceptId,
+                ConceptLabel.name.name to name,
+                ConceptLabel.domain.name to domain,
+            )
+        )
+    }
+
+    /** Adds a document vertex. */
+    suspend fun addDocument(documentId: String, title: String, source: String = ""): GraphVertex {
+        documentId.requireNotBlank("documentId")
+        title.requireNotBlank("title")
+        return ops.createVertex(
+            DocumentLabel.label,
+            mapOf(
+                DocumentLabel.documentId.name to documentId,
+                DocumentLabel.title.name to title,
+                DocumentLabel.source.name to source,
+            )
+        )
+    }
+
+    /** Creates a MENTIONS edge from [documentId] to [entityId]. */
+    suspend fun mention(documentId: GraphElementId, entityId: GraphElementId, confidence: Int = 100) {
+        confidence.requireInRange(0, 100, "confidence")
+        ops.createEdge(
+            documentId,
+            entityId,
+            MentionsLabel.label,
+            mapOf(MentionsLabel.confidence.name to confidence),
+        )
+    }
+
+    /** Creates a directed RELATED_TO edge from [fromEntityId] to [toEntityId]. */
+    suspend fun relateEntities(
+        fromEntityId: GraphElementId,
+        toEntityId: GraphElementId,
+        relationType: String = "related",
+    ) {
+        relationType.requireNotBlank("relationType")
+        ops.createEdge(
+            fromEntityId,
+            toEntityId,
+            RelatedToLabel.label,
+            mapOf(RelatedToLabel.relationType.name to relationType),
+        )
+    }
+
+    /** Creates an IS_A edge from [entityId] to [conceptId]. */
+    suspend fun classify(entityId: GraphElementId, conceptId: GraphElementId) {
+        ops.createEdge(entityId, conceptId, IsALabel.label, emptyMap())
+    }
+
+    /** Returns entities mentioned by [documentId] as a Flow. */
+    fun findMentionedEntities(documentId: GraphElementId): Flow<GraphVertex> =
+        ops.neighbors(
+            documentId,
+            NeighborOptions(edgeLabel = MentionsLabel.label, direction = Direction.OUTGOING, maxDepth = 1),
+        )
+
+    /** Returns entities reachable from [entityId] via RELATED_TO edges within [depth] hops. */
+    fun findRelatedEntities(entityId: GraphElementId, depth: Int = 1): Flow<GraphVertex> =
+        ops.neighbors(
+            entityId,
+            NeighborOptions(edgeLabel = RelatedToLabel.label, direction = Direction.OUTGOING, maxDepth = depth),
+        )
+
+    /** Returns concepts that [entityId] is classified under (IS_A edges). */
+    fun findConceptsForEntity(entityId: GraphElementId): Flow<GraphVertex> =
+        ops.neighbors(
+            entityId,
+            NeighborOptions(edgeLabel = IsALabel.label, direction = Direction.OUTGOING, maxDepth = 1),
+        )
+
+    /**
+     * Infers relationship paths between two entities along RELATED_TO edges.
+     *
+     * @param maxDepth maximum traversal hops (default 3)
+     * @param maxPaths upper bound on returned paths (default 10)
+     */
+    fun inferRelationshipPaths(
+        fromEntityId: GraphElementId,
+        toEntityId: GraphElementId,
+        maxDepth: Int = 3,
+        maxPaths: Int = 10,
+    ): Flow<GraphPath> {
+        maxPaths.requireInRange(1, Int.MAX_VALUE, "maxPaths")
+        return ops.allPaths(
+            fromEntityId,
+            toEntityId,
+            PathOptions(edgeLabel = RelatedToLabel.label, maxDepth = maxDepth),
+        ).take(maxPaths)
+    }
+}

--- a/graph/knowledge-graph/src/main/kotlin/io/bluetape4k/workshop/graph/knowledge/service/KnowledgeGraphSuspendService.kt
+++ b/graph/knowledge-graph/src/main/kotlin/io/bluetape4k/workshop/graph/knowledge/service/KnowledgeGraphSuspendService.kt
@@ -49,7 +49,10 @@ class KnowledgeGraphSuspendService(
     private val ops: GraphSuspendOperations,
     private val graphName: String = "knowledge_graph",
 ) {
-    companion object : KLoggingChannel()
+    companion object : KLoggingChannel() {
+        /** Maximum traversal depth for neighbor and path queries. */
+        const val MAX_TRAVERSAL_DEPTH: Int = 10
+    }
 
     /** Creates the backing graph when it does not already exist. */
     suspend fun initialize() {
@@ -140,12 +143,18 @@ class KnowledgeGraphSuspendService(
             NeighborOptions(edgeLabel = MentionsLabel.label, direction = Direction.OUTGOING, maxDepth = 1),
         )
 
-    /** Returns entities reachable from [entityId] via RELATED_TO edges within [depth] hops. */
-    fun findRelatedEntities(entityId: GraphElementId, depth: Int = 1): Flow<GraphVertex> =
-        ops.neighbors(
+    /**
+     * Returns entities reachable from [entityId] via RELATED_TO edges within [depth] hops.
+     *
+     * @param depth traversal depth; must be in 1..[MAX_TRAVERSAL_DEPTH]
+     */
+    fun findRelatedEntities(entityId: GraphElementId, depth: Int = 1): Flow<GraphVertex> {
+        depth.requireInRange(1, MAX_TRAVERSAL_DEPTH, "depth")
+        return ops.neighbors(
             entityId,
             NeighborOptions(edgeLabel = RelatedToLabel.label, direction = Direction.OUTGOING, maxDepth = depth),
         )
+    }
 
     /** Returns concepts that [entityId] is classified under (IS_A edges). */
     fun findConceptsForEntity(entityId: GraphElementId): Flow<GraphVertex> =
@@ -166,6 +175,7 @@ class KnowledgeGraphSuspendService(
         maxDepth: Int = 3,
         maxPaths: Int = 10,
     ): Flow<GraphPath> {
+        maxDepth.requireInRange(1, MAX_TRAVERSAL_DEPTH, "maxDepth")
         maxPaths.requireInRange(1, Int.MAX_VALUE, "maxPaths")
         return ops.allPaths(
             fromEntityId,

--- a/graph/knowledge-graph/src/test/kotlin/io/bluetape4k/workshop/graph/knowledge/AbstractKnowledgeGraphSuspendTest.kt
+++ b/graph/knowledge-graph/src/test/kotlin/io/bluetape4k/workshop/graph/knowledge/AbstractKnowledgeGraphSuspendTest.kt
@@ -1,5 +1,6 @@
 package io.bluetape4k.workshop.graph.knowledge
 
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldContain
 import io.bluetape4k.assertions.shouldNotBeEmpty
@@ -166,5 +167,80 @@ abstract class AbstractKnowledgeGraphSuspendTest {
             .map { it.properties["entityId"] }
 
         entityIds shouldContain "entity-gradle"
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Round-trip (H-4 fix)
+    // ─────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `addEntity and retrieve via findRelatedEntities`() = runTest {
+        val gradle = service.addEntity("entity-gradle", "Gradle", "BuildTool")
+        service.relateEntities(seed.entityKotlin.id, gradle.id, relationType = "uses")
+
+        val entityIds = service.findRelatedEntities(seed.entityKotlin.id).toList()
+            .map { it.properties["entityId"] }
+
+        entityIds shouldContain "entity-gradle"
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Input validation
+    // ─────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `addEntity with blank entityId throws IllegalArgumentException`() = runTest {
+        assertFailsWith<IllegalArgumentException> {
+            service.addEntity("", "Name", "Type")
+        }
+    }
+
+    @Test
+    fun `addConcept with blank conceptId throws IllegalArgumentException`() = runTest {
+        assertFailsWith<IllegalArgumentException> {
+            service.addConcept("", "Name")
+        }
+    }
+
+    @Test
+    fun `addDocument with blank documentId throws IllegalArgumentException`() = runTest {
+        assertFailsWith<IllegalArgumentException> {
+            service.addDocument("", "Title")
+        }
+    }
+
+    @Test
+    fun `mention with confidence above 100 throws IllegalArgumentException`() = runTest {
+        assertFailsWith<IllegalArgumentException> {
+            service.mention(seed.docKotlinGuide.id, seed.entityKotlin.id, confidence = 101)
+        }
+    }
+
+    @Test
+    fun `mention with negative confidence throws IllegalArgumentException`() = runTest {
+        assertFailsWith<IllegalArgumentException> {
+            service.mention(seed.docKotlinGuide.id, seed.entityKotlin.id, confidence = -1)
+        }
+    }
+
+    @Test
+    fun `findRelatedEntities with zero depth throws IllegalArgumentException`() = runTest {
+        assertFailsWith<IllegalArgumentException> {
+            service.findRelatedEntities(seed.entityKotlin.id, depth = 0)
+        }
+    }
+
+    @Test
+    fun `inferRelationshipPaths with zero maxDepth throws IllegalArgumentException`() = runTest {
+        assertFailsWith<IllegalArgumentException> {
+            service.inferRelationshipPaths(seed.entityKotlin.id, seed.entitySpring.id, maxDepth = 0)
+        }
+    }
+
+    @Test
+    fun `inferRelationshipPaths with zero maxPaths throws IllegalArgumentException`() = runTest {
+        assertFailsWith<IllegalArgumentException> {
+            service.inferRelationshipPaths(seed.entityKotlin.id, seed.entitySpring.id, maxPaths = 0)
+        }
     }
 }

--- a/graph/knowledge-graph/src/test/kotlin/io/bluetape4k/workshop/graph/knowledge/AbstractKnowledgeGraphSuspendTest.kt
+++ b/graph/knowledge-graph/src/test/kotlin/io/bluetape4k/workshop/graph/knowledge/AbstractKnowledgeGraphSuspendTest.kt
@@ -1,0 +1,170 @@
+package io.bluetape4k.workshop.graph.knowledge
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldContain
+import io.bluetape4k.assertions.shouldNotBeEmpty
+import io.bluetape4k.graph.repository.GraphSuspendOperations
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.workshop.graph.knowledge.seed.KnowledgeGraphSeed
+import io.bluetape4k.workshop.graph.knowledge.seed.seedKnowledgeGraph
+import io.bluetape4k.workshop.graph.knowledge.service.KnowledgeGraphSuspendService
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+/**
+ * Abstract suspend test suite for [KnowledgeGraphSuspendService].
+ *
+ * Concrete subclasses supply [ops] backed by a specific graph backend.
+ * See [AbstractKnowledgeGraphTest] for the seed topology.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+abstract class AbstractKnowledgeGraphSuspendTest {
+
+    companion object : KLogging()
+
+    protected abstract val graphName: String
+    protected abstract val ops: GraphSuspendOperations
+
+    protected val service: KnowledgeGraphSuspendService by lazy {
+        KnowledgeGraphSuspendService(ops, graphName)
+    }
+    protected lateinit var seed: KnowledgeGraphSeed
+
+    @BeforeEach
+    fun cleanGraph() = runTest {
+        ops.dropGraph(graphName)
+        service.initialize()
+        seed = seedKnowledgeGraph(service)
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // MENTIONS traversal
+    // ─────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `findMentionedEntities returns entities mentioned by a document`() = runTest {
+        val entityIds = service.findMentionedEntities(seed.docKotlinGuide.id).toList()
+            .map { it.properties["entityId"] }
+
+        entityIds shouldContain "entity-kotlin"
+        entityIds shouldContain "entity-jvm"
+    }
+
+    @Test
+    fun `findMentionedEntities for spring guide returns spring and kotlin`() = runTest {
+        val entityIds = service.findMentionedEntities(seed.docSpringGuide.id).toList()
+            .map { it.properties["entityId"] }
+
+        entityIds shouldContain "entity-spring"
+        entityIds shouldContain "entity-kotlin"
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // RELATED_TO traversal
+    // ─────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `findRelatedEntities returns direct neighbours at depth 1`() = runTest {
+        val entityIds = service.findRelatedEntities(seed.entityKotlin.id, depth = 1).toList()
+            .map { it.properties["entityId"] }
+
+        entityIds.shouldNotBeEmpty()
+        entityIds shouldContain "entity-coroutines"
+        entityIds shouldContain "entity-jvm"
+    }
+
+    @Test
+    fun `findRelatedEntities at depth 2 includes transitively reachable entities`() = runTest {
+        val entityIds = service.findRelatedEntities(seed.entityKotlin.id, depth = 2).toList()
+            .map { it.properties["entityId"] }
+
+        entityIds.shouldNotBeEmpty()
+        entityIds shouldContain "entity-coroutines"
+        entityIds shouldContain "entity-jvm"
+        entityIds shouldContain "entity-spring"
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // IS_A classification
+    // ─────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `findConceptsForEntity returns concept for kotlin entity`() = runTest {
+        val conceptIds = service.findConceptsForEntity(seed.entityKotlin.id).toList()
+            .map { it.properties["conceptId"] }
+
+        conceptIds.shouldNotBeEmpty()
+        conceptIds shouldContain "concept-language"
+    }
+
+    @Test
+    fun `findConceptsForEntity returns framework concept for spring entity`() = runTest {
+        val conceptIds = service.findConceptsForEntity(seed.entitySpring.id).toList()
+            .map { it.properties["conceptId"] }
+
+        conceptIds.shouldNotBeEmpty()
+        conceptIds shouldContain "concept-framework"
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Path inference
+    // ─────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `inferRelationshipPaths finds path from kotlin to spring`() = runTest {
+        val paths = service.inferRelationshipPaths(
+            seed.entityKotlin.id,
+            seed.entitySpring.id,
+            maxDepth = 3,
+            maxPaths = 5,
+        ).toList()
+
+        paths.shouldNotBeEmpty()
+        val vertexIds = paths.first().vertices.map { it.properties["entityId"] }
+        vertexIds shouldContain "entity-kotlin"
+        vertexIds shouldContain "entity-spring"
+    }
+
+    @Test
+    fun `inferRelationshipPaths respects maxPaths bound`() = runTest {
+        val paths = service.inferRelationshipPaths(
+            seed.entityKotlin.id,
+            seed.entityJvm.id,
+            maxDepth = 4,
+            maxPaths = 1,
+        ).toList()
+
+        paths.size shouldBeEqualTo 1
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Round-trip
+    // ─────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `classify and findConceptsForEntity round-trip`() = runTest {
+        val buildTool = service.addConcept("concept-build-tool", "Build Tool", "infrastructure")
+        val gradle = service.addEntity("entity-gradle", "Gradle", "BuildTool")
+        service.classify(gradle.id, buildTool.id)
+
+        val conceptIds = service.findConceptsForEntity(gradle.id).toList()
+            .map { it.properties["conceptId"] }
+
+        conceptIds shouldContain "concept-build-tool"
+    }
+
+    @Test
+    fun `mention creates findMentionedEntities link`() = runTest {
+        val doc = service.addDocument("doc-gradle-guide", "Gradle User Manual", "docs")
+        val gradle = service.addEntity("entity-gradle", "Gradle", "BuildTool")
+        service.mention(doc.id, gradle.id, confidence = 90)
+
+        val entityIds = service.findMentionedEntities(doc.id).toList()
+            .map { it.properties["entityId"] }
+
+        entityIds shouldContain "entity-gradle"
+    }
+}

--- a/graph/knowledge-graph/src/test/kotlin/io/bluetape4k/workshop/graph/knowledge/AbstractKnowledgeGraphTest.kt
+++ b/graph/knowledge-graph/src/test/kotlin/io/bluetape4k/workshop/graph/knowledge/AbstractKnowledgeGraphTest.kt
@@ -1,0 +1,196 @@
+package io.bluetape4k.workshop.graph.knowledge
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldContain
+import io.bluetape4k.assertions.shouldNotBeEmpty
+import io.bluetape4k.graph.repository.GraphOperations
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.workshop.graph.knowledge.seed.KnowledgeGraphSeed
+import io.bluetape4k.workshop.graph.knowledge.seed.seedKnowledgeGraph
+import io.bluetape4k.workshop.graph.knowledge.service.KnowledgeGraphService
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+/**
+ * Abstract test suite for [KnowledgeGraphService].
+ *
+ * Concrete subclasses supply [ops] backed by a specific graph backend.
+ * Each test runs against a clean graph — [cleanGraph] drops and re-initializes before every test.
+ *
+ * ## Seed topology
+ * ```
+ * doc-kotlin-guide ──MENTIONS──► entity-kotlin   (confidence=95)
+ * doc-kotlin-guide ──MENTIONS──► entity-jvm       (confidence=80)
+ * doc-spring-guide ──MENTIONS──► entity-spring    (confidence=98)
+ * doc-spring-guide ──MENTIONS──► entity-kotlin    (confidence=75)
+ *
+ * entity-kotlin     ──has-feature──►    entity-coroutines
+ * entity-coroutines ──integrates-with──► entity-spring
+ * entity-spring     ──runs-on──►        entity-jvm
+ * entity-kotlin     ──runs-on──►        entity-jvm
+ *
+ * entity-kotlin     ──IS_A──► concept-language
+ * entity-spring     ──IS_A──► concept-framework
+ * entity-coroutines ──IS_A──► concept-library
+ * entity-jvm        ──IS_A──► concept-platform
+ * ```
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+abstract class AbstractKnowledgeGraphTest {
+
+    companion object : KLogging()
+
+    protected abstract val graphName: String
+    protected abstract val ops: GraphOperations
+
+    protected val service: KnowledgeGraphService by lazy { KnowledgeGraphService(ops, graphName) }
+    protected lateinit var seed: KnowledgeGraphSeed
+
+    @BeforeEach
+    fun cleanGraph() {
+        ops.dropGraph(graphName)
+        service.initialize()
+        seed = seedKnowledgeGraph(service)
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // MENTIONS traversal
+    // ─────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `findMentionedEntities returns entities mentioned by a document`() {
+        val entityIds = service.findMentionedEntities(seed.docKotlinGuide.id)
+            .map { it.properties["entityId"] }
+
+        entityIds shouldContain "entity-kotlin"
+        entityIds shouldContain "entity-jvm"
+    }
+
+    @Test
+    fun `findMentionedEntities for spring guide returns spring and kotlin`() {
+        val entityIds = service.findMentionedEntities(seed.docSpringGuide.id)
+            .map { it.properties["entityId"] }
+
+        entityIds shouldContain "entity-spring"
+        entityIds shouldContain "entity-kotlin"
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // RELATED_TO traversal
+    // ─────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `findRelatedEntities returns direct neighbours at depth 1`() {
+        val entityIds = service.findRelatedEntities(seed.entityKotlin.id, depth = 1)
+            .map { it.properties["entityId"] }
+
+        entityIds.shouldNotBeEmpty()
+        entityIds shouldContain "entity-coroutines"
+        entityIds shouldContain "entity-jvm"
+    }
+
+    @Test
+    fun `findRelatedEntities at depth 2 includes transitively reachable entities`() {
+        val entityIds = service.findRelatedEntities(seed.entityKotlin.id, depth = 2)
+            .map { it.properties["entityId"] }
+
+        entityIds.shouldNotBeEmpty()
+        entityIds shouldContain "entity-coroutines"
+        entityIds shouldContain "entity-jvm"
+        entityIds shouldContain "entity-spring"
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // IS_A classification
+    // ─────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `findConceptsForEntity returns concept for kotlin entity`() {
+        val conceptIds = service.findConceptsForEntity(seed.entityKotlin.id)
+            .map { it.properties["conceptId"] }
+
+        conceptIds.shouldNotBeEmpty()
+        conceptIds shouldContain "concept-language"
+    }
+
+    @Test
+    fun `findConceptsForEntity returns framework concept for spring entity`() {
+        val conceptIds = service.findConceptsForEntity(seed.entitySpring.id)
+            .map { it.properties["conceptId"] }
+
+        conceptIds.shouldNotBeEmpty()
+        conceptIds shouldContain "concept-framework"
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Path inference
+    // ─────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `inferRelationshipPaths finds path from kotlin to spring`() {
+        val paths = service.inferRelationshipPaths(
+            seed.entityKotlin.id,
+            seed.entitySpring.id,
+            maxDepth = 3,
+            maxPaths = 5,
+        )
+
+        paths.shouldNotBeEmpty()
+        val vertexIds = paths.first().vertices.map { it.properties["entityId"] }
+        vertexIds shouldContain "entity-kotlin"
+        vertexIds shouldContain "entity-spring"
+    }
+
+    @Test
+    fun `inferRelationshipPaths respects maxPaths bound`() {
+        val paths = service.inferRelationshipPaths(
+            seed.entityKotlin.id,
+            seed.entityJvm.id,
+            maxDepth = 4,
+            maxPaths = 1,
+        )
+
+        // at most 1 path returned
+        paths.size shouldBeEqualTo 1
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Ad-hoc entity/concept/document creation
+    // ─────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `addEntity and retrieve via findRelatedEntities`() {
+        val gradle = service.addEntity("entity-gradle", "Gradle", "BuildTool")
+        service.relateEntities(seed.entityKotlin.id, gradle.id, relationType = "uses")
+
+        val entityIds = service.findRelatedEntities(seed.entityKotlin.id)
+            .map { it.properties["entityId"] }
+
+        entityIds shouldContain "entity-gradle"
+    }
+
+    @Test
+    fun `classify and findConceptsForEntity round-trip`() {
+        val buildTool = service.addConcept("concept-build-tool", "Build Tool", "infrastructure")
+        val gradle = service.addEntity("entity-gradle", "Gradle", "BuildTool")
+        service.classify(gradle.id, buildTool.id)
+
+        val conceptIds = service.findConceptsForEntity(gradle.id)
+            .map { it.properties["conceptId"] }
+
+        conceptIds shouldContain "concept-build-tool"
+    }
+
+    @Test
+    fun `mention creates findMentionedEntities link`() {
+        val doc = service.addDocument("doc-gradle-guide", "Gradle User Manual", "docs")
+        val gradle = service.addEntity("entity-gradle", "Gradle", "BuildTool")
+        service.mention(doc.id, gradle.id, confidence = 90)
+
+        val entityIds = service.findMentionedEntities(doc.id)
+            .map { it.properties["entityId"] }
+
+        entityIds shouldContain "entity-gradle"
+    }
+}

--- a/graph/knowledge-graph/src/test/kotlin/io/bluetape4k/workshop/graph/knowledge/AbstractKnowledgeGraphTest.kt
+++ b/graph/knowledge-graph/src/test/kotlin/io/bluetape4k/workshop/graph/knowledge/AbstractKnowledgeGraphTest.kt
@@ -1,5 +1,6 @@
 package io.bluetape4k.workshop.graph.knowledge
 
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldContain
 import io.bluetape4k.assertions.shouldNotBeEmpty
@@ -192,5 +193,65 @@ abstract class AbstractKnowledgeGraphTest {
             .map { it.properties["entityId"] }
 
         entityIds shouldContain "entity-gradle"
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Input validation
+    // ─────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `addEntity with blank entityId throws IllegalArgumentException`() {
+        assertFailsWith<IllegalArgumentException> {
+            service.addEntity("", "Name", "Type")
+        }
+    }
+
+    @Test
+    fun `addConcept with blank conceptId throws IllegalArgumentException`() {
+        assertFailsWith<IllegalArgumentException> {
+            service.addConcept("", "Name")
+        }
+    }
+
+    @Test
+    fun `addDocument with blank documentId throws IllegalArgumentException`() {
+        assertFailsWith<IllegalArgumentException> {
+            service.addDocument("", "Title")
+        }
+    }
+
+    @Test
+    fun `mention with confidence above 100 throws IllegalArgumentException`() {
+        assertFailsWith<IllegalArgumentException> {
+            service.mention(seed.docKotlinGuide.id, seed.entityKotlin.id, confidence = 101)
+        }
+    }
+
+    @Test
+    fun `mention with negative confidence throws IllegalArgumentException`() {
+        assertFailsWith<IllegalArgumentException> {
+            service.mention(seed.docKotlinGuide.id, seed.entityKotlin.id, confidence = -1)
+        }
+    }
+
+    @Test
+    fun `findRelatedEntities with zero depth throws IllegalArgumentException`() {
+        assertFailsWith<IllegalArgumentException> {
+            service.findRelatedEntities(seed.entityKotlin.id, depth = 0)
+        }
+    }
+
+    @Test
+    fun `inferRelationshipPaths with zero maxDepth throws IllegalArgumentException`() {
+        assertFailsWith<IllegalArgumentException> {
+            service.inferRelationshipPaths(seed.entityKotlin.id, seed.entitySpring.id, maxDepth = 0)
+        }
+    }
+
+    @Test
+    fun `inferRelationshipPaths with zero maxPaths throws IllegalArgumentException`() {
+        assertFailsWith<IllegalArgumentException> {
+            service.inferRelationshipPaths(seed.entityKotlin.id, seed.entitySpring.id, maxPaths = 0)
+        }
     }
 }

--- a/graph/knowledge-graph/src/test/kotlin/io/bluetape4k/workshop/graph/knowledge/MemgraphKnowledgeGraphTest.kt
+++ b/graph/knowledge-graph/src/test/kotlin/io/bluetape4k/workshop/graph/knowledge/MemgraphKnowledgeGraphTest.kt
@@ -1,0 +1,75 @@
+package io.bluetape4k.workshop.graph.knowledge
+
+import io.bluetape4k.graph.memgraph.MemgraphGraphOperations
+import io.bluetape4k.graph.memgraph.MemgraphGraphSuspendOperations
+import io.bluetape4k.graph.repository.GraphOperations
+import io.bluetape4k.graph.repository.GraphSuspendOperations
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.warn
+import io.bluetape4k.testcontainers.graphdb.MemgraphServer
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.TestInstance
+import org.neo4j.driver.Driver
+import org.neo4j.driver.GraphDatabase
+
+/**
+ * [AbstractKnowledgeGraphTest] backed by a Memgraph Testcontainer.
+ *
+ * Requires Docker. Run with: `./gradlew :graph-knowledge-graph:integrationTest`
+ */
+@Tag("integration")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class MemgraphKnowledgeGraphTest : AbstractKnowledgeGraphTest() {
+    companion object : KLogging() {
+        private val memgraph = MemgraphServer.Launcher.memgraph
+    }
+
+    override val graphName: String = "memgraph_knowledge"
+
+    private lateinit var driver: Driver
+    override lateinit var ops: GraphOperations
+
+    @BeforeAll
+    fun setUp() {
+        driver = GraphDatabase.driver(memgraph.boltUrl)
+        ops = MemgraphGraphOperations(driver)
+    }
+
+    @AfterAll
+    fun tearDown() {
+        runCatching { driver.close() }
+            .onFailure { log.warn(it) { "Driver close failed during tearDown" } }
+    }
+}
+
+/**
+ * [AbstractKnowledgeGraphSuspendTest] backed by a Memgraph Testcontainer.
+ *
+ * Requires Docker. Run with: `./gradlew :graph-knowledge-graph:integrationTest`
+ */
+@Tag("integration")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class MemgraphKnowledgeGraphSuspendTest : AbstractKnowledgeGraphSuspendTest() {
+    companion object : KLogging() {
+        private val memgraph = MemgraphServer.Launcher.memgraph
+    }
+
+    override val graphName: String = "memgraph_knowledge_suspend"
+
+    private lateinit var driver: Driver
+    override lateinit var ops: GraphSuspendOperations
+
+    @BeforeAll
+    fun setUp() {
+        driver = GraphDatabase.driver(memgraph.boltUrl)
+        ops = MemgraphGraphSuspendOperations(driver)
+    }
+
+    @AfterAll
+    fun tearDown() {
+        runCatching { driver.close() }
+            .onFailure { log.warn(it) { "Driver close failed during tearDown" } }
+    }
+}

--- a/graph/knowledge-graph/src/test/kotlin/io/bluetape4k/workshop/graph/knowledge/Neo4jKnowledgeGraphTest.kt
+++ b/graph/knowledge-graph/src/test/kotlin/io/bluetape4k/workshop/graph/knowledge/Neo4jKnowledgeGraphTest.kt
@@ -1,0 +1,72 @@
+package io.bluetape4k.workshop.graph.knowledge
+
+import io.bluetape4k.graph.neo4j.Neo4jGraphOperations
+import io.bluetape4k.graph.neo4j.Neo4jGraphSuspendOperations
+import io.bluetape4k.graph.repository.GraphOperations
+import io.bluetape4k.graph.repository.GraphSuspendOperations
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.warn
+import io.bluetape4k.testcontainers.graphdb.Neo4jServer
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.TestInstance
+import org.neo4j.driver.Driver
+import org.neo4j.driver.GraphDatabase
+
+/**
+ * [AbstractKnowledgeGraphTest] backed by a Neo4j Testcontainer.
+ *
+ * Requires Docker. Run with: `./gradlew :graph-knowledge-graph:integrationTest`
+ */
+@Tag("integration")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class Neo4jKnowledgeGraphTest : AbstractKnowledgeGraphTest() {
+    companion object : KLogging() {
+        private val neo4j = Neo4jServer.Launcher.neo4j
+    }
+
+    override val graphName: String = "neo4j_knowledge"
+
+    private val driver: Driver by lazy {
+        GraphDatabase.driver(neo4j.url)
+    }
+
+    override val ops: GraphOperations by lazy {
+        Neo4jGraphOperations(driver)
+    }
+
+    @AfterAll
+    fun tearDown() {
+        runCatching { driver.close() }
+            .onFailure { log.warn(it) { "Driver close failed during tearDown" } }
+    }
+}
+
+/**
+ * [AbstractKnowledgeGraphSuspendTest] backed by a Neo4j Testcontainer.
+ *
+ * Requires Docker. Run with: `./gradlew :graph-knowledge-graph:integrationTest`
+ */
+@Tag("integration")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class Neo4jKnowledgeGraphSuspendTest : AbstractKnowledgeGraphSuspendTest() {
+    companion object : KLogging() {
+        private val neo4j = Neo4jServer.Launcher.neo4j
+    }
+
+    override val graphName: String = "neo4j_knowledge_suspend"
+
+    private val driver: Driver by lazy {
+        GraphDatabase.driver(neo4j.url)
+    }
+
+    override val ops: GraphSuspendOperations by lazy {
+        Neo4jGraphSuspendOperations(driver)
+    }
+
+    @AfterAll
+    fun tearDown() {
+        runCatching { driver.close() }
+            .onFailure { log.warn(it) { "Driver close failed during tearDown" } }
+    }
+}

--- a/graph/knowledge-graph/src/test/kotlin/io/bluetape4k/workshop/graph/knowledge/TinkerGraphKnowledgeGraphTest.kt
+++ b/graph/knowledge-graph/src/test/kotlin/io/bluetape4k/workshop/graph/knowledge/TinkerGraphKnowledgeGraphTest.kt
@@ -1,9 +1,9 @@
 package io.bluetape4k.workshop.graph.knowledge
 
-import io.bluetape4k.graph.tinkerpop.TinkerGraphOperations
-import io.bluetape4k.graph.tinkerpop.TinkerGraphSuspendOperations
 import io.bluetape4k.graph.repository.GraphOperations
 import io.bluetape4k.graph.repository.GraphSuspendOperations
+import io.bluetape4k.graph.tinkerpop.TinkerGraphOperations
+import io.bluetape4k.graph.tinkerpop.TinkerGraphSuspendOperations
 import io.bluetape4k.logging.KLogging
 
 /**

--- a/graph/knowledge-graph/src/test/kotlin/io/bluetape4k/workshop/graph/knowledge/TinkerGraphKnowledgeGraphTest.kt
+++ b/graph/knowledge-graph/src/test/kotlin/io/bluetape4k/workshop/graph/knowledge/TinkerGraphKnowledgeGraphTest.kt
@@ -1,0 +1,31 @@
+package io.bluetape4k.workshop.graph.knowledge
+
+import io.bluetape4k.graph.tinkerpop.TinkerGraphOperations
+import io.bluetape4k.graph.tinkerpop.TinkerGraphSuspendOperations
+import io.bluetape4k.graph.repository.GraphOperations
+import io.bluetape4k.graph.repository.GraphSuspendOperations
+import io.bluetape4k.logging.KLogging
+
+/**
+ * [AbstractKnowledgeGraphTest] backed by TinkerGraph (in-memory).
+ *
+ * No Docker required — runs in the default `:test` task.
+ */
+class TinkerGraphKnowledgeGraphTest : AbstractKnowledgeGraphTest() {
+    companion object : KLogging()
+
+    override val graphName: String = "default"
+    override val ops: GraphOperations = TinkerGraphOperations()
+}
+
+/**
+ * [AbstractKnowledgeGraphSuspendTest] backed by TinkerGraph (in-memory).
+ *
+ * No Docker required — runs in the default `:test` task.
+ */
+class TinkerGraphKnowledgeGraphSuspendTest : AbstractKnowledgeGraphSuspendTest() {
+    companion object : KLogging()
+
+    override val graphName: String = "default"
+    override val ops: GraphSuspendOperations = TinkerGraphSuspendOperations()
+}

--- a/graph/knowledge-graph/src/test/kotlin/io/bluetape4k/workshop/graph/knowledge/seed/KnowledgeGraphSeed.kt
+++ b/graph/knowledge-graph/src/test/kotlin/io/bluetape4k/workshop/graph/knowledge/seed/KnowledgeGraphSeed.kt
@@ -1,0 +1,172 @@
+package io.bluetape4k.workshop.graph.knowledge.seed
+
+import io.bluetape4k.graph.model.GraphVertex
+import io.bluetape4k.workshop.graph.knowledge.service.KnowledgeGraphService
+import io.bluetape4k.workshop.graph.knowledge.service.KnowledgeGraphSuspendService
+import java.io.Serializable
+
+/**
+ * Snapshot of all vertices created by [seedKnowledgeGraph].
+ *
+ * Graph structure (Technology knowledge graph):
+ * ```
+ * Documents:
+ *   doc-kotlin-guide  ──MENTIONS──► entity-kotlin   (confidence=95)
+ *   doc-kotlin-guide  ──MENTIONS──► entity-jvm       (confidence=80)
+ *   doc-spring-guide  ──MENTIONS──► entity-spring    (confidence=98)
+ *   doc-spring-guide  ──MENTIONS──► entity-kotlin    (confidence=75)
+ *
+ * Entity relationships (RELATED_TO):
+ *   entity-kotlin     ──has-feature──► entity-coroutines
+ *   entity-coroutines ──integrates-with──► entity-spring
+ *   entity-spring     ──runs-on──► entity-jvm
+ *   entity-kotlin     ──runs-on──► entity-jvm
+ *
+ * Concepts (IS_A):
+ *   entity-kotlin     ──IS_A──► concept-language
+ *   entity-spring     ──IS_A──► concept-framework
+ *   entity-coroutines ──IS_A──► concept-library
+ *   entity-jvm        ──IS_A──► concept-platform
+ * ```
+ *
+ * Key traversal expectations:
+ * - doc-kotlin-guide mentions: [entity-kotlin, entity-jvm]
+ * - doc-spring-guide mentions: [entity-spring, entity-kotlin]
+ * - entity-kotlin related (depth=1): [entity-coroutines, entity-jvm]
+ * - entity-kotlin related (depth=2): [entity-coroutines, entity-jvm, entity-spring]
+ * - paths from entity-kotlin to entity-spring via RELATED_TO: kotlin→coroutines→spring
+ * - entity-kotlin concepts: [concept-language]
+ */
+data class KnowledgeGraphSeed(
+    // Documents
+    val docKotlinGuide: GraphVertex,
+    val docSpringGuide: GraphVertex,
+    // Entities
+    val entityKotlin: GraphVertex,
+    val entityCoroutines: GraphVertex,
+    val entitySpring: GraphVertex,
+    val entityJvm: GraphVertex,
+    // Concepts
+    val conceptLanguage: GraphVertex,
+    val conceptFramework: GraphVertex,
+    val conceptLibrary: GraphVertex,
+    val conceptPlatform: GraphVertex,
+) : Serializable {
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Blocking seed
+// ─────────────────────────────────────────────────────────────────────────
+
+/**
+ * Populates the knowledge graph with a deterministic technology-domain dataset using [service].
+ *
+ * See [KnowledgeGraphSeed] for the full graph topology and traversal expectations.
+ */
+fun seedKnowledgeGraph(service: KnowledgeGraphService): KnowledgeGraphSeed {
+    // Documents
+    val docKotlinGuide = service.addDocument("doc-kotlin-guide", "Kotlin in Action", "book")
+    val docSpringGuide = service.addDocument("doc-spring-guide", "Spring Boot Reference", "docs")
+
+    // Entities
+    val entityKotlin = service.addEntity("entity-kotlin", "Kotlin", "Language")
+    val entityCoroutines = service.addEntity("entity-coroutines", "Coroutines", "Library")
+    val entitySpring = service.addEntity("entity-spring", "Spring", "Framework")
+    val entityJvm = service.addEntity("entity-jvm", "JVM", "Platform")
+
+    // Concepts
+    val conceptLanguage = service.addConcept("concept-language", "Programming Language", "software")
+    val conceptFramework = service.addConcept("concept-framework", "Application Framework", "software")
+    val conceptLibrary = service.addConcept("concept-library", "Software Library", "software")
+    val conceptPlatform = service.addConcept("concept-platform", "Runtime Platform", "infrastructure")
+
+    // MENTIONS edges
+    service.mention(docKotlinGuide.id, entityKotlin.id, confidence = 95)
+    service.mention(docKotlinGuide.id, entityJvm.id, confidence = 80)
+    service.mention(docSpringGuide.id, entitySpring.id, confidence = 98)
+    service.mention(docSpringGuide.id, entityKotlin.id, confidence = 75)
+
+    // RELATED_TO edges
+    service.relateEntities(entityKotlin.id, entityCoroutines.id, relationType = "has-feature")
+    service.relateEntities(entityCoroutines.id, entitySpring.id, relationType = "integrates-with")
+    service.relateEntities(entitySpring.id, entityJvm.id, relationType = "runs-on")
+    service.relateEntities(entityKotlin.id, entityJvm.id, relationType = "runs-on")
+
+    // IS_A edges (classification)
+    service.classify(entityKotlin.id, conceptLanguage.id)
+    service.classify(entitySpring.id, conceptFramework.id)
+    service.classify(entityCoroutines.id, conceptLibrary.id)
+    service.classify(entityJvm.id, conceptPlatform.id)
+
+    return KnowledgeGraphSeed(
+        docKotlinGuide = docKotlinGuide,
+        docSpringGuide = docSpringGuide,
+        entityKotlin = entityKotlin,
+        entityCoroutines = entityCoroutines,
+        entitySpring = entitySpring,
+        entityJvm = entityJvm,
+        conceptLanguage = conceptLanguage,
+        conceptFramework = conceptFramework,
+        conceptLibrary = conceptLibrary,
+        conceptPlatform = conceptPlatform,
+    )
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Suspend seed
+// ─────────────────────────────────────────────────────────────────────────
+
+/**
+ * Suspend variant of [seedKnowledgeGraph].
+ */
+suspend fun seedKnowledgeGraph(service: KnowledgeGraphSuspendService): KnowledgeGraphSeed {
+    // Documents
+    val docKotlinGuide = service.addDocument("doc-kotlin-guide", "Kotlin in Action", "book")
+    val docSpringGuide = service.addDocument("doc-spring-guide", "Spring Boot Reference", "docs")
+
+    // Entities
+    val entityKotlin = service.addEntity("entity-kotlin", "Kotlin", "Language")
+    val entityCoroutines = service.addEntity("entity-coroutines", "Coroutines", "Library")
+    val entitySpring = service.addEntity("entity-spring", "Spring", "Framework")
+    val entityJvm = service.addEntity("entity-jvm", "JVM", "Platform")
+
+    // Concepts
+    val conceptLanguage = service.addConcept("concept-language", "Programming Language", "software")
+    val conceptFramework = service.addConcept("concept-framework", "Application Framework", "software")
+    val conceptLibrary = service.addConcept("concept-library", "Software Library", "software")
+    val conceptPlatform = service.addConcept("concept-platform", "Runtime Platform", "infrastructure")
+
+    // MENTIONS edges
+    service.mention(docKotlinGuide.id, entityKotlin.id, confidence = 95)
+    service.mention(docKotlinGuide.id, entityJvm.id, confidence = 80)
+    service.mention(docSpringGuide.id, entitySpring.id, confidence = 98)
+    service.mention(docSpringGuide.id, entityKotlin.id, confidence = 75)
+
+    // RELATED_TO edges
+    service.relateEntities(entityKotlin.id, entityCoroutines.id, relationType = "has-feature")
+    service.relateEntities(entityCoroutines.id, entitySpring.id, relationType = "integrates-with")
+    service.relateEntities(entitySpring.id, entityJvm.id, relationType = "runs-on")
+    service.relateEntities(entityKotlin.id, entityJvm.id, relationType = "runs-on")
+
+    // IS_A edges (classification)
+    service.classify(entityKotlin.id, conceptLanguage.id)
+    service.classify(entitySpring.id, conceptFramework.id)
+    service.classify(entityCoroutines.id, conceptLibrary.id)
+    service.classify(entityJvm.id, conceptPlatform.id)
+
+    return KnowledgeGraphSeed(
+        docKotlinGuide = docKotlinGuide,
+        docSpringGuide = docSpringGuide,
+        entityKotlin = entityKotlin,
+        entityCoroutines = entityCoroutines,
+        entitySpring = entitySpring,
+        entityJvm = entityJvm,
+        conceptLanguage = conceptLanguage,
+        conceptFramework = conceptFramework,
+        conceptLibrary = conceptLibrary,
+        conceptPlatform = conceptPlatform,
+    )
+}

--- a/graph/knowledge-graph/src/test/resources/junit-platform.properties
+++ b/graph/knowledge-graph/src/test/resources/junit-platform.properties
@@ -1,0 +1,6 @@
+junit.jupiter.extensions.autodetection.enabled=true
+junit.jupiter.testinstance.lifecycle.default=per_class
+
+junit.jupiter.execution.parallel.enabled=false
+junit.jupiter.execution.parallel.mode.default=same_thread
+junit.jupiter.execution.parallel.mode.classes.default=concurrent

--- a/graph/knowledge-graph/src/test/resources/logback-test.xml
+++ b/graph/knowledge-graph/src/test/resources/logback-test.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
+        <immediateFlush>true</immediateFlush>
+        <encoder>
+            <!-- @formatter:off -->
+            <pattern>%d{HH:mm:ss.SSS} %highlight(%-5level) [%blue(%36.36t)] %yellow(%logger{36}):%line: %msg%n%ex</pattern>
+            <!-- @formatter:on -->
+            <charset>UTF-8</charset>
+        </encoder>
+    </appender>
+
+    <logger name="io.bluetape4k.workshop.graph.knowledge" level="DEBUG"/>
+
+    <root level="INFO">
+        <appender-ref ref="Console"/>
+    </root>
+
+</configuration>


### PR DESCRIPTION
## Summary

Implements the knowledge graph workshop example requested in issue #11.

## Changes

### New module: `graph/knowledge-graph`

**Schema** (`KnowledgeGraphSchema.kt`)
- `EntityLabel` — people, technologies, organizations (`entityId`, `name`, `entityType`)
- `ConceptLabel` — normalized domain vocabulary (`conceptId`, `name`, `domain`)
- `DocumentLabel` — source documents that mention entities (`documentId`, `title`, `source`)
- `MentionsLabel` — Document→Entity with confidence score
- `RelatedToLabel` — Entity→Entity with typed relationType
- `IsALabel` — Entity→Concept classification

**Services**
- `KnowledgeGraphService` — blocking API with `addEntity/Concept/Document`, `mention`, `relateEntities`, `classify`, `findMentionedEntities`, `findRelatedEntities`, `findConceptsForEntity`, `inferRelationshipPaths`
- `KnowledgeGraphSuspendService` — coroutine/Flow variant of the same API

**Seed dataset** — technology-domain graph (Kotlin, Spring, Coroutines, JVM entities with MENTIONS/RELATED_TO/IS_A edges and two documents)

**Tests** (abstract + concrete per backend)
| Backend | Task | Docker |
|---------|------|--------|
| TinkerGraph | `:test` | No |
| Neo4j | `:integrationTest` | Yes |
| Memgraph | `:integrationTest` | Yes |

## Test results

```
./gradlew :graph-knowledge-graph:test
BUILD SUCCESSFUL
TinkerGraph blocking:  10 tests passed, 0 failures
TinkerGraph suspend:   11 tests passed, 0 failures
```

## Verification

```bash
# Unit tests (no Docker)
./gradlew :graph-knowledge-graph:test

# Integration tests (requires Docker)
./gradlew :graph-knowledge-graph:integrationTest
```

Closes #11