### PR TITLE
feat: exercise bluetape4k messaging and redis modules

### DIFF
--- a/docs/lessons/2026-05-26-issue-81-messaging-advanced.md
+++ b/docs/lessons/2026-05-26-issue-81-messaging-advanced.md
@@ -1,0 +1,39 @@
+# Issue #81 Messaging/Redis Advanced
+
+## Context
+
+Issue #81 needed the workshop examples to actively use Bluetape4k Kafka, Lettuce, and Redisson modules, not only raw Spring Kafka, Lettuce, Redisson, or Testcontainers APIs.
+
+## Decisions
+
+- Use `bluetape4k-kafka4`, not `bluetape4k-kafka`, because this workshop is on Spring Kafka 4.
+- Keep Kafka request/reply on Spring Kafka `ReplyingKafkaTemplate`; no verified `bluetape4k-kafka4` request/reply wrapper exists.
+- Keep Redis Cluster behavior on Spring Data Redis cluster APIs, and add a scoped `bluetape4k-lettuce` executable path for low-level typed codec/coroutine usage.
+- Use existing `bluetape4k-redisson` helpers in Redisson examples with low churn: `localCachedMap()` and existing `streamAddArgsOf()`.
+- Treat `SuspendedJobTester.workers(N)` as concurrency only; total executions are `rounds * blockCount`.
+
+## Outcome
+
+- Kafka send path now uses `KafkaOperations.suspendSend()`.
+- Kafka reply module declares `bluetape4k-kafka4` and documents the request/reply boundary.
+- Redis cluster demo has a `Bluetape4kLettuceUsageTest` that exercises `LettuceClients`, `LettuceLongCodec`, and `awaitSuspending()`.
+- Redisson examples explicitly depend on `bluetape4k-redisson` and use `localCachedMap()`.
+- Distributed-lock tests use Bluetape4k `assertFailsWith`, and README/README.ko semantics now match `SuspendedJobTester`.
+
+## Verification
+
+- `./gradlew :messaging-kafka:compileKotlin :messaging-kafka:compileTestKotlin`
+- `./gradlew :messaging-kafka-reply:compileKotlin :messaging-kafka-reply:compileTestKotlin`
+- `./gradlew :redis-cluster-demo:test`
+- `./gradlew :redis-distributed-lock:test`
+- `./gradlew :redis-redisson-examples:test`
+- `git diff --check`
+- Step 2-R, Step 3-R, and Step 6-R Claude advisor gates all reached `P0=0 P1=0`.
+
+## Future Guidance
+
+- For Spring Kafka 4 examples, add `bluetape4k-kafka4` aliases/dependencies. `bluetape4k-kafka` is the Spring Kafka 3 line.
+- Do not claim `bluetape4k-lettuce` is cluster-aware unless a `RedisClusterClient` helper is verified in the resolved artifact.
+- Keep `MultithreadingTester` and `SuspendedJobTester` semantics separate in docs.
+- `.codegraph/` is local generated index state and must not be committed.
+

--- a/docs/superpowers/plans/2026-05-26-issue-81-messaging-advanced-plan.md
+++ b/docs/superpowers/plans/2026-05-26-issue-81-messaging-advanced-plan.md
@@ -1,0 +1,230 @@
+# Issue #81 Messaging/Redis Advanced Implementation Plan
+
+Date: 2026-05-26
+Repository: `bluetape4k-workshop`
+Branch: `feat/issue-81-messaging-advanced`
+Spec: `docs/superpowers/specs/2026-05-26-issue-81-messaging-advanced-design.md`
+Issue: https://github.com/bluetape4k/bluetape4k-workshop/issues/81
+
+## Gate State
+
+- Step 2 spec exists and passed Claude Step 2-R.
+- Step 2-R artifact: `.omx/artifacts/claude-step-2r-issue-81-spec-5min-final-20260526090610.md`
+- Step 3-R must pass with `P0=0` and `P1=0` before implementation.
+- Commit this spec and plan before Step 4 implementation.
+- Do not stage or commit `.codegraph/`.
+
+## Implementation Sequence
+
+### Task 1: Dependency and API verification
+
+Complexity: small
+Risk: build compatibility
+
+1. Confirm `gradle/libs.versions.toml` has:
+   - `bluetape4k-dependencies-version = "1.1.3"`
+   - `bluetape4k-dependencies` with `version.ref = "bluetape4k-dependencies-version"`
+   - `bluetape4k-lettuce` without explicit version
+   - `bluetape4k-redisson` without explicit version
+2. Add `bluetape4k-kafka4 = { module = "io.github.bluetape4k:bluetape4k-kafka4" }` next to the existing `bluetape4k-kafka` alias if absent.
+3. Confirm root build imports `platform(rootLibs.bluetape4k.dependencies)` and Spring Boot 4 BOM.
+4. Confirm the resolved `bluetape4k-kafka4` artifact exposes `KafkaOperations<K, V>.suspendSend(...)` compatible with `KafkaTemplate<String, Any>`.
+5. Confirm the resolved `bluetape4k-lettuce` artifact provides the selected low-level APIs: `LettuceClients`, `LettuceLongCodec` or `RedisFuture.awaitSuspending()`.
+6. Confirm the resolved `bluetape4k-redisson` artifact provides the selected APIs: `redissonClient` or `redissonClientForHighConcurrency`, `RedissonCodecs`, `localCachedMap` or `mapCache`, `streamAddArgsOf`, and coroutine `RFuture` helpers.
+
+Validation:
+
+- Run dependency insight or targeted compile after dependency edits if source inspection is not enough.
+- If any selected BT API is missing from the resolved artifact, stop and update this plan/spec before implementation rather than hand-rolling a replacement.
+
+### Task 2: Kafka send path uses `bluetape4k-kafka4`
+
+Complexity: small
+Risk: coroutine/send semantics
+
+1. In `messaging/kafka/build.gradle.kts`, replace the commented Spring Kafka 3 alias with `implementation(libs.bluetape4k.kafka4)`.
+2. In `GreetingController.kt`, replace both raw `KafkaTemplate.send(...)` calls with `kafkaTemplate.suspendSend(...)`.
+3. Import the verified `bluetape4k-kafka4` extension package.
+4. Keep controller signatures suspend-aware and do not add `runBlocking`.
+5. Do not alter topic names, payload types, or listener behavior.
+
+Validation:
+
+- `./gradlew :messaging-kafka:compileKotlin :messaging-kafka:compileTestKotlin`
+- If compile fails due to extension receiver mismatch, revert only the send-path call change, keep the dependency change for review, and update the spec/plan with the resolved API gap.
+
+### Task 3: Kafka request/reply boundary documents `bluetape4k-kafka4`
+
+Complexity: small
+Risk: documentation accuracy
+
+1. In `messaging/kafka-reply/build.gradle.kts`, replace the commented Spring Kafka 3 alias with `implementation(libs.bluetape4k.kafka4)`.
+2. Keep `PingController` on Spring Kafka `ReplyingKafkaTemplate.sendAndReceive(...)`.
+3. Do not invent a Bluetape4k request/reply wrapper unless Task 1 verifies one in the resolved artifact.
+4. Update `messaging/kafka-reply/README.md` with a short `Bluetape4k boundary` section:
+   - `bluetape4k-kafka4` is present for Spring Kafka 4 coroutine/send helpers.
+   - True request/reply remains on `ReplyingKafkaTemplate` because no verified BT request/reply abstraction exists.
+   - Existing `onSuccess`, `onFailure`, and coroutine `await()` usage remains part of the BT/coroutine ergonomics story.
+
+Validation:
+
+- `./gradlew :messaging-kafka-reply:compileKotlin :messaging-kafka-reply:compileTestKotlin`
+- README review for no false claim that BT replaces `ReplyingKafkaTemplate`.
+
+### Task 4: Redis cluster demo gets executable `bluetape4k-lettuce` usage
+
+Complexity: medium
+Risk: Testcontainers and client lifecycle
+
+1. Add `implementation(libs.bluetape4k.lettuce)` to `redis/cluster-demo/build.gradle.kts`.
+2. Keep the existing Spring Data Redis cluster path and `RedisClusterServer.Launcher.LettuceLib.clientResources(redisCluster)` unchanged.
+3. Add `redis/cluster-demo/src/test/kotlin/io/bluetape4k/workshop/redis/cluster/basic/Bluetape4kLettuceUsageTest.kt` extending `AbstractRedisClusterTest` to exercise a BT Lettuce low-level path against a Testcontainers Redis endpoint.
+4. Use verified BT Lettuce APIs, preferring:
+   - `LettuceClients` for client/command creation
+   - `LettuceLongCodec` for typed numeric values, or `RedisFuture.awaitSuspending()` for coroutine future bridging
+5. Client lifecycle must be explicit:
+   - create the client in the test scope
+   - close stateful connection after use
+   - shut down client resources if the BT helper does not own them
+6. Keep Testcontainers-backed execution serial; do not introduce parallel test assumptions.
+7. Update `redis/cluster-demo/README.md` and `README.ko.md` if present/needed to explain the boundary:
+   - Spring Data Redis remains the Redis Cluster proof.
+   - `bluetape4k-lettuce` demonstrates typed codecs/client helpers/coroutine support for a scoped low-level path.
+
+Validation:
+
+- `./gradlew :redis-cluster-demo:test`
+- The new or changed test must execute the BT Lettuce path, not just compile it.
+
+### Task 5: Redisson examples explicitly foreground `bluetape4k-redisson`
+
+Complexity: medium
+Risk: broad test module runtime
+
+1. Add `implementation(libs.bluetape4k.redisson)` to `redis/redisson-examples/build.gradle.kts`.
+2. Prefer focused, low-churn changes in existing tests:
+   - update `AbstractRedissonTest` only if `redissonClient {}` or `redissonClientForHighConcurrency(...)` is compatible with the current shared lifecycle and preserves `ShutdownQueue.register { shutdown() }`.
+   - update `collections/LocalCachedMapExamples.kt` to use the verified BT `localCachedMap(...)` or `mapCache(...)` helper instead of raw `redisson.getLocalCachedMap(options)` when the helper supports the same options.
+   - update `collections/StreamExamples.kt` to use the verified BT `streamAddArgsOf(...)` helper for append arguments.
+   - keep `RedissonCodecs` usage visible through `AbstractRedissonTest` or the touched examples.
+3. Keep raw Redisson APIs where the example is teaching raw Redisson object behavior.
+4. Ensure client lifecycle remains explicit in `AbstractRedissonTest` or the touched test:
+   - create once per test class/scope
+   - close/shutdown in the existing lifecycle hook
+5. Update `redis/redisson-examples/README.md` and `README.ko.md` if present/needed with concrete used-feature rows for `bluetape4k-redisson`.
+
+Validation:
+
+- Prefer `./gradlew :redis-redisson-examples:test`.
+- If the full module is too broad or slow, run a narrower Gradle test slice that includes the changed BT-backed example and record the exact command.
+- Compile-only proof is not enough for the new active `bluetape4k-redisson` usage.
+
+### Task 6: Distributed lock cleanup and README parity
+
+Complexity: small
+Risk: documentation/test assertion drift
+
+1. Replace `kotlin.test.assertFailsWith` with the approved `io.bluetape4k.assertions.assertFailsWith` import in:
+   - `redis/distributed-lock/src/test/kotlin/io/bluetape4k/workshop/lock/DistributedLockTest.kt`
+   - `redis/distributed-lock/src/test/kotlin/io/bluetape4k/workshop/lock/FencedStaleHolderTest.kt`
+   - `redis/distributed-lock/src/test/kotlin/io/bluetape4k/workshop/lock/LockFailureTest.kt`
+2. Preserve `SuspendFencedLockTest.kt` comment semantics:
+   - `totalUnits = rounds * blockCount`
+   - `workers` controls concurrency only
+   - `workers(20).rounds(20)` with one block means 20 attempts
+3. Update `redis/distributed-lock/README.md`:
+   - replace `SuspendedJobTester.workers(N).rounds(R) launches N workers each running R rounds of the add { } block` with: `SuspendedJobTester.workers(N).rounds(R) spawns N concurrent workers that cooperatively execute R rounds of each add { } block. totalUnits = R x blockCount.`
+   - replace `workers x rounds = total attempts` with `rounds x blockCount = total attempts`
+   - change the Before/After example from `.rounds(1) // ... 20 total attempts` to `.rounds(20) // 20 total attempts, exactly 10 succeed`
+   - state `workers(20).rounds(20) -> 20 total attempts -> exactly 10 succeed`
+4. Apply the same semantic correction in `redis/distributed-lock/README.ko.md`.
+   - replace `N개의 워커가 각각 R라운드의 add { } 블록을 실행합니다` with: `N개의 동시 워커가 협력하여 각 add { } 블록을 R라운드 실행합니다. totalUnits = R x blockCount.`
+5. Bring `README.ko.md` into parity for touched dependency and BT feature table content.
+6. Keep `MultithreadingTester` wording separate from `SuspendedJobTester`; `MultithreadingTester` examples such as `DistributedLockTest` may still use `workers x rounds` semantics and must not be rewritten as if they were `SuspendedJobTester`.
+
+Validation:
+
+- `./gradlew :redis-distributed-lock:test`
+- Confirm no touched test imports `kotlin.test.assertFailsWith`.
+
+### Task 7: README and diagram check
+
+Complexity: small
+Risk: user-facing drift
+
+1. Review README pairs for touched modules:
+   - `messaging/kafka/README.md` and localized variants if present
+   - `messaging/kafka-reply/README.md` and localized variants if present
+   - `redis/cluster-demo/README.md` and `README.ko.md` if present
+   - `redis/redisson-examples/README.md` and `README.ko.md` if present
+   - `redis/distributed-lock/README.md` and `README.ko.md`
+2. Add or update `Used Bluetape4k Features` rows only where the code path actually uses the named module.
+3. Do not update existing diagram images unless the event or lock/cache flow changes materially. The planned code changes are API-adoption and documentation-boundary changes, not new flow semantics.
+4. Keep public-facing README text in the existing language of each file.
+
+Validation:
+
+- Manual content review.
+- `git diff --check`.
+
+### Task 8: Full targeted verification
+
+Complexity: medium
+Risk: Docker/Testcontainers runtime
+
+Run commands serially:
+
+```bash
+./gradlew :messaging-kafka:compileKotlin :messaging-kafka:compileTestKotlin
+./gradlew :messaging-kafka-reply:compileKotlin :messaging-kafka-reply:compileTestKotlin
+./gradlew :redis-cluster-demo:test
+./gradlew :redis-distributed-lock:test
+./gradlew :redis-redisson-examples:test
+git diff --check
+```
+
+If `:redis-redisson-examples:test` is too broad or unstable, run a narrower `--tests` command that executes the changed BT-backed example and record the limitation in the final report and PR.
+
+### Task 9: Review, lesson, and PR
+
+Complexity: small
+Risk: workflow compliance
+
+1. Run Step 6-R code review gate with Claude Code CLI artifact and integrated P0/P1 table.
+2. Fix any P0/P1 findings and rerun affected verification.
+3. Add `docs/lessons/2026-05-26-issue-81-messaging-advanced.md` with:
+   - context
+   - decisions
+   - outcome
+   - verification evidence
+   - future-agent guidance
+4. Commit implementation and lesson with Lore protocol trailers.
+5. Create a GitHub PR assigned to `debop`, referencing `Fixes #81`.
+6. Do not auto-merge; report PR URL and CI status.
+
+## Review Log
+
+### Step 3-R Codex Perspectives
+
+Artifact: `.omx/artifacts/codex-step-3r-issue-81-plan-perspectives-20260526091300.md`
+
+Result: `P0=0 P1=0 P2=8 P3=0`
+
+### Step 3-R Claude Code Opus Advisor
+
+Initial artifact: `.omx/artifacts/claude-step-3r-issue-81-plan-5min-20260526091049.md`
+
+Initial result: `P0=0 P1=1`; accepted the finding that README prose still described `SuspendedJobTester` as each worker running every round.
+
+Final artifact: `.omx/artifacts/claude-step-3r-issue-81-plan-5min-final-20260526091541.md`
+
+Final result: `P0=0 P1=0 Verdict=PASS`
+
+### Step 3-R Integration
+
+Step 3-R is closed. Required P1 plan edit was applied in Task 6:
+
+- Exact English and Korean README wording replacements for cooperative `SuspendedJobTester` workers.
+- Explicit separation from `MultithreadingTester` semantics.
+
+No P0/P1 findings remain.

--- a/docs/superpowers/specs/2026-05-26-issue-81-messaging-advanced-design.md
+++ b/docs/superpowers/specs/2026-05-26-issue-81-messaging-advanced-design.md
@@ -1,0 +1,283 @@
+# Issue #81 Messaging/Redis Advanced Design
+
+Date: 2026-05-26
+Repository: `bluetape4k-workshop`
+Branch: `feat/issue-81-messaging-advanced`
+Issue: https://github.com/bluetape4k/bluetape4k-workshop/issues/81
+
+## Problem
+
+Issue #81 asks for production-shaped messaging and distributed-state examples across:
+
+- `messaging/kafka`
+- `messaging/kafka-reply`
+- `redis/cluster-demo`
+- `redis/redisson-examples`
+
+The examples must demonstrate request/reply, retry or replay behavior, distributed lock correctness, Redis cluster behavior, failure-path tests, event-flow and lock/cache coordination diagrams, Testcontainers or local-service requirements, and a Bluetape4k-first explanation.
+
+The user also explicitly tightened the requirement: actively use the Bluetape4k Kafka, Lettuce, and Redisson modules, not just raw framework APIs or Testcontainers helpers. In this Spring Kafka 4 workshop, that Kafka requirement maps to the compatible `bluetape4k-kafka4` artifact, not the Spring Kafka 3.x `bluetape4k-kafka` artifact.
+
+## Current Evidence
+
+### Prior work
+
+`docs/lessons/2026-05-24-issue-81-messaging-advanced.md` records earlier README strengthening for `redis/cluster-demo` and `redis/distributed-lock`; it also notes that `messaging/kafka`, `messaging/kafka-reply`, and `redis/redisson-examples` were partly covered in Issue #83.
+
+Current docs already include several diagrams and BT feature tables, but current build files show underuse of the requested BT modules:
+
+- `messaging/kafka/build.gradle.kts` has the Spring Kafka 3.x `implementation(libs.bluetape4k.kafka)` alias commented out.
+- `messaging/kafka-reply/build.gradle.kts` has the Spring Kafka 3.x `implementation(libs.bluetape4k.kafka)` alias commented out.
+- `redis/cluster-demo/build.gradle.kts` uses raw `lettuce.core` but does not declare `bluetape4k-lettuce`.
+- `redis/redisson-examples/build.gradle.kts` uses `bluetape4k-redis` and raw Redisson, but does not declare `bluetape4k-redisson`.
+- `redis/distributed-lock/build.gradle.kts` already declares `bluetape4k-redis` and `bluetape4k-redisson`.
+- `gradle/libs.versions.toml` already declares `bluetape4k-kafka`, `bluetape4k-lettuce`, and `bluetape4k-redisson` aliases without explicit versions, but it does not yet declare the needed Spring Kafka 4-compatible `bluetape4k-kafka4` alias.
+- The actual imported BOM is `io.github.bluetape4k:bluetape4k-dependencies:1.1.3`, not the stale values mentioned in older guidance text.
+
+### CodeGraph and source inspection
+
+CodeGraph was initialized for this worktree and reports 1,403 indexed files, 17,552 nodes, and 34,425 edges. Relevant current entry points are:
+
+- `messaging/kafka/src/main/kotlin/io/bluetape4k/workshop/messaging/kafka/controller/GreetingController.kt`
+- `messaging/kafka/src/main/kotlin/io/bluetape4k/workshop/messaging/kafka/listener/GreetingMessageHandler.kt`
+- `messaging/kafka-reply/src/main/kotlin/io/bluetape4k/workshop/kafka/ping/PingController.kt`
+- `messaging/kafka-reply/src/main/kotlin/io/bluetape4k/workshop/kafka/pong/PongHandler.kt`
+- `redis/cluster-demo/src/main/kotlin/io/bluetape4k/workshop/redis/cluster/RedisClusterApplication.kt`
+- `redis/cluster-demo/src/main/kotlin/io/bluetape4k/workshop/redis/cluster/service/NumberService.kt`
+- `redis/distributed-lock/src/main/kotlin/io/bluetape4k/workshop/lock/service/SuspendingFencedInventoryService.kt`
+- `redis/redisson-examples/src/test/kotlin/io/bluetape4k/workshop/redisson/AbstractRedissonTest.kt`
+
+Current usage:
+
+- Kafka modules already use `KafkaServer.Launcher.kafka`, but main send paths still call raw `KafkaTemplate.send(...)`.
+- `PingController` uses `ReplyingKafkaTemplate.sendAndReceive(...)`, Bluetape4k `onSuccess` / `onFailure`, and coroutine `await()`.
+- `RedisClusterApplication` uses `RedisClusterServer.Launcher.redisCluster` and `RedisClusterServer.Launcher.LettuceLib.clientResources(redisCluster)`.
+- `NumberService` uses Spring Data Redis `clusterConnection` and Bluetape4k byte conversion helpers, but not `bluetape4k-lettuce` APIs.
+- `SuspendingFencedInventoryService` uses `RedissonClient.getLockId`, `tryLockAsync(..., lockId)`, `tokenAsync.await()`, and `withContext(NonCancellable)` around `unlockAsync(lockId).await()`.
+- `redis/redisson-examples` uses `RedissonCodecs`, `streamAddArgsOf`, and coroutine `getLockId`, but the artifact dependency should be made explicit through `bluetape4k-redisson`.
+
+### Bluetape4k API evidence from sibling source
+
+Current sibling library source under `bluetape4k-projects` shows:
+
+- `bluetape4k-kafka4` provides Spring Kafka 4-compatible `KafkaOperations.suspendSend(...)` extensions and `sendFlowAsParallel(...)` / `sendAndForget(...)` flow helpers.
+- `bluetape4k-kafka4` also provides `KafkaCodecs` for string, byte array, Jackson, Kryo, Fory, and compressed binary codecs.
+- `bluetape4k-lettuce` provides `LettuceClients`, `LettuceLongCodec`, `LettuceJsonCodecs`, `LettuceBinaryCodec`, `RedisFuture.awaitSuspending()`, `awaitAll()`, `withPipeline(...)`, `LettuceLock`, `LettuceSuspendLock`, and `LettuceSuspendAtomicLong`.
+- `bluetape4k-redisson` provides `redissonClient {}`, `redissonClientForHighConcurrency(...)`, `RedissonCodecs`, `RedissonCacheConfig`, `localCachedMap(...)`, `mapCache(...)`, `streamAddArgsOf(...)`, and coroutine `RFuture` helpers.
+
+### Current test and doc drift
+
+Existing Redis distributed-lock tests already cover over-sell prevention, cancellation-safe unlock, stale-token rejection, and lock-acquisition failure. However:
+
+- `DistributedLockTest.kt` imports `kotlin.test.assertFailsWith`; new changes should use Bluetape4k assertion APIs.
+- `SuspendFencedLockTest.kt` correctly describes `SuspendedJobTester().workers(20).rounds(20)`: `totalUnits = rounds x blockCount`; `workers` controls concurrency only.
+- `redis/distributed-lock/README.md` and `README.ko.md` contain independent `SuspendedJobTester` drift in the Before/After example: they imply `workers x rounds` or pair `.rounds(1)` with "20 attempts"; the correct formula is `rounds x blockCount`.
+- `redis/distributed-lock/README.ko.md` lacks full parity with the English README's `Used bluetape4k Features` and Before/After content.
+
+## External Reference Evidence
+
+Context7 was attempted for Spring Kafka, Redisson, and Spring Data Redis, but returned a monthly quota error. Official web fallback was used:
+
+- Spring Kafka documents `ReplyingKafkaTemplate.sendAndReceive(...)`, `sendFuture`, reply timeout behavior, and `@SendTo` request/reply usage.
+- Redisson documents `RFencedLock` fencing tokens and stale-token rejection by guarded services.
+- Spring Data Redis documents Redis Cluster configuration and cluster behavior.
+- Lettuce documents adaptive topology refresh triggers and dynamic refresh sources.
+
+## Constraints
+
+- Use `bluetape4k-workflow` Type A Full Design and `bluetape4k-design` strictly.
+- Actively use `bluetape4k-kafka4`, `bluetape4k-lettuce`, and `bluetape4k-redisson` in happy paths or executable smoke/test paths.
+- Do not add a generic framework wrapper when an existing Bluetape4k utility exists.
+- Do not commit `.codegraph/`; it is generated local index state.
+- Keep public GitHub, PR, commit, and KDoc artifacts in English.
+- Internal specs, plans, and lessons may be Korean or English; this spec uses English for compact review.
+- Testcontainers-backed tests must run serially.
+- README changes must preserve localized README parity where localized files already exist.
+- No new dependency versions: use existing aliases governed by `bluetape4k-dependencies` BOM and repo-local catalog aliases.
+
+## Pre-Implementation Verification Gates
+
+Before implementation starts, the plan must verify these API and dependency facts:
+
+1. **Version catalog and BOM**
+   - Confirm `libs.bluetape4k.kafka4`, `libs.bluetape4k.lettuce`, and `libs.bluetape4k.redisson` exist in `gradle/libs.versions.toml`.
+   - Add `bluetape4k-kafka4 = { module = "io.github.bluetape4k:bluetape4k-kafka4" }` if the alias is absent.
+   - Confirm those aliases have no explicit version.
+   - Confirm the root build imports `platform(libs.bluetape4k.dependencies)`.
+   - Confirm the resolved BOM version from this repo's catalog is `bluetape4k-dependencies-version = "1.1.3"`.
+
+2. **Kafka extension receiver**
+   - Confirm the resolved `bluetape4k-kafka4` artifact exposes `suspendSend` on a receiver type compatible with `KafkaTemplate<String, Any>`.
+   - Sibling source shows `KafkaOperations<K, V>.suspendSend(...)`; the implementation must verify that `KafkaTemplate` implements `KafkaOperations` for the resolved Spring Kafka version.
+   - If the resolved artifact lacks the extension, do not hand-roll a replacement under the Bluetape4k name. Record the gap and keep the existing raw Spring Kafka path until an upstream issue exists.
+
+3. **Lettuce cluster boundary**
+   - Confirm whether `bluetape4k-lettuce` exposes Redis Cluster-aware helpers.
+   - Sibling source evidence currently shows `RedisClient`-oriented `LettuceClients`, codecs, locks, atomic longs, and future helpers. Unless a cluster-aware helper is verified, the BT Lettuce adoption must be a scoped low-level Redis path, while Spring Data Redis keeps the Redis Cluster example.
+
+4. **Redisson helper compatibility**
+   - Confirm `bluetape4k-redisson` provides the intended helpers in the resolved artifact: `redissonClient {}`, `RedissonCodecs`, `localCachedMap(...)`/`mapCache(...)`, `streamAddArgsOf(...)`, and coroutine future helpers.
+
+## Design Options
+
+### Option A: Dependency-only documentation cleanup
+
+Scope:
+
+- Uncomment/add the requested BT module dependencies.
+- Update README tables and fix test comments/docs.
+
+Pros:
+
+- Lowest risk.
+
+Cons:
+
+- Fails the user's explicit "actively use" requirement because artifacts would appear without meaningful happy-path usage.
+
+### Option B: Focused BT-module adoption in existing examples
+
+Scope:
+
+- `messaging/kafka`: depend on `bluetape4k-kafka4` and replace raw `KafkaTemplate.send(...)` calls in `GreetingController` with `KafkaOperations.suspendSend(...)`.
+- `messaging/kafka-reply`: depend on `bluetape4k-kafka4`; keep `ReplyingKafkaTemplate.sendAndReceive(...)` for true request/reply because the current BT API evidence does not show a direct request/reply replacement. Document the gap honestly and keep BT callback/coroutine helpers in the path.
+- `redis/cluster-demo`: depend on `bluetape4k-lettuce` and add a small Lettuce-backed cluster support path, such as using `LettuceClients`, `LettuceLongCodec`, and `awaitSuspending()` in a new service/test that exercises a Testcontainers Redis endpoint. Keep existing Spring Data Redis cluster behavior as the main cluster example when cluster-aware BT Lettuce wrappers are not present.
+- `redis/redisson-examples`: depend on `bluetape4k-redisson` explicitly and update examples/docs to foreground `RedissonCodecs`, `redissonClient {}` or high-concurrency client helpers, `localCachedMap(...)`/`mapCache(...)`, `streamAddArgsOf(...)`, and coroutine helpers where they already fit.
+- `redis/distributed-lock`: keep existing `bluetape4k-redisson`/`bluetape4k-redis` lock path; fix assertion style and `SuspendedJobTester` semantics in code comments and README pairs.
+
+Pros:
+
+- Satisfies the explicit BT-module adoption request without large new subsystems.
+- Improves executable proof rather than only README text.
+- Reuses current module boundaries and examples.
+
+Cons:
+
+- Adds cross-module Gradle verification surface.
+- Requires careful distinction between `bluetape4k-lettuce` single-node utilities and the existing Redis Cluster example.
+
+### Option C: New combined Kafka + Redis orchestration subsystem
+
+Scope:
+
+- Add a new advanced module or broad scenario combining Kafka event replay, Redis locks, cluster writes, and Redisson near-cache coordination.
+
+Pros:
+
+- Broadest possible interpretation of #81.
+
+Cons:
+
+- Too much churn for an issue that already has most examples in place.
+- Higher risk of generic hand-rolled code.
+- Would need CI/nightly/module registration checks and larger review scope.
+
+## Selected Approach
+
+Select Option B.
+
+Option A is rejected because it would not meet the user's explicit "actively use" requirement. Option C is rejected because current evidence supports focused adoption inside existing examples.
+
+## Required Behavior Changes
+
+### Kafka
+
+- Add `implementation(libs.bluetape4k.kafka4)` to `messaging/kafka`.
+- Replace raw fire-and-forget `kafkaTemplate.send(...)` calls in `GreetingController` with `kafkaTemplate.suspendSend(...)`.
+- Use the exact import and receiver confirmed by the pre-implementation gate.
+- Verify controller tests or compile tests prove the BT-backed path.
+- Add `implementation(libs.bluetape4k.kafka4)` to `messaging/kafka-reply`.
+- Keep request/reply on `ReplyingKafkaTemplate.sendAndReceive(...)`; if no BT request/reply extension exists, document this as an intentional boundary rather than inventing a wrapper.
+- Add a `Bluetape4k boundary` section to `messaging/kafka-reply/README.md` explaining that request/reply remains on Spring Kafka's `ReplyingKafkaTemplate` because no verified `bluetape4k-kafka4` request/reply abstraction exists in the resolved artifact.
+
+### Lettuce
+
+- Add `implementation(libs.bluetape4k.lettuce)` to `redis/cluster-demo`.
+- Add a focused executable test path using `LettuceClients` plus a BT codec or coroutine future helper. The intended test shape is a new cluster-demo test that uses the Testcontainers Redis endpoint, `LettuceClients`, `LettuceLongCodec` or `RedisFuture.awaitSuspending()`, and verifies a write/read round trip.
+- Do not replace Spring Data Redis cluster behavior with a non-cluster-aware helper unless source evidence proves the BT helper supports Redis Cluster.
+- Document the boundary: `RedisClusterServer.Launcher.LettuceLib` configures Testcontainers cluster client resources; `bluetape4k-lettuce` provides typed codecs, client helpers, and coroutine future support for low-level Redis operations.
+
+### Redisson
+
+- Add `implementation(libs.bluetape4k.redisson)` to `redis/redisson-examples`.
+- Prefer BT Redisson helpers in examples where straightforward:
+  - `redissonClient {}` or `redissonClientForHighConcurrency(...)` for client construction.
+  - `RedissonCodecs.*` for codec selection.
+  - `localCachedMap(...)` or `mapCache(...)` for options-heavy cache examples.
+  - `streamAddArgsOf(...)` for stream append examples.
+  - coroutine `RFuture` helpers where collections of futures are awaited.
+- Keep raw Redisson API where the example specifically teaches a raw Redisson object and no BT helper is appropriate; document the boundary.
+
+### Distributed Lock Cleanup
+
+- Replace `kotlin.test.assertFailsWith` with the approved Bluetape4k assertion import in all currently affected distributed-lock tests:
+  - `redis/distributed-lock/src/test/kotlin/io/bluetape4k/workshop/lock/DistributedLockTest.kt`
+  - `redis/distributed-lock/src/test/kotlin/io/bluetape4k/workshop/lock/FencedStaleHolderTest.kt`
+  - `redis/distributed-lock/src/test/kotlin/io/bluetape4k/workshop/lock/LockFailureTest.kt`
+- Correct `SuspendedJobTester` comments and README semantics:
+  - `workers(N).rounds(R).add { ... }` means `R * blockCount` total executions; `workers` controls concurrency only.
+  - `workers(20).rounds(20).add { ... }` means 20 attempts for one registered block, not 400.
+  - Keep `workers(20).rounds(20)` as a 20-attempt concurrent stress proof. The expected successful deductions remain 10 because stock is 100 and qty is 10; the remaining attempts must fail without over-sell.
+  - In `README.md`, replace `SuspendedJobTester.workers(N).rounds(R) launches N workers each running R rounds` with wording that `rounds(R)` controls total executions per registered block and `workers(N)` controls concurrency.
+  - In `README.md`, replace `fixed workers x rounds = total attempts` with `fixed rounds x blockCount = total attempts`, and change the Before/After example from `.rounds(1) // ... 20 total attempts` to `.rounds(20) // 20 total attempts, exactly 10 succeed`.
+  - Apply the same Korean wording correction in `README.ko.md`: `rounds(R)`는 등록된 `add { }` 블록당 총 실행 횟수이고 `workers(N)`는 동시성만 제어한다고 설명한다.
+  - In both README files, keep the summary example as `workers(20).rounds(20) -> 20 total attempts -> exactly 10 succeed`.
+- Bring `README.ko.md` into parity with the English README's BT feature coverage and dependencies.
+
+## Risks and Failure Modes
+
+1. **BT API compatibility risk**: `bluetape4k-kafka4`, `bluetape4k-lettuce`, or `bluetape4k-redisson` APIs may differ between sibling source and the version resolved by this workshop.
+   - Mitigation: compile affected modules before claiming implementation. Use source evidence only as design input, not proof.
+
+2. **Cluster boundary risk**: `bluetape4k-lettuce` helpers may be single-node utilities while the issue asks for Redis cluster behavior.
+   - Mitigation: keep existing Spring Data Redis cluster tests and use BT Lettuce for a clearly scoped low-level path unless a cluster-aware BT API is verified.
+
+3. **Kafka request/reply overreach**: There may be no BT request/reply abstraction over `ReplyingKafkaTemplate`.
+   - Mitigation: keep Spring Kafka request/reply as the protocol primitive, use BT helpers where they exist, and document the unsupported BT gap explicitly.
+
+4. **Serialization security risk**: Kafka/Redis codec examples can accidentally imply unsafe polymorphic deserialization.
+   - Mitigation: prefer type-specific codec examples and document codec boundaries. Do not add open polymorphic deserialization or type-header deserialization without an explicit allow-list.
+
+5. **Testcontainers flakiness**: Kafka/Redis tests need Docker and must not run concurrently.
+   - Mitigation: run targeted Testcontainers-backed Gradle commands serially.
+
+6. **Generated local index contamination**: `.codegraph/` may appear in `git status`.
+   - Mitigation: exclude `.codegraph/` from commits and verify staged files before commit.
+
+## Acceptance Criteria Mapping
+
+| Issue criterion | Current evidence | Planned closure |
+|---|---|---|
+| Request/reply | `PingController`, `PongHandler`, Kafka reply README and diagram | Keep Spring Kafka request/reply; add BT dependency and document BT boundary |
+| Retry or replay behavior | Redisson stale-token rejection and read/write-through examples | Keep and strengthen Redisson docs/tests; do not fake retry if unsupported |
+| Distributed lock correctness | `DistributedLockTest`, `FencedLockTest`, `SuspendFencedLockTest` | Fix assertion style and `SuspendedJobTester` semantics; rerun tests |
+| Redis cluster behavior | `RedisClusterApplication`, `NumberServiceTest`, cluster README | Keep cluster proof; add scoped BT Lettuce usage |
+| Failure-path tests | Lock acquisition failure, stale token rejection, cancellation unlock, insufficient stock | Preserve and verify |
+| Sequence diagrams | Existing Kafka reply, Kafka, Redis cluster, distributed lock, Redisson diagram assets | Update docs only if new flow changes require it |
+| Testcontainers/local prerequisites | Existing READMEs document Docker/Testcontainers | Keep and update where BT module usage changes commands |
+| Used Bluetape4k features table | Present but incomplete or drifted in places | Add `bluetape4k-kafka4`, `bluetape4k-lettuce`, `bluetape4k-redisson` rows with real code references |
+| BT-backed smoke/tests | Redis lock/cluster tests and Kafka controller paths | Ensure tests or compile checks exercise BT-backed code |
+
+## Definition of Done
+
+- Spec and plan exist under `docs/superpowers/`.
+- Step 2-R and Step 3-R pass with Claude Code CLI artifacts and P0/P1 = 0.
+- `messaging/kafka` uses `bluetape4k-kafka4` APIs in the send path.
+- `messaging/kafka-reply` declares and documents `bluetape4k-kafka4` usage/boundary without replacing true request/reply incorrectly.
+- `redis/cluster-demo` declares and exercises `bluetape4k-lettuce` in a scoped low-level Redis path while preserving Redis Cluster tests.
+- `redis/redisson-examples` declares and foregrounds `bluetape4k-redisson` helpers.
+- Any narrower `redis-redisson-examples` test slice must execute the added or changed BT-backed code path; compile-only proof is insufficient for active usage.
+- `redis/distributed-lock` comments and README pairs correctly describe `SuspendedJobTester` semantics.
+- `redis/distributed-lock/README.ko.md` is brought into parity with the English README where touched.
+- `kotlin.test.assertFailsWith` is removed from touched tests.
+- Targeted verification passes serially:
+  - `./gradlew :messaging-kafka:compileKotlin :messaging-kafka:compileTestKotlin`
+  - `./gradlew :messaging-kafka-reply:compileKotlin :messaging-kafka-reply:compileTestKotlin`
+  - `./gradlew :redis-cluster-demo:test`
+  - `./gradlew :redis-distributed-lock:test`
+  - `./gradlew :redis-redisson-examples:test` or a narrower test slice if full module runtime is too broad, with the gap recorded
+- `git diff --check` passes.
+- Step 6-R code review gate passes with P0/P1 = 0.
+- Lesson file is written and committed before PR creation.
+- PR references `Fixes #81`, includes DoD evidence, and is assigned to `debop`.
+- CI passes before any merge request.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -210,6 +210,7 @@ bluetape4k-r2dbc = { module = "io.github.bluetape4k:bluetape4k-r2dbc" }
 bluetape4k-bucket4j = { module = "io.github.bluetape4k:bluetape4k-bucket4j" }
 bluetape4k-cache-core = { module = "io.github.bluetape4k:bluetape4k-cache-core" }
 bluetape4k-kafka = { module = "io.github.bluetape4k:bluetape4k-kafka" }
+bluetape4k-kafka4 = { module = "io.github.bluetape4k:bluetape4k-kafka4" }
 bluetape4k-lettuce = { module = "io.github.bluetape4k:bluetape4k-lettuce" }
 bluetape4k-leader-core = { module = "io.github.bluetape4k.leader:bluetape4k-leader-core" }
 bluetape4k-leader-redis-lettuce = { module = "io.github.bluetape4k.leader:bluetape4k-leader-redis-lettuce" }

--- a/messaging/kafka-reply/README.md
+++ b/messaging/kafka-reply/README.md
@@ -2,6 +2,7 @@
 
 `ReplyingKafkaTemplate`을 이용한 Kafka 요청-응답(Request-Reply) 패턴 예제입니다.
 bluetape4k의 `CompletableFuture.onSuccess/onFailure`, `uninitialized()`, `KLoggingChannel`을 활용합니다.
+Spring Kafka 4 호환 Bluetape4k 모듈은 `bluetape4k-kafka4`를 사용합니다.
 
 ## 아키텍처
 
@@ -21,8 +22,14 @@ bluetape4k의 `CompletableFuture.onSuccess/onFailure`, `uninitialized()`, `KLogg
 | 기능 | 아티팩트 | 코드 위치 | 이점 |
 |---|---|---|---|
 | `CompletableFuture.onSuccess/onFailure` | `bluetape4k-coroutines` | `PingController.ping()` | Java Future에 Kotlin 스타일 콜백 확장 |
+| `bluetape4k-kafka4` dependency | `bluetape4k-kafka4` | `build.gradle.kts` | Spring Kafka 4 예제에서 Bluetape4k Kafka 확장을 사용할 수 있는 호환 아티팩트 |
 | `uninitialized()` | `bluetape4k-core` | `PingController` | 타입 안전 lateinit 초기화 대체 |
 | `KLoggingChannel` | `bluetape4k-logging` | companion object | 코루틴 컨텍스트 포함 구조적 로깅 |
+
+## Bluetape4k boundary
+
+`messaging/kafka-reply`는 실제 요청-응답 프로토콜을 Spring Kafka의 `ReplyingKafkaTemplate.sendAndReceive()`로 유지합니다.
+현재 검증된 `bluetape4k-kafka4` API에는 `ReplyingKafkaTemplate`을 대체하는 request/reply 전용 추상화가 없으므로, 이 예제는 Spring Kafka의 프로토콜 primitive와 Bluetape4k의 Future/coroutine ergonomics를 함께 사용합니다.
 
 ## bluetape4k Before / After
 

--- a/messaging/kafka-reply/build.gradle.kts
+++ b/messaging/kafka-reply/build.gradle.kts
@@ -21,7 +21,7 @@ dependencies {
     implementation(libs.spring.kafka.test)
     implementation(libs.spring.data.commons)
 
-    // implementation(libs.bluetape4k.kafka)
+    implementation(libs.bluetape4k.kafka4)
     implementation(libs.bluetape4k.testcontainers)
     implementation(libs.testcontainers.kafka)
 

--- a/messaging/kafka/README.md
+++ b/messaging/kafka/README.md
@@ -1,7 +1,7 @@
 # Kafka Demo
 
 Spring Kafka를 사용하는 기본 메시지 발행·소비 예제입니다.
-bluetape4k의 `KafkaServer.Launcher`로 Testcontainers Kafka를 자동 구동하고, `KLoggingChannel`과 `uninitialized()`를 활용합니다.
+bluetape4k의 `KafkaServer.Launcher`로 Testcontainers Kafka를 자동 구동하고, `bluetape4k-kafka4`의 `suspendSend()`로 Spring Kafka 4 발행 경로를 코루틴 친화적으로 처리합니다.
 
 ## 아키텍처
 
@@ -13,7 +13,7 @@ bluetape4k의 `KafkaServer.Launcher`로 Testcontainers Kafka를 자동 구동하
 |---|---|
 | `KafkaApplication` | `KafkaServer.Launcher.kafka`로 Testcontainers Kafka 자동 구동 |
 | `KafkaConfig` | `KafkaTemplate` 빈 구성 |
-| `GreetingController` | `suspend` 엔드포인트 — `KafkaTemplate`으로 메시지 발행 |
+| `GreetingController` | `suspend` 엔드포인트 — `KafkaTemplate.suspendSend()`로 메시지 발행 |
 | `SimpleMessageHandler` | `TOPIC_SIMPLE` 문자열 메시지 소비 |
 | `GreetingMessageHandler` | `TOPIC_GREETING` JSON 객체 메시지 소비 |
 | `LoggerMessageHandler` | 모든 토픽 로깅 |
@@ -23,6 +23,7 @@ bluetape4k의 `KafkaServer.Launcher`로 Testcontainers Kafka를 자동 구동하
 | 기능 | 아티팩트 | 코드 위치 | 이점 |
 |---|---|---|---|
 | `KafkaServer.Launcher.kafka` | `bluetape4k-testcontainers` | `KafkaApplication` companion | Testcontainers Kafka 싱글톤 — `application.yml` 없이 자동 구동 |
+| `KafkaOperations.suspendSend()` | `bluetape4k-kafka4` | `GreetingController` | Spring Kafka 4 `KafkaTemplate` 발행 결과를 suspend 함수 안에서 코루틴 방식으로 대기 |
 | `KLoggingChannel` | `bluetape4k-logging` | 모든 companion object | 코루틴 컨텍스트 포함 구조적 로깅 |
 | `uninitialized()` | `bluetape4k-core` | `GreetingController` | 타입 안전 lateinit 초기화 대체 |
 
@@ -71,10 +72,10 @@ log.debug { "Received message: $message" }
 
 ```kotlin
 // 문자열 메시지 발행
-kafkaTemplate.send(KafkaTopics.TOPIC_SIMPLE, "Hello Kafka")
+kafkaTemplate.suspendSend(KafkaTopics.TOPIC_SIMPLE, "Hello Kafka")
 
 // JSON 객체 메시지 발행
-kafkaTemplate.send(KafkaTopics.TOPIC_GREETING, GreetingRequest("Alice", "안녕하세요"))
+kafkaTemplate.suspendSend(KafkaTopics.TOPIC_GREETING, GreetingRequest("Alice", "안녕하세요"))
 ```
 
 ## @KafkaListener — 코루틴 제약
@@ -114,3 +115,4 @@ fun handleWithMono(message: String): Mono<Void> = mono {
 - [Spring Kafka 공식 문서](https://docs.spring.io/spring-kafka/reference/)
 - [Apache Kafka](https://kafka.apache.org/documentation/)
 - [bluetape4k-testcontainers](https://github.com/bluetape4k/bluetape4k-projects)
+- [bluetape4k-kafka4](https://github.com/bluetape4k/bluetape4k-projects)

--- a/messaging/kafka/build.gradle.kts
+++ b/messaging/kafka/build.gradle.kts
@@ -17,7 +17,7 @@ dependencies {
     implementation(platform(libs.spring.boot4.dependencies))
     
     // Kafka
-    // implementation(libs.bluetape4k.kafka)
+    implementation(libs.bluetape4k.kafka4)
     implementation(libs.kafka.clients)
     implementation(libs.spring.kafka.lib)
     testImplementation(libs.spring.kafka.test)

--- a/messaging/kafka/src/main/kotlin/io/bluetape4k/workshop/messaging/kafka/controller/GreetingController.kt
+++ b/messaging/kafka/src/main/kotlin/io/bluetape4k/workshop/messaging/kafka/controller/GreetingController.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.workshop.messaging.kafka.controller
 
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
+import io.bluetape4k.kafka.spring.suspendSend
 import io.bluetape4k.support.uninitialized
 import io.bluetape4k.workshop.messaging.kafka.KafkaTopics
 import io.bluetape4k.workshop.messaging.kafka.listener.LoggerMessageHandler
@@ -35,7 +36,7 @@ class GreetingController {
     suspend fun sendGreetingMessage(
         @RequestParam(name = "message", defaultValue = "Hello world") message: String,
     ): String {
-        kafkaTemplate.send(KafkaTopics.TOPIC_SIMPLE, message)
+        kafkaTemplate.suspendSend(KafkaTopics.TOPIC_SIMPLE, message)
         return message
     }
 
@@ -43,6 +44,6 @@ class GreetingController {
     @ResponseStatus(HttpStatus.ACCEPTED)
     suspend fun sendGreetingRequest(@RequestBody greeting: GreetingRequest) {
         log.debug { "Send greeting: $greeting" }
-        kafkaTemplate.send(KafkaTopics.TOPIC_GREETING, greeting)
+        kafkaTemplate.suspendSend(KafkaTopics.TOPIC_GREETING, greeting)
     }
 }

--- a/redis/cluster-demo/README.md
+++ b/redis/cluster-demo/README.md
@@ -76,6 +76,7 @@ spring:
 |---|---|---|---|
 | `RedisClusterServer.Launcher.redisCluster` | `bluetape4k-testcontainers` | `RedisClusterApplication` companion | Testcontainers Redis Cluster 싱글톤 — 6노드(3마스터+3슬레이브) 자동 구동·종료 |
 | `Launcher.LettuceLib.clientResources(redisCluster)` | `bluetape4k-testcontainers` | `RedisClusterApplication.lettuceClientResource()` | 컨테이너 포트에 맞춘 Lettuce `ClientResources` 원스텝 생성 |
+| `LettuceClients` / `LettuceLongCodec` / `awaitSuspending()` | `bluetape4k-lettuce` | `Bluetape4kLettuceUsageTest` | 저수준 Redis 경로에서 타입 codec과 coroutine-friendly async 대기를 검증 |
 | `KLoggingChannel` | `bluetape4k-logging` | `RedisClusterApplication` companion, `NumberService` companion, `AbstractRedisClusterTest` companion | 코루틴 MDC 컨텍스트 포함 구조적 로깅 |
 | `Fakers.faker` / `Fakers.fixedString` | `bluetape4k-junit5` | `AbstractRedisClusterTest` | 재현 가능한 랜덤 키·값 생성 |
 | `bluetape4k-core` — `toByteArray()` / `toInt()` | `bluetape4k-core` | `NumberService` | Int ↔ ByteArray 변환 유틸리티 — 바이너리 클러스터 커맨드에서 활용 |
@@ -148,6 +149,11 @@ fun multiplyAndSave(number: Int) {
     }
 }
 ```
+
+## Lettuce boundary
+
+Redis Cluster 동작 증명은 Spring Data Redis `clusterConnection` 경로가 담당합니다.
+`bluetape4k-lettuce`는 별도 저수준 테스트에서 `LettuceClients`, `LettuceLongCodec`, `awaitSuspending()`을 사용해 typed codec과 coroutine-friendly async bridge를 검증합니다.
 
 ## 클러스터 슬롯 분배
 

--- a/redis/cluster-demo/build.gradle.kts
+++ b/redis/cluster-demo/build.gradle.kts
@@ -19,6 +19,7 @@ dependencies {
     implementation(libs.bluetape4k.core)
     implementation(libs.bluetape4k.jackson3)
     implementation(libs.bluetape4k.idgenerators)
+    implementation(libs.bluetape4k.lettuce)
     testImplementation(libs.bluetape4k.junit5)
     implementation(libs.bluetape4k.testcontainers)
 

--- a/redis/cluster-demo/src/test/kotlin/io/bluetape4k/workshop/redis/cluster/basic/Bluetape4kLettuceUsageTest.kt
+++ b/redis/cluster-demo/src/test/kotlin/io/bluetape4k/workshop/redis/cluster/basic/Bluetape4kLettuceUsageTest.kt
@@ -1,0 +1,29 @@
+package io.bluetape4k.workshop.redis.cluster.basic
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.redis.lettuce.LettuceClients
+import io.bluetape4k.redis.lettuce.awaitSuspending
+import io.bluetape4k.redis.lettuce.codec.LettuceLongCodec
+import io.bluetape4k.testcontainers.storage.RedisServer
+import io.bluetape4k.workshop.redis.cluster.AbstractRedisClusterTest
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+class Bluetape4kLettuceUsageTest: AbstractRedisClusterTest() {
+
+    @Test
+    fun `bluetape4k lettuce client supports typed async round trip`() = runTest {
+        val redis = RedisServer.Launcher.redis
+        val client = LettuceClients.clientOf(redis.url)
+
+        try {
+            val commands = LettuceClients.asyncCommands(client, LettuceLongCodec)
+            val key = "lettuce:${randomKey()}"
+
+            commands.set(key, 42L).awaitSuspending() shouldBeEqualTo "OK"
+            commands.get(key).awaitSuspending() shouldBeEqualTo 42L
+        } finally {
+            LettuceClients.shutdown(client)
+        }
+    }
+}

--- a/redis/distributed-lock/README.ko.md
+++ b/redis/distributed-lock/README.ko.md
@@ -157,7 +157,7 @@ try {
 
 ### SuspendedJobTester 의미론
 
-`SuspendedJobTester.workers(N).rounds(R)`는 `N`개의 워커가 각각 `R`라운드의 `add { }` 블록을 실행합니다.
+`SuspendedJobTester.workers(N).rounds(R)`는 `N`개의 동시 워커가 협력하여 각 `add { }` 블록을 `R`라운드 실행합니다.
 `totalUnits = R × blockCount`.
 
 stock=100/qty=10 테스트의 경우:
@@ -175,7 +175,20 @@ stock=100/qty=10 테스트의 경우:
 ## 의존성
 
 - **Redisson** — `RLock`, `RFencedLock`, 비동기 API
-- **bluetape4k-redisson** — `getLockId()` (Snowflake ID), `redissonClient {}` DSL
+- **bluetape4k-redisson** — `redissonClient {}` DSL
+- **bluetape4k-redis** — `getLockId()` (Snowflake ID)
 - **bluetape4k-coroutines** — `awaitSuspending()`, `io.bluetape4k.logging.coroutines`
 - **bluetape4k-testcontainers** — `RedisServer.Launcher.redis` Testcontainers 싱글턴
+- **bluetape4k-junit5** — `SuspendedJobTester`, `MultithreadingTester`
 - **kotlinx.atomicfu** — `atomic(0L)` for `FencedResource.lastSeenToken`
+
+## 사용된 bluetape4k 기능
+
+| 기능 | 아티팩트 | 코드 위치 | 이점 |
+|---|---|---|---|
+| `RedisServer.Launcher.redis` | `bluetape4k-testcontainers` | `AbstractDistributedLockTest` companion | Testcontainers Redis 싱글턴으로 `@DynamicPropertySource` 없이 테스트 Redis 구동 |
+| `redissonClient {}` DSL | `bluetape4k-redisson` | `AbstractDistributedLockTest.redisson` | `RedissonClient` 설정을 Kotlin DSL로 구성 |
+| `getLockId(lockName)` | `bluetape4k-redis` | `SuspendingFencedInventoryService.deduct()` | 코루틴 안전 RFencedLock identity 생성 |
+| `requirePositiveNumber` | `bluetape4k-core` | `SuspendingFencedInventoryService.deduct()` | 입력 검증 실패를 명확한 `IllegalArgumentException`으로 표현 |
+| `SuspendedJobTester` | `bluetape4k-junit5` | `SuspendFencedLockTest` | 재현 가능한 코루틴 경쟁 조건 검증 |
+| `MultithreadingTester` | `bluetape4k-junit5` | `DistributedLockTest` | OS thread 기반 분산 락 동시성 검증 |

--- a/redis/distributed-lock/README.md
+++ b/redis/distributed-lock/README.md
@@ -160,8 +160,8 @@ Client A resumes → FencedResource rejects write (1 < 2) ✅
 
 ### SuspendedJobTester Semantics
 
-`SuspendedJobTester.workers(N).rounds(R)` launches `N` workers each running `R` rounds
-of the `add { }` block. `totalUnits = R × blockCount`.
+`SuspendedJobTester.workers(N).rounds(R)` spawns `N` concurrent workers that
+cooperatively execute `R` rounds of each `add { }` block. `totalUnits = R × blockCount`.
 
 For a stock-100/qty-10 test:
 - `workers(20).rounds(20)` → 20 total attempts → exactly 10 succeed
@@ -259,10 +259,10 @@ val results = (1..20).map {
     async { suspendingService.deduct(inventoryId, qty = 10) }
 }.awaitAll()
 
-// After — bluetape4k SuspendedJobTester (fixed workers × rounds = total attempts)
+// After — bluetape4k SuspendedJobTester (fixed rounds × blockCount = total attempts)
 SuspendedJobTester()
     .workers(20)    // 20 coroutine workers
-    .rounds(1)      // 1 round each → 20 total attempts, exactly 10 succeed (stock=100, qty=10)
+    .rounds(20)     // 20 total attempts, exactly 10 succeed (stock=100, qty=10)
     .add {
         suspendingService.deduct(inventoryId, qty = 10, waitMs = 3000L, leaseMs = 5000L)
     }
@@ -274,8 +274,9 @@ SuspendedJobTester()
 ## Dependencies
 
 - **Redisson** — `RLock`, `RFencedLock`, async API
-- **bluetape4k-redisson** — `getLockId()` (Snowflake ID), `redissonClient {}` DSL
+- **bluetape4k-redisson** — `redissonClient {}` DSL
 - **bluetape4k-redis** — `getLockId()` coroutines extension (`io.bluetape4k.redis.redisson.coroutines`)
 - **bluetape4k-coroutines** — `awaitSuspending()`, `io.bluetape4k.logging.coroutines`
 - **bluetape4k-testcontainers** — `RedisServer.Launcher.redis` Testcontainers singleton
+- **bluetape4k-junit5** — `SuspendedJobTester`, `MultithreadingTester`
 - **kotlinx.atomicfu** — `atomic(0L)` for `FencedResource.lastSeenToken`

--- a/redis/distributed-lock/src/test/kotlin/io/bluetape4k/workshop/lock/DistributedLockTest.kt
+++ b/redis/distributed-lock/src/test/kotlin/io/bluetape4k/workshop/lock/DistributedLockTest.kt
@@ -1,5 +1,6 @@
 package io.bluetape4k.workshop.lock
 
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeInstanceOf
 import io.bluetape4k.assertions.shouldBeLessThan
@@ -13,7 +14,6 @@ import org.junit.jupiter.api.RepeatedTest
 import org.junit.jupiter.api.Test
 import java.util.concurrent.TimeUnit.MILLISECONDS
 import java.util.concurrent.atomic.AtomicInteger
-import kotlin.test.assertFailsWith
 
 /**
  * Verifies that [io.bluetape4k.workshop.lock.service.LockedInventoryService]

--- a/redis/distributed-lock/src/test/kotlin/io/bluetape4k/workshop/lock/FencedStaleHolderTest.kt
+++ b/redis/distributed-lock/src/test/kotlin/io/bluetape4k/workshop/lock/FencedStaleHolderTest.kt
@@ -1,5 +1,6 @@
 package io.bluetape4k.workshop.lock
 
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeGreaterThan
 import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.assertions.shouldNotBeNull
@@ -7,7 +8,6 @@ import io.bluetape4k.workshop.lock.fenced.FencedResource
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import java.util.concurrent.TimeUnit.MILLISECONDS
-import kotlin.test.assertFailsWith
 
 /**
  * Smoke test — full stale-holder scenario demonstrating fencing token protection.

--- a/redis/distributed-lock/src/test/kotlin/io/bluetape4k/workshop/lock/LockFailureTest.kt
+++ b/redis/distributed-lock/src/test/kotlin/io/bluetape4k/workshop/lock/LockFailureTest.kt
@@ -1,10 +1,10 @@
 package io.bluetape4k.workshop.lock
 
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeTrue
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import java.util.concurrent.TimeUnit.MILLISECONDS
-import kotlin.test.assertFailsWith
 
 /**
  * Smoke tests for lock failure scenarios.

--- a/redis/redisson-examples/README.md
+++ b/redis/redisson-examples/README.md
@@ -1,7 +1,7 @@
 # Redisson Examples
 
 Redis 클라이언트 라이브러리 [Redisson](https://redisson.org/)의 분산 동기화 객체를 활용하는 예제 모음입니다.
-bluetape4k의 `RedissonCodecs.LZ4ForyComposite`, `VirtualThreadExecutor`, `RedisServer.Launcher`, 테스트 동시성 헬퍼를 활용합니다.
+bluetape4k의 `RedissonCodecs.LZ4ForyComposite`, `localCachedMap()`, `streamAddArgsOf()`, `VirtualThreadExecutor`, `RedisServer.Launcher`, 테스트 동시성 헬퍼를 활용합니다.
 Testcontainers로 Redis 컨테이너를 자동으로 구동하여 통합 테스트를 수행합니다.
 
 ## 아키텍처
@@ -67,7 +67,9 @@ Testcontainers로 Redis 컨테이너를 자동으로 구동하여 통합 테스�
 
 | 기능 | 아티팩트 | 코드 위치 | 이점 |
 |---|---|---|---|
-| `RedissonCodecs.LZ4ForyComposite` | `bluetape4k-redis` | `AbstractRedissonTest` | LZ4 압축 + Fory 직렬화 — JSON 대비 공간·속도 우위 |
+| `RedissonCodecs.LZ4ForyComposite` | `bluetape4k-redisson` | `AbstractRedissonTest` | LZ4 압축 + Fory 직렬화 — JSON 대비 공간·속도 우위 |
+| `localCachedMap()` | `bluetape4k-redisson` | `LocalCachedMapExamples` | `LocalCachedMapOptions` DSL과 map 생성 호출을 한 곳에 묶어 Near Cache 설정 중복 축소 |
+| `streamAddArgsOf()` | `bluetape4k-redisson` | `StreamExamples` | Redis Stream append 인자를 Kotlin-friendly helper로 생성 |
 | `VirtualThreadExecutor` | `bluetape4k-coroutines` | `AbstractRedissonTest` | Redisson I/O를 Virtual Thread로 처리 |
 | `RedisServer.Launcher.redis` | `bluetape4k-testcontainers` | `AbstractRedissonTest` | Testcontainers Redis 싱글톤 — 자동 구동·종료 |
 | `ShutdownQueue.register` | `bluetape4k-core` | `AbstractRedissonTest` | JVM 종료 시 RedissonClient 자동 close |
@@ -156,4 +158,5 @@ SuspendedJobTester()
 - [Redisson 공식 문서](https://redisson.org/docs/)
 - [Redisson GitHub](https://github.com/redisson/redisson)
 - [bluetape4k-redis](https://github.com/bluetape4k/bluetape4k-projects)
+- [bluetape4k-redisson](https://github.com/bluetape4k/bluetape4k-projects)
 - Spring Data Redis 기반 예제는 [`spring-data/redis-examples`](../../spring-data/redis-examples) 참고

--- a/redis/redisson-examples/build.gradle.kts
+++ b/redis/redisson-examples/build.gradle.kts
@@ -12,6 +12,7 @@ dependencies {
 
     // Redis
     implementation(libs.bluetape4k.redis)
+    implementation(libs.bluetape4k.redisson)
     testImplementation(libs.bluetape4k.testcontainers)
 
     // Redisson

--- a/redis/redisson-examples/src/test/kotlin/io/bluetape4k/workshop/redisson/collections/LocalCachedMapExamples.kt
+++ b/redis/redisson-examples/src/test/kotlin/io/bluetape4k/workshop/redisson/collections/LocalCachedMapExamples.kt
@@ -1,6 +1,7 @@
 package io.bluetape4k.workshop.redisson.collections
 
 import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.redis.redisson.cache.localCachedMap
 import io.bluetape4k.workshop.redisson.AbstractRedissonTest
 import kotlinx.coroutines.future.await
 import kotlinx.coroutines.test.runTest
@@ -30,12 +31,12 @@ class LocalCachedMapExamples: AbstractRedissonTest() {
     fun `simple local cached map`() = runTest {
         // Local cache 설정
         val cachedMapName = "local:" + UUID.randomUUID().toString()
-        val options = LocalCachedMapOptions.name<String, Int>(cachedMapName)
-            .cacheSize(10000)
-            .evictionPolicy(LocalCachedMapOptions.EvictionPolicy.LRU)
-            .maxIdle(10.seconds.toJavaDuration())
-            .timeToLive(60.seconds.toJavaDuration())
-        val cachedMap: RLocalCachedMap<String, Int> = redisson.getLocalCachedMap(options)
+        val cachedMap: RLocalCachedMap<String, Int> = localCachedMap(cachedMapName, redisson) {
+            cacheSize(10000)
+            evictionPolicy(LocalCachedMapOptions.EvictionPolicy.LRU)
+            maxIdle(10.seconds.toJavaDuration())
+            timeToLive(60.seconds.toJavaDuration())
+        }
 
         // NOTE: fastPutAsync 의 결과는 new insert 인 경우는 true, update 는 false 를 반환한다.
         cachedMap.fastPutAsync("a", 1).await().shouldBeTrue()


### PR DESCRIPTION
## Summary

Fixes #81.

This PR makes the advanced messaging/Redis workshop examples actively use the requested Bluetape4k modules:

- Adds Spring Kafka 4-compatible `bluetape4k-kafka4` and uses `KafkaOperations.suspendSend()` in `messaging/kafka`.
- Adds `bluetape4k-kafka4` to `messaging/kafka-reply` while preserving the Spring Kafka `ReplyingKafkaTemplate` request/reply boundary.
- Adds `bluetape4k-lettuce` to `redis/cluster-demo` and an executable `Bluetape4kLettuceUsageTest` using `LettuceClients`, `LettuceLongCodec`, and `awaitSuspending()`.
- Adds explicit `bluetape4k-redisson` usage in `redis/redisson-examples` through `localCachedMap()` and documented `streamAddArgsOf()` usage.
- Replaces `kotlin.test.assertFailsWith` in distributed-lock tests and fixes `SuspendedJobTester` semantics in `README.md` / `README.ko.md`.

## Design Gates

- Step 2-R spec review: `P0=0 P1=0`
  - `.omx/artifacts/claude-step-2r-issue-81-spec-5min-final-20260526090610.md`
- Step 3-R plan review: `P0=0 P1=0`
  - `.omx/artifacts/claude-step-3r-issue-81-plan-5min-final-20260526091541.md`
- Step 6-R code review: `P0=0 P1=0`
  - `.omx/artifacts/claude-step-6r-issue-81-code-review-5min-20260526092744.md`

## Verification

- [x] `./gradlew :messaging-kafka:compileKotlin :messaging-kafka:compileTestKotlin`
- [x] `./gradlew :messaging-kafka-reply:compileKotlin :messaging-kafka-reply:compileTestKotlin`
- [x] `./gradlew :redis-cluster-demo:test`
- [x] `./gradlew :redis-distributed-lock:test`
- [x] `./gradlew :redis-redisson-examples:test`
- [x] `git diff --check`

Notes:

- `:redis-redisson-examples:test` passed with 133 passing and 1 pending. It emitted a shutdown-time Netty `RejectedExecutionException` after tests completed; Gradle result was successful.
- `messaging/kafka` has compile coverage for `suspendSend()` because existing runtime Kafka tests are disabled for Spring Boot 4 embedded Kafka.
- `.codegraph/` is local generated index state and is intentionally not committed.
