### PR TITLE
docs: remove mermaid blocks from observability READMEs, keep PNG diagrams only

### DIFF
--- a/observability/micrometer-observation/README.md
+++ b/observability/micrometer-observation/README.md
@@ -5,25 +5,6 @@ Micrometer Observation API를 Spring MVC와 연동하는 예제입니다.
 
 ## Architecture
 
-```mermaid
-flowchart TD
-    Client -->|HTTP GET /greeting| GreetingController
-    GreetingController -->|calls| GreetingService
-    GreetingService -->|@Observed AOP| ObservedAspect
-    ObservedAspect -->|creates span| ObservationRegistry
-    ObservationRegistry -->|fires events| ObservationHandler
-    ObservationHandler -->|logs| ObservationTextPublisher
-
-    subgraph "bluetape4k-micrometer"
-        ObservationTextPublisher
-    end
-
-    subgraph "bluetape4k-logging"
-        KLogging
-        debug_ext["debug { } / info { }"]
-    end
-```
-
 ![micrometer observation Architecture diagram](../../docs/images/readme-diagrams/observability-micrometer-observation-diagram-01.png)
 
 ## Key Components

--- a/observability/micrometer-tracing-coroutines/README.md
+++ b/observability/micrometer-tracing-coroutines/README.md
@@ -5,34 +5,6 @@ bluetape4k의 `withObservation` / `withObservationSuspending` DSL로 코루틴 c
 
 ## Architecture
 
-```mermaid
-flowchart TD
-    Client -->|HTTP| Router["WebFlux Router"]
-    Router -->|/sync| SyncController
-    Router -->|/coroutine| CoroutineController
-    Router -->|/reactor| ReactorController
-
-    SyncController -->|withObservation| SyncService
-    CoroutineController -->|withObservationSuspending| CoroutineService
-    ReactorController -->|@Observed| ReactorService
-
-    SyncService -->|nested spans| ObservationRegistry
-    CoroutineService -->|nested suspend spans| ObservationRegistry
-    ReactorService -->|class-level span| ObservationRegistry
-
-    ObservationRegistry -->|OTel Bridge| OTelExporter["OTel Exporter"]
-    OTelExporter -->|HTTP POST| Zipkin["Zipkin Server\n(Testcontainers)"]
-
-    subgraph "bluetape4k-micrometer"
-        withObservation["withObservation {}"]
-        withObservationSuspending["withObservationSuspending {}"]
-    end
-
-    subgraph "bluetape4k-testcontainers"
-        ZipkinLauncher["ZipkinServer.Launcher.zipkin"]
-    end
-```
-
 ![micrometer tracing coroutines Architecture diagram](../../docs/images/readme-diagrams/observability-micrometer-tracing-coroutines-sequence-01.png)
 
 ![micrometer tracing coroutines Sequence Flow 2 diagram](../../docs/images/readme-diagrams/observability-micrometer-tracing-coroutines-diagram-01.png)


### PR DESCRIPTION
## Summary

Remove redundant Mermaid code blocks from two observability module READMEs. The PNG diagram assets already exist and render correctly; the Mermaid blocks caused display issues.

## Modules

- `observability/micrometer-observation` — removed Mermaid flowchart, kept PNG
- `observability/micrometer-tracing-coroutines` — removed Mermaid flowchart, kept PNG images

## Changes

- 2 files, -47 lines