### PR TITLE
fix: preserve coroutine observation parent spans

### DIFF
--- a/docs/lessons/2026-05-26-issue-85-observability-performance.md
+++ b/docs/lessons/2026-05-26-issue-85-observability-performance.md
@@ -1,0 +1,46 @@
+# Issue #85 — Observability/Performance Advanced Completion
+
+## Context
+
+Issue #85 was still open after PR #178 had improved several observability,
+Gatling, and virtual-thread READMEs. The remaining gap was in
+`observability/observability-advanced`: its README did not fully satisfy the
+Bluetape4k-first table/before-after/load-command requirement, and the local
+`observed()` helper started and stopped observations without opening a
+Micrometer scope across coroutine dispatcher boundaries.
+
+## Decision
+
+Keep the local `observed()` wrapper because it works around the known
+`withObservationContextSuspending` happy-path stop issue, but make it
+coroutine-scope-aware with a `ThreadContextElement`. This preserves structured
+cancellation behavior while allowing child observations to see the current
+parent observation after `withContext(Dispatchers.IO)`.
+
+## Outcome
+
+- `observed()` now validates the span name, opens/closes a Micrometer scope via
+  coroutine context, rethrows `CancellationException`, records only real errors,
+  and always stops the observation.
+- `UserServiceTest` now proves parent-child span relationships on cache miss,
+  cache hit, and create paths.
+- `README.md` and `README.ko.md` now include the Used Bluetape4k features table,
+  raw-vs-Bluetape4k before/after, smoke commands, retained load modules, and
+  stop conditions.
+
+## Verification
+
+- `./gradlew :observability-advanced:test` — 8 tests passing.
+- `git diff --check` — clean.
+- IntelliJ diagnostics were attempted but timed out in this Codex App session;
+  targeted Gradle compile/test served as fallback.
+- Claude Code CLI review-style prompts repeatedly produced empty artifacts, but
+  focused blocker prompts produced:
+  - `.omx/artifacts/claude-issue-85-spec-plan-blockers-20260526055825.md`
+  - `.omx/artifacts/claude-issue-85-code-blockers-20260526060522.md`
+
+## Future Guard
+
+For coroutine-based Micrometer helpers, test both span lifecycle and parent
+context propagation. A green "span exists" assertion is insufficient when the
+work crosses `withContext(...)` dispatcher boundaries.

--- a/docs/superpowers/plans/2026-05-26-issue-85-observability-performance-plan.md
+++ b/docs/superpowers/plans/2026-05-26-issue-85-observability-performance-plan.md
@@ -1,0 +1,65 @@
+# Implementation Plan — Issue #85 Observability/Performance Advanced Completion
+
+**Date**: 2026-05-26
+**Branch**: `feat/issue-85-observability-performance`
+**Spec**: `docs/superpowers/specs/2026-05-26-issue-85-observability-performance-design.md`
+
+## Task List
+
+| ID | Task | Files | Verification |
+|---|---|---|---|
+| T1 | Replace `observed()` with coroutine-aware scoped observation wrapper | `observability/observability-advanced/src/main/kotlin/.../ObservationSupport.kt` | compile + parent-child test |
+| T2 | Add cache-miss parent-child span regression test | `observability/observability-advanced/src/test/kotlin/.../UserServiceTest.kt` | `:observability-advanced:test` |
+| T3 | Update English README for issue #85 Bluetape4k-first AC | `observability/observability-advanced/README.md` | source-name grep + markdown review |
+| T4 | Update Korean README to match English README user-facing changes | `observability/observability-advanced/README.ko.md` | source-name grep + markdown review |
+| T5 | Run targeted verification | no source edits | `./gradlew :observability-advanced:test` |
+| T6 | Run Step 6-R dual code review | `.omx/artifacts/*` | Codex review + Claude Code CLI artifact P0/P1 = 0 |
+| T7 | Capture lesson, commit, push, create PR | `docs/lessons/2026-05-26-issue-85-observability-performance.md` | `git status`, PR URL |
+
+## Implementation Constraints
+
+- Do not change dependency versions or add new dependencies.
+- Do not run Gatling load tests in CI-like verification; document smoke/load
+  commands and stop conditions instead.
+- Do not touch generated README diagram assets in this pass.
+- Keep README public API/code references aligned with actual class/function names.
+- Keep Kotlin KDoc in English and conversation/internal plan text Korean-friendly.
+
+## Validation Commands
+
+```bash
+./gradlew :observability-advanced:test
+rg -n "observed\\(|Used Bluetape4k|structuredTaskScopeAll|Dispatchers.VT|gatlingRun" \
+  observability/observability-advanced/README.md \
+  observability/observability-advanced/README.ko.md \
+  observability/observability-advanced/src/main/kotlin \
+  observability/observability-advanced/src/test/kotlin
+git diff --check
+```
+
+## Review Gates
+
+1. Step 2-R / 3-R: local spec/plan review plus Claude Code CLI advisor.
+2. Step 6-R: current Codex diff review plus Claude Code CLI code review.
+3. P0/P1 findings block progress until fixed and rechecked.
+
+## Stop Condition
+
+Stop after PR creation and CI status report. Do not merge automatically.
+
+## Step 3-R Review Notes
+
+Claude Code CLI review-style prompts repeatedly returned empty artifacts in this
+Codex App session. The usable focused advisor artifact is:
+
+- `.omx/artifacts/claude-issue-85-spec-plan-blockers-20260526055825.md`
+
+Plan integration:
+
+| Priority | Finding | Plan response |
+|---|---|---|
+| P1 | Coroutine scope propagation can leak or lose current observation. | T1 implements `ThreadContextElement`; T2 proves parent-child spans. |
+| P1 | Cancellation must remain structured. | T1 keeps explicit `CancellationException` rethrow. |
+| P2 | Runtime proof must be concrete. | T5 runs `:observability-advanced:test`; T6 reviews the diff. |
+
+Latest Step 3-R status: P0 = 0, P1 = 0 for the executable plan.

--- a/docs/superpowers/specs/2026-05-26-issue-85-observability-performance-design.md
+++ b/docs/superpowers/specs/2026-05-26-issue-85-observability-performance-design.md
@@ -1,0 +1,128 @@
+# Issue #85 — Observability/Performance Advanced Completion Design
+
+**Date**: 2026-05-26
+**Branch**: `feat/issue-85-observability-performance`
+**Repository**: `bluetape4k-workshop`
+**Work type**: Type A — Full Design
+
+## Context
+
+Issue #85 asks the workshop to strengthen advanced observability/performance examples:
+
+- demonstrate trace/span propagation across coroutine and reactive boundaries;
+- decide and document retained Gatling / virtual-thread load examples;
+- include sequence diagrams, metrics/traces/screenshots where useful;
+- include load-test prerequisites and stop conditions;
+- maximize supported `bluetape4k-*` APIs in the happy path;
+- document a `Used Bluetape4k features` table plus before/after rationale.
+
+PR #178 already updated several README files for `micrometer-observation`,
+`micrometer-tracing-coroutines`, `gatling/virtualthread-simulation`,
+`virtualthreads/spring-mvc-tomcat`, and `virtualthreads/spring-webflux`, but the
+issue remains open. Current `origin/develop` still has a gap in
+`observability/observability-advanced`: its README lacks the required
+`Used Bluetape4k features` table and before/after explanation, and the local
+`observed()` helper starts/stops observations without opening a Micrometer scope
+across coroutine dispatcher boundaries. That means the documented span tree can
+become independent observations rather than parent-child spans.
+
+CodeGraph is not initialized for this repository, so structural impact review
+uses current source inspection plus targeted Gradle verification.
+
+## Scope
+
+Primary implementation scope:
+
+- `observability/observability-advanced/src/main/kotlin/.../observation/ObservationSupport.kt`
+- `observability/observability-advanced/src/test/kotlin/.../service/UserServiceTest.kt`
+- `observability/observability-advanced/README.md`
+- `observability/observability-advanced/README.ko.md`
+- `docs/lessons/2026-05-26-issue-85-observability-performance.md`
+
+Review-only regression scope:
+
+- `observability/micrometer-observation/README.md`
+- `observability/micrometer-tracing-coroutines/README.md`
+- `gatling/virtualthread-simulation/README.md`
+- `virtualthreads/spring-mvc-tomcat/README.md`
+- `virtualthreads/spring-webflux/README.md`
+
+## Design
+
+### D1. Coroutine-aware observation wrapper
+
+Replace the current local `observed()` implementation with a helper that:
+
+1. validates `name` with bluetape4k validation;
+2. creates and starts a Micrometer observation;
+3. opens the observation scope through a coroutine `ThreadContextElement`;
+4. executes the suspend block inside `withContext(scopeElement)`;
+5. rethrows `CancellationException` before recording an error;
+6. records non-cancellation errors;
+7. always stops the observation in `finally`.
+
+This preserves the existing workaround for the upstream
+`withObservationContextSuspending` happy-path stop issue while restoring
+Micrometer current-observation propagation across `withContext(Dispatchers.IO)`.
+
+### D2. Parent-child span proof
+
+Add a regression test proving that `user.cache.get`, `user.db.find`, and
+`user.cache.put` all have `user.service.get` as their parent observation context
+on the cache-miss path. Keep existing tests for cache-hit DB skip, no leaked
+current observation, and stop semantics.
+
+### D3. README completion
+
+Update English and Korean READMEs for `observability-advanced` with:
+
+- `Used Bluetape4k features` table;
+- raw framework approach vs bluetape4k-supported approach;
+- concrete benefit explanation;
+- coroutine/reactive boundary propagation notes;
+- smoke and load commands, prerequisites, and stop conditions;
+- clarification that Gatling/virtual-thread modules are retained because they
+  teach supported `bluetape4k-virtualthread`, logging, and Testcontainers paths.
+
+No new generated diagram asset is planned; existing PNG architecture asset is
+retained and existing README diagrams are only referenced.
+
+## Acceptance Criteria
+
+| Criterion | Required evidence |
+|---|---|
+| `observed()` propagates current observation across coroutine dispatcher boundaries | New parent-child span test passes |
+| Cancellation remains safe | Existing `CancellationException` behavior preserved in code path; test registry has no leaked current observation |
+| `observability-advanced` satisfies issue #85 Bluetape4k-first README requirement | README/README.ko include feature table, before/after, benefits, smoke/load commands |
+| Retained Gatling/virtual-thread modules are documented | README text names retained modules and stop-condition commands |
+| No unrelated modules changed | `git diff --name-status` limited to scoped files |
+| Targeted verification passes | `./gradlew :observability-advanced:test` |
+
+## Risks
+
+- `TestObservationRegistry` parent assertions depend on Micrometer test APIs.
+  Mitigation: use `hasParentObservationContextSatisfying` from the local 1.16.5
+  jar confirmed with `javap`.
+- Redis-backed tests use Testcontainers and must run serially. Mitigation:
+  one targeted Gradle invocation only.
+- CodeGraph is unavailable. Mitigation: record the tooling gap and rely on
+  targeted source inspection plus compile/test evidence.
+
+## Step 2-R Review Notes
+
+Claude Code CLI review-style prompts repeatedly returned empty artifacts in this
+Codex App session, although `claude -p 'Return exactly OK'` succeeded. The usable
+advisor artifact is:
+
+- `.omx/artifacts/claude-issue-85-spec-plan-blockers-20260526055825.md`
+
+Normalized findings:
+
+| Priority | Finding | Decision |
+|---|---|---|
+| P1 | Scope can leak or fail to propagate if the coroutine context element is not restored correctly. | Accepted; implementation uses `ThreadContextElement` and closes the scope returned by `updateThreadContext`. |
+| P1 | `CancellationException` must not be swallowed. | Accepted; implementation rethrows before `observation.error(e)`. |
+| P2 | Child coroutines must inherit the context element. | Accepted; scope is installed with `withContext(...)`; parent-child behavior is verified by `TestObservationRegistry`. |
+
+Latest Step 2-R status: P0 = 0, P1 = 0 after the planned implementation and test
+proof.

--- a/observability/observability-advanced/README.ko.md
+++ b/observability/observability-advanced/README.ko.md
@@ -36,10 +36,99 @@ http.server.requests              (자동)
 | 긍정 테스트 어설션 | `TestObservationRegistryAssert.assertThat(testRegistry).hasObservationWithNameEqualTo(...)` |
 | 부정 테스트 어설션 | `TestObservationRegistryAssert.assertThat(testRegistry).hasNumberOfObservationsWithNameEqualTo(name, 0)` |
 
+## 사용한 Bluetape4k 기능
+
+| 기능 | 모듈 / Artifact | 코드 위치 | 이점 |
+|------|-----------------|-----------|------|
+| Micrometer Observation starter | `bluetape4k-micrometer` | `ObservationSupport.observed()`가 `ObservationRegistry.start(name)` 사용 | `Observation.Context`를 직접 조립하지 않고 bluetape4k Observation factory 재사용 |
+| 코루틴 친화 로깅 | `bluetape4k-logging` | `UserService`, `UserRepository`, `UserCacheRepository`, 테스트 base | lazy Kotlin logging과 trace/span MDC 출력 일관성 |
+| Redis/Redisson DSL | `bluetape4k-redisson`, `bluetape4k-redis` | `RedissonConfig` | `redissonClient {}` 설정 경로로 Redisson client 생성 |
+| Redis Testcontainer singleton | `bluetape4k-testcontainers` | `AbstractAdvancedTest` | 임의 `GenericContainer` 대신 `RedisServer.Launcher.redis` 재사용 |
+| 코루틴 테스트 runner | `bluetape4k-junit5` | `UserServiceTest`, `UserControllerTest` | 테스트 본문에서 `runBlocking` 없이 `runSuspendIO {}`로 suspend 통합 테스트 실행 |
+| Assertion DSL | `bluetape4k-assertions` | `UserServiceTest`, `UserControllerTest` | JUnit assertion API 대신 Kotlin 스타일 null/value assertion 사용 |
+
+## Before / After
+
+### Raw Micrometer 방식
+
+```kotlin
+val observation = Observation.createNotStarted("user.service.get", registry)
+observation.start()
+try {
+    observation.openScope().use {
+        withContext(Dispatchers.IO) {
+            transaction { /* DB query */ }
+        }
+    }
+} catch (e: CancellationException) {
+    throw e
+} catch (e: Throwable) {
+    observation.error(e)
+    throw e
+} finally {
+    observation.stop()
+}
+```
+
+### Bluetape4k 지원 워크샵 방식
+
+```kotlin
+suspend fun getById(id: Long): User? =
+    observed("user.service.get", observationRegistry) {
+        val cached = cache.get(id)
+        cached ?: observed("user.db.find", observationRegistry) {
+            repo.findById(id)
+        }
+    }
+```
+
+`observed()`는 `bluetape4k-micrometer`의 `ObservationRegistry.start(name)` 경로를 유지하면서,
+코루틴 context element로 Micrometer scope를 열고, `CancellationException`은 그대로 다시 던지며,
+실제 오류만 span error로 기록하고, 항상 span을 stop합니다. 그래서 수동
+`start/openScope/error/stop` 보일러플레이트 없이도 `withContext(Dispatchers.IO)` 경계에서
+부모-자식 span tree가 유지됩니다.
+
 ## 테스트 커버리지
 
 - `UserServiceTest`: 캐시 미스/히트 스팬, null 결과, 생성 스팬, 명시적 캐시 삭제로 DB 조회 강제
 - `UserControllerTest`: HTTP POST 생성, GET 캐시 미스, GET 캐시 히트
+
+캐시 미스 서비스 테스트는 parent-child propagation도 검증합니다.
+
+```
+user.service.get
+  ├─ user.cache.get
+  ├─ user.db.find
+  └─ user.cache.put
+```
+
+## Smoke / Load 확인
+
+### 대상 smoke
+
+```bash
+./gradlew :observability-advanced:test
+./gradlew :observability-advanced:bootRun
+```
+
+사전 조건:
+
+- 통합 테스트의 Redis Testcontainer를 위해 Docker가 필요합니다.
+- Gradle이 사용할 수 있는 JDK 21+ toolchain이 필요합니다.
+
+### 유지하는 load/performance 예제
+
+이 모듈은 tracing/correlation 증명에 집중합니다. 부하 동작은 아래 성능 지향 모듈에 남깁니다.
+해당 모듈들은 지원되는 bluetape4k runtime helper를 보여주기 때문입니다.
+
+| 모듈 | 명령 | 중단 조건 |
+|------|------|-----------|
+| `gatling/virtualthread-simulation` | `./gradlew :gatling-virtualthread-simulation:gatlingRun` | Gatling assertion이 README 임계값 안에서 p95 latency와 success rate를 유지해야 함 |
+| `virtualthreads/spring-mvc-tomcat` | `./gradlew :virtualthreads-spring-mvc-tomcat:gatlingRun` | 문서화된 ramp profile에서 virtual-thread request handling이 악화되지 않아야 함 |
+| `virtualthreads/spring-webflux` | `./gradlew :virtualthreads-spring-webflux:gatlingRun` | dispatcher scenario가 error-rate regression 없이 끝나야 함 |
+
+로컬 load run은 error rate가 1%를 넘거나, p95 latency가 scenario README 임계값을 넘거나,
+컨테이너 CPU/메모리가 포화되거나, 애플리케이션 로그에 연결 실패가 반복되면 중단합니다.
 
 ## 의존성
 

--- a/observability/observability-advanced/README.md
+++ b/observability/observability-advanced/README.md
@@ -36,10 +36,99 @@ http.server.requests              (auto)
 | Positive test assertions | `TestObservationRegistryAssert.assertThat(testRegistry).hasObservationWithNameEqualTo(...)` |
 | Negative test assertions | `TestObservationRegistryAssert.assertThat(testRegistry).hasNumberOfObservationsWithNameEqualTo(name, 0)` |
 
+## Used Bluetape4k Features
+
+| Feature | Module / Artifact | Code Reference | Benefit |
+|---|---|---|---|
+| Micrometer observation starter | `bluetape4k-micrometer` | `ObservationSupport.observed()` uses `ObservationRegistry.start(name)` | Reuses the bluetape4k Observation factory instead of hand-building `Observation.Context` objects |
+| Coroutine-aware logging | `bluetape4k-logging` | `UserService`, `UserRepository`, `UserCacheRepository`, test base | Lazy Kotlin logging and consistent trace/span MDC output |
+| Redis/Redisson DSL | `bluetape4k-redisson`, `bluetape4k-redis` | `RedissonConfig` | Creates a Redisson client from a concise `redissonClient {}` configuration path |
+| Redis Testcontainer singleton | `bluetape4k-testcontainers` | `AbstractAdvancedTest` | Reuses `RedisServer.Launcher.redis` instead of ad-hoc `GenericContainer` setup |
+| Coroutine test runner | `bluetape4k-junit5` | `UserServiceTest`, `UserControllerTest` | Runs suspend integration tests with `runSuspendIO {}` without `runBlocking` in test bodies |
+| Assertion DSL | `bluetape4k-assertions` | `UserServiceTest`, `UserControllerTest` | Kotlin-style null/value assertions without JUnit assertion APIs |
+
+## Before / After
+
+### Raw Micrometer approach
+
+```kotlin
+val observation = Observation.createNotStarted("user.service.get", registry)
+observation.start()
+try {
+    observation.openScope().use {
+        withContext(Dispatchers.IO) {
+            transaction { /* DB query */ }
+        }
+    }
+} catch (e: CancellationException) {
+    throw e
+} catch (e: Throwable) {
+    observation.error(e)
+    throw e
+} finally {
+    observation.stop()
+}
+```
+
+### Bluetape4k-supported workshop approach
+
+```kotlin
+suspend fun getById(id: Long): User? =
+    observed("user.service.get", observationRegistry) {
+        val cached = cache.get(id)
+        cached ?: observed("user.db.find", observationRegistry) {
+            repo.findById(id)
+        }
+    }
+```
+
+`observed()` keeps the `bluetape4k-micrometer` `ObservationRegistry.start(name)` path,
+opens the Micrometer scope through a coroutine context element, rethrows
+`CancellationException`, records only real errors, and always stops the span. This removes
+manual `start/openScope/error/stop` boilerplate while keeping the parent-child span tree stable
+across `withContext(Dispatchers.IO)` boundaries.
+
 ## Test Coverage
 
 - `UserServiceTest`: cache miss/hit spans, null result, create spans, explicit cache delete forces DB lookup
 - `UserControllerTest`: HTTP POST create, GET cache miss, GET cache hit
+
+The cache-miss service test also verifies parent-child propagation:
+
+```
+user.service.get
+  ├─ user.cache.get
+  ├─ user.db.find
+  └─ user.cache.put
+```
+
+## Smoke and Load Checks
+
+### Targeted smoke
+
+```bash
+./gradlew :observability-advanced:test
+./gradlew :observability-advanced:bootRun
+```
+
+Prerequisites:
+
+- Docker must be available for the Redis Testcontainer used by integration tests.
+- JDK 21+ toolchain must be available through Gradle.
+
+### Retained load/performance examples
+
+This module is the tracing/correlation proof. Load behavior remains in the retained
+performance-oriented modules because they demonstrate supported bluetape4k runtime helpers:
+
+| Module | Command | Stop condition |
+|---|---|---|
+| `gatling/virtualthread-simulation` | `./gradlew :gatling-virtualthread-simulation:gatlingRun` | Gatling assertions should keep p95 latency and success rate inside the README thresholds |
+| `virtualthreads/spring-mvc-tomcat` | `./gradlew :virtualthreads-spring-mvc-tomcat:gatlingRun` | Virtual-thread request handling should not degrade under the documented ramp profile |
+| `virtualthreads/spring-webflux` | `./gradlew :virtualthreads-spring-webflux:gatlingRun` | Dispatcher scenarios should complete without error-rate regression |
+
+Stop a local load run when error rate exceeds 1%, p95 latency exceeds the README threshold for
+the scenario, container CPU/memory saturates, or the application logs repeated connection failures.
 
 ## Configuration
 

--- a/observability/observability-advanced/src/main/kotlin/io/bluetape4k/workshop/observability/advanced/observation/ObservationSupport.kt
+++ b/observability/observability-advanced/src/main/kotlin/io/bluetape4k/workshop/observability/advanced/observation/ObservationSupport.kt
@@ -1,14 +1,22 @@
 package io.bluetape4k.workshop.observability.advanced.observation
 
 import io.bluetape4k.micrometer.observation.start
+import io.bluetape4k.support.requireNotBlank
+import io.micrometer.observation.Observation
 import io.micrometer.observation.ObservationRegistry
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.ThreadContextElement
+import kotlinx.coroutines.withContext
+import kotlin.coroutines.AbstractCoroutineContextElement
+import kotlin.coroutines.CoroutineContext
 
 /**
- * Runs [block] under a named Micrometer Observation, always stopping the observation on exit.
+ * Runs [block] under a named Micrometer Observation and propagates its scope through coroutine resumes.
  *
  * ## Behavior / Contract
  * - Creates and starts a new Observation with [name] in [registry].
+ * - Opens the observation scope through a coroutine [ThreadContextElement], so child observations
+ *   created after `withContext(...)` calls still see this observation as their parent.
  * - Calls `observation.stop()` in a `finally` block — guarantees stop on both success and failure.
  * - Records the throwable via `observation.error(e)` before stopping on non-cancellation errors.
  * - Rethrows [CancellationException] immediately (before error recording) to preserve structured
@@ -32,9 +40,12 @@ suspend fun <T> observed(
     registry: ObservationRegistry,
     block: suspend () -> T,
 ): T {
+    name.requireNotBlank("name")
     val observation = registry.start(name)
     return try {
-        block()
+        withContext(ObservationScopeContextElement(observation)) {
+            block()
+        }
     } catch (e: CancellationException) {
         throw e
     } catch (e: Throwable) {
@@ -42,5 +53,21 @@ suspend fun <T> observed(
         throw e
     } finally {
         observation.stop()
+    }
+}
+
+private class ObservationScopeContextElement(
+    private val observation: Observation,
+) : ThreadContextElement<Observation.Scope>,
+    AbstractCoroutineContextElement(ObservationScopeContextElement) {
+
+    companion object Key : CoroutineContext.Key<ObservationScopeContextElement>
+
+    override fun updateThreadContext(context: CoroutineContext): Observation.Scope =
+        observation.openScope()
+
+    override fun restoreThreadContext(context: CoroutineContext, oldState: Observation.Scope) {
+        // Kotlin passes the value returned by updateThreadContext() back as oldState.
+        oldState.close()
     }
 }

--- a/observability/observability-advanced/src/test/kotlin/io/bluetape4k/workshop/observability/advanced/service/UserServiceTest.kt
+++ b/observability/observability-advanced/src/test/kotlin/io/bluetape4k/workshop/observability/advanced/service/UserServiceTest.kt
@@ -6,6 +6,7 @@ import io.bluetape4k.workshop.observability.advanced.TestObservationConfig
 import io.bluetape4k.workshop.observability.advanced.model.User
 import io.bluetape4k.workshop.observability.advanced.repository.UserCacheRepository
 import io.bluetape4k.workshop.observability.advanced.repository.UserRepository
+import io.micrometer.observation.tck.ObservationContextAssert
 import io.micrometer.observation.tck.TestObservationRegistry
 import io.micrometer.observation.tck.TestObservationRegistryAssert
 import org.junit.jupiter.api.AfterEach
@@ -66,6 +67,9 @@ class UserServiceTest : AbstractAdvancedTest() {
         TestObservationRegistryAssert.assertThat(testRegistry)
             .hasObservationWithNameEqualTo("user.cache.put")
             .that().hasBeenStarted().hasBeenStopped()
+        assertParentObservation("user.cache.get", "user.service.get")
+        assertParentObservation("user.db.find", "user.service.get")
+        assertParentObservation("user.cache.put", "user.service.get")
     }
 
     @Test
@@ -82,6 +86,7 @@ class UserServiceTest : AbstractAdvancedTest() {
         TestObservationRegistryAssert.assertThat(testRegistry)
             .hasObservationWithNameEqualTo("user.cache.get")
             .that().hasBeenStarted().hasBeenStopped()
+        assertParentObservation("user.cache.get", "user.service.get")
         // DB span must NOT be present on cache hit
         TestObservationRegistryAssert.assertThat(testRegistry)
             .hasNumberOfObservationsWithNameEqualTo("user.db.find", 0)
@@ -108,6 +113,7 @@ class UserServiceTest : AbstractAdvancedTest() {
         TestObservationRegistryAssert.assertThat(testRegistry)
             .hasObservationWithNameEqualTo("user.db.save")
             .that().hasBeenStarted().hasBeenStopped()
+        assertParentObservation("user.db.save", "user.service.create")
     }
 
     @Test
@@ -131,5 +137,14 @@ class UserServiceTest : AbstractAdvancedTest() {
         TestObservationRegistryAssert.assertThat(testRegistry)
             .hasObservationWithNameEqualTo("user.cache.put")
             .that().hasBeenStarted().hasBeenStopped()
+    }
+
+    private fun assertParentObservation(childName: String, parentName: String) {
+        TestObservationRegistryAssert.assertThat(testRegistry)
+            .hasObservationWithNameEqualTo(childName)
+            .that()
+            .hasParentObservationContextSatisfying { parent ->
+                ObservationContextAssert.assertThat(parent).hasNameEqualTo(parentName)
+            }
     }
 }


### PR DESCRIPTION
Fixes #85

## Summary
- preserve parent-child Micrometer observation propagation in `observability-advanced` across coroutine `withContext(...)` boundaries
- add regression assertions for service/cache/db span parent contexts
- complete the English/Korean README issue #85 Bluetape4k-first requirements with feature table, raw-vs-Bluetape4k before/after, smoke/load commands, and stop conditions
- add spec, plan, and lesson artifacts for the completion pass

## Verification
- `./gradlew :observability-advanced:test` — 8 passing
- `git diff --check` — clean

## Review Gates
- Codex local review: P0=0, P1=0
- Claude Code CLI: review-style prompts returned empty artifacts in this Codex App session; focused blocker artifacts were captured under `.omx/artifacts/claude-issue-85-*` and integrated. No accepted P0/P1 blockers remain.
- IntelliJ diagnostics: attempted, timed out after 120s; targeted Gradle compile/test used as fallback.

## Notes
- Gatling load runs are documented as smoke/load commands but were not executed locally.
- No new dependencies or generated diagram assets were added.
