### PR TITLE
Adopt Exposed Gradle plugin in workshop modules

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,6 +26,7 @@ plugins {
     alias(libs.plugins.shadow) apply false
 
     alias(libs.plugins.graalvm.native) apply false
+    alias(libs.plugins.exposed) apply false
 
     // for JMolecules
     id("net.bytebuddy.byte-buddy-gradle-plugin") version "1.18.8" apply false

--- a/docs/lessons/2026-05-26-exposed-gradle-plugin.md
+++ b/docs/lessons/2026-05-26-exposed-gradle-plugin.md
@@ -1,0 +1,19 @@
+## Context
+
+Adopted the JetBrains Exposed Gradle plugin for workshop modules that define Exposed tables in main sources.
+
+## Decision
+
+Workshop repositories stay independent from the managed `bt4k` catalog. They use their repo-local Exposed version alias for the Gradle plugin and continue to consume `bluetape4k-dependencies` as a BOM.
+
+## Outcome
+
+Main Exposed workshop modules now expose `generateMigrations` with module-local table package and H2 migration database settings.
+
+## Verification
+
+Ran `git diff --check`, `./gradlew -q help`, and `:exposed-mvc-jdbc:tasks --all`.
+
+## Future Guard
+
+Do not add `bluetape4kDependenciesCatalogRef` to workshop repositories unless they are intentionally promoted to managed library repos.

--- a/exposed/javers-audit/build.gradle.kts
+++ b/exposed/javers-audit/build.gradle.kts
@@ -1,5 +1,15 @@
 plugins {
     alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.exposed)
+}
+
+exposed {
+    migrations {
+        tablesPackage = "io.bluetape4k.workshop.exposed.javers"
+        databaseUrl = "jdbc:h2:mem:workshop-exposed-javers-audit-migrations;DB_CLOSE_DELAY=-1;MODE=PostgreSQL"
+        databaseUser = "sa"
+        databasePassword = ""
+    }
 }
 
 dependencies {

--- a/exposed/mvc-jdbc/build.gradle.kts
+++ b/exposed/mvc-jdbc/build.gradle.kts
@@ -1,6 +1,16 @@
 plugins {
     alias(libs.plugins.kotlin.spring)
     alias(libs.plugins.spring.boot)
+    alias(libs.plugins.exposed)
+}
+
+exposed {
+    migrations {
+        tablesPackage = "io.bluetape4k.workshop.exposed.mvc.jdbc"
+        databaseUrl = "jdbc:h2:mem:workshop-exposed-mvc-jdbc-migrations;DB_CLOSE_DELAY=-1;MODE=PostgreSQL"
+        databaseUser = "sa"
+        databasePassword = ""
+    }
 }
 
 springBoot {

--- a/exposed/mvc-virtualthread/build.gradle.kts
+++ b/exposed/mvc-virtualthread/build.gradle.kts
@@ -1,6 +1,16 @@
 plugins {
     alias(libs.plugins.kotlin.spring)
     alias(libs.plugins.spring.boot)
+    alias(libs.plugins.exposed)
+}
+
+exposed {
+    migrations {
+        tablesPackage = "io.bluetape4k.workshop.exposed.mvc.vt"
+        databaseUrl = "jdbc:h2:mem:workshop-exposed-mvc-virtualthread-migrations;DB_CLOSE_DELAY=-1;MODE=PostgreSQL"
+        databaseUser = "sa"
+        databasePassword = ""
+    }
 }
 
 springBoot {

--- a/exposed/webflux-r2dbc/build.gradle.kts
+++ b/exposed/webflux-r2dbc/build.gradle.kts
@@ -1,6 +1,16 @@
 plugins {
     alias(libs.plugins.kotlin.spring)
     alias(libs.plugins.spring.boot)
+    alias(libs.plugins.exposed)
+}
+
+exposed {
+    migrations {
+        tablesPackage = "io.bluetape4k.workshop.exposed.webflux.r2dbc"
+        databaseUrl = "jdbc:h2:mem:workshop-exposed-webflux-r2dbc-migrations;DB_CLOSE_DELAY=-1;MODE=PostgreSQL"
+        databaseUser = "sa"
+        databasePassword = ""
+    }
 }
 
 springBoot {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -160,6 +160,7 @@ graalvm-native = { id = "org.graalvm.buildtools.native", version.ref = "graalvm-
 docker-compose = { id = "com.avast.gradle.docker-compose", version.ref = "docker-compose" }
 protobuf-plugin = { id = "com.google.protobuf", version.ref = "protobuf-plugin" }
 gatling-plugin = { id = "io.gatling.gradle", version.ref = "gatling-plugin" }
+exposed = { id = "org.jetbrains.exposed.plugin", version.ref = "exposed" }
 
 [libraries]
 jetbrains-annotations = { module = "org.jetbrains:annotations", version = "26.1.0" }  # https://mvnrepository.com/artifact/org.jetbrains/annotations

--- a/messaging/transactional-outbox/build.gradle.kts
+++ b/messaging/transactional-outbox/build.gradle.kts
@@ -1,6 +1,16 @@
 plugins {
+    alias(libs.plugins.exposed)
     alias(libs.plugins.kotlin.spring)
     alias(libs.plugins.spring.boot)
+}
+
+exposed {
+    migrations {
+        tablesPackage = "io.bluetape4k.workshop.messaging.outbox"
+        databaseUrl = "jdbc:h2:mem:messaging-transactional-outbox-migrations;DB_CLOSE_DELAY=-1;MODE=PostgreSQL"
+        databaseUser = "sa"
+        databasePassword = ""
+    }
 }
 
 springBoot {

--- a/observability/observability-advanced/build.gradle.kts
+++ b/observability/observability-advanced/build.gradle.kts
@@ -1,6 +1,16 @@
 plugins {
+    alias(libs.plugins.exposed)
     alias(libs.plugins.kotlin.spring)
     alias(libs.plugins.spring.boot)
+}
+
+exposed {
+    migrations {
+        tablesPackage = "io.bluetape4k.workshop.observability.advanced"
+        databaseUrl = "jdbc:h2:mem:observability-observability-advanced-migrations;DB_CLOSE_DELAY=-1;MODE=PostgreSQL"
+        databaseUser = "sa"
+        databasePassword = ""
+    }
 }
 
 springBoot {

--- a/spring-boot/multi-tenant-data-isolation/build.gradle.kts
+++ b/spring-boot/multi-tenant-data-isolation/build.gradle.kts
@@ -1,6 +1,16 @@
 plugins {
+    alias(libs.plugins.exposed)
     alias(libs.plugins.kotlin.spring)
     alias(libs.plugins.spring.boot)
+}
+
+exposed {
+    migrations {
+        tablesPackage = "io.bluetape4k.workshop.multitenant"
+        databaseUrl = "jdbc:h2:mem:spring-boot-multi-tenant-data-isolation-migrations;DB_CLOSE_DELAY=-1;MODE=PostgreSQL"
+        databaseUser = "sa"
+        databasePassword = ""
+    }
 }
 springBoot {
     mainClass.set("io.bluetape4k.workshop.multitenant.MultiTenantDataIsolationApplicationKt")

--- a/spring-data/r2dbc-webflux-exposed/build.gradle.kts
+++ b/spring-data/r2dbc-webflux-exposed/build.gradle.kts
@@ -2,6 +2,16 @@ plugins {
     alias(libs.plugins.kotlin.spring)
     alias(libs.plugins.spring.boot)
     // alias(libs.plugins.graalvm.native)
+    alias(libs.plugins.exposed)
+}
+
+exposed {
+    migrations {
+        tablesPackage = "io.bluetape4k.workshop.exposed.r2dbc.domain"
+        databaseUrl = "jdbc:h2:mem:workshop-r2dbc-webflux-exposed-migrations;DB_CLOSE_DELAY=-1;MODE=PostgreSQL"
+        databaseUser = "sa"
+        databasePassword = ""
+    }
 }
 
 springBoot {


### PR DESCRIPTION
## Summary
- Applies the JetBrains Exposed Gradle plugin to modules that define Exposed tables.
- Adds migration task configuration with explicit table package and H2 migration database settings where main table definitions exist.
- Keeps the workshop independent from the managed catalog and uses the repo-local Exposed plugin alias.
- Adds a short lesson under docs/lessons for future catalog/plugin governance.

## Validation
- git diff --check; ./gradlew -q help; :exposed-mvc-jdbc:tasks --all

Closes #211
