### PR TITLE
refactor: Migrate LocalStackServer → FlociServer in AWS S3 example

### DIFF
--- a/aws/s3-spring-cloud/src/main/kotlin/io/bluetape4k/workshop/aws/s3/SpringCloudAwsS3Sample.kt
+++ b/aws/s3-spring-cloud/src/main/kotlin/io/bluetape4k/workshop/aws/s3/SpringCloudAwsS3Sample.kt
@@ -5,7 +5,7 @@ import io.bluetape4k.aws.auth.staticCredentialsProviderOf
 import io.bluetape4k.aws.s3.createBucket
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.info
-import io.bluetape4k.testcontainers.aws.LocalStackServer
+import io.bluetape4k.testcontainers.aws.FlociServer
 import org.springframework.boot.ApplicationRunner
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
@@ -27,7 +27,7 @@ class SpringCloudAwsS3Sample {
     companion object: KLogging() {
         private const val TEST_FILE_URL = "s3://spring-cloud-aws-sample-bucket1/test-file.txt"
 
-        private val s3Server = LocalStackServer.Launcher.localStack.withServices("s3")
+        private val s3Server = FlociServer.Launcher.floci.withServices("s3")
     }
 
 //    @Value(TEST_FILE_URL)
@@ -36,9 +36,9 @@ class SpringCloudAwsS3Sample {
     @Bean
     fun s3Client(): S3Client {
         return S3Client.builder()
-            .endpointOverride(s3Server.endpoint)
-            .region(Region.of(s3Server.region))
-            .credentialsProvider(staticCredentialsProviderOf(s3Server.accessKey, s3Server.secretKey))
+            .endpointOverride(s3Server.awsEndpoint)
+            .region(Region.of(s3Server.regionName))
+            .credentialsProvider(staticCredentialsProviderOf(s3Server.awsAccessKey, s3Server.awsSecretKey))
             .build()
     }
 


### PR DESCRIPTION
## Summary

Migrates the AWS S3 Spring Cloud example from the deprecated `LocalStackServer` to `FlociServer`.

## Changes

- Replace `LocalStackServer.Launcher.*` with `FlociServer.Launcher.floci` in `SpringCloudAwsS3Sample.kt`
- Update S3Client configuration references:
  - `endpoint` → `awsEndpoint`
  - `region` → `regionName`
  - credentials accessor updated accordingly

## Motivation

`LocalStackServer` is deprecated as of `bluetape4k-testcontainers 1.9.1`. `FlociServer` is the replacement singleton launcher for local AWS service emulation.

## Test

The existing S3 integration tests in the `aws-s3` module cover this change. No new tests required — this is a drop-in replacement.

```bash
./gradlew :aws-s3:test
```

## Checklist

- [x] Compiles without errors
- [x] Drop-in replacement — no behavioral change
- [x] No new dependencies required