### PR TITLE
Refactor workshop examples to use bluetape4k patterns

### DIFF
--- a/aws/storage-abstraction/src/test/kotlin/io/bluetape4k/workshop/storage/AbstractStorageServiceTest.kt
+++ b/aws/storage-abstraction/src/test/kotlin/io/bluetape4k/workshop/storage/AbstractStorageServiceTest.kt
@@ -3,9 +3,9 @@ package io.bluetape4k.workshop.storage
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldNotBeBlank
 import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.support.toUtf8Bytes
-import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.MethodOrderer
 import org.junit.jupiter.api.Order
 import org.junit.jupiter.api.Test
@@ -31,14 +31,14 @@ abstract class AbstractStorageServiceTest {
 
     @Test
     @Order(1)
-    fun `upload returns a non-blank URL`() = runTest {
+    fun `upload returns a non-blank URL`() = runSuspendIO {
         val url = storageService.upload(TEST_KEY, TEST_CONTENT, TEST_CONTENT_TYPE)
         url.shouldNotBeNull().shouldNotBeBlank()
     }
 
     @Test
     @Order(2)
-    fun `download returns the same bytes that were uploaded`() = runTest {
+    fun `download returns the same bytes that were uploaded`() = runSuspendIO {
         storageService.upload(TEST_KEY, TEST_CONTENT, TEST_CONTENT_TYPE)
         val downloaded = storageService.download(TEST_KEY)
         downloaded shouldBeEqualTo TEST_CONTENT
@@ -46,7 +46,7 @@ abstract class AbstractStorageServiceTest {
 
     @Test
     @Order(3)
-    fun `getUrl returns a non-blank URL for an existing key`() = runTest {
+    fun `getUrl returns a non-blank URL for an existing key`() = runSuspendIO {
         storageService.upload(TEST_KEY, TEST_CONTENT, TEST_CONTENT_TYPE)
         val url = storageService.getUrl(TEST_KEY)
         url.shouldNotBeBlank()
@@ -54,7 +54,7 @@ abstract class AbstractStorageServiceTest {
 
     @Test
     @Order(4)
-    fun `delete removes the object without error`() = runTest {
+    fun `delete removes the object without error`() = runSuspendIO {
         storageService.upload(TEST_KEY, TEST_CONTENT, TEST_CONTENT_TYPE)
         // Should not throw
         storageService.delete(TEST_KEY)
@@ -62,7 +62,7 @@ abstract class AbstractStorageServiceTest {
 
     @Test
     @Order(5)
-    fun `delete is idempotent for missing key`() = runTest {
+    fun `delete is idempotent for missing key`() = runSuspendIO {
         // Delete a key that was never uploaded — must not throw
         storageService.delete("non-existent/key.txt")
     }

--- a/aws/storage-abstraction/src/test/kotlin/io/bluetape4k/workshop/storage/AbstractStorageServiceTest.kt
+++ b/aws/storage-abstraction/src/test/kotlin/io/bluetape4k/workshop/storage/AbstractStorageServiceTest.kt
@@ -1,15 +1,16 @@
 package io.bluetape4k.workshop.storage
 
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldNotBeBlank
+import io.bluetape4k.assertions.shouldNotBeNull
 import io.bluetape4k.logging.KLogging
+import io.bluetape4k.support.toUtf8Bytes
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.MethodOrderer
 import org.junit.jupiter.api.Order
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestMethodOrder
 import org.springframework.beans.factory.annotation.Autowired
-import kotlin.test.assertContentEquals
-import kotlin.test.assertNotNull
-import kotlin.test.assertTrue
 
 /**
  * Base test class for all [StorageService] implementations.
@@ -21,7 +22,7 @@ abstract class AbstractStorageServiceTest {
 
     companion object : KLogging() {
         const val TEST_KEY = "test/hello.txt"
-        val TEST_CONTENT = "Hello, Storage Abstraction!".toByteArray(Charsets.UTF_8)
+        val TEST_CONTENT = "Hello, Storage Abstraction!".toUtf8Bytes()
         const val TEST_CONTENT_TYPE = "text/plain"
     }
 
@@ -32,8 +33,7 @@ abstract class AbstractStorageServiceTest {
     @Order(1)
     fun `upload returns a non-blank URL`() = runTest {
         val url = storageService.upload(TEST_KEY, TEST_CONTENT, TEST_CONTENT_TYPE)
-        assertNotNull(url)
-        assertTrue(url.isNotBlank(), "URL must not be blank, got: $url")
+        url.shouldNotBeNull().shouldNotBeBlank()
     }
 
     @Test
@@ -41,7 +41,7 @@ abstract class AbstractStorageServiceTest {
     fun `download returns the same bytes that were uploaded`() = runTest {
         storageService.upload(TEST_KEY, TEST_CONTENT, TEST_CONTENT_TYPE)
         val downloaded = storageService.download(TEST_KEY)
-        assertContentEquals(TEST_CONTENT, downloaded)
+        downloaded shouldBeEqualTo TEST_CONTENT
     }
 
     @Test
@@ -49,7 +49,7 @@ abstract class AbstractStorageServiceTest {
     fun `getUrl returns a non-blank URL for an existing key`() = runTest {
         storageService.upload(TEST_KEY, TEST_CONTENT, TEST_CONTENT_TYPE)
         val url = storageService.getUrl(TEST_KEY)
-        assertTrue(url.isNotBlank(), "URL must not be blank, got: $url")
+        url.shouldNotBeBlank()
     }
 
     @Test

--- a/aws/storage-abstraction/src/test/kotlin/io/bluetape4k/workshop/storage/S3PresignedStorageServiceTest.kt
+++ b/aws/storage-abstraction/src/test/kotlin/io/bluetape4k/workshop/storage/S3PresignedStorageServiceTest.kt
@@ -1,11 +1,11 @@
 package io.bluetape4k.workshop.storage
 
+import io.bluetape4k.assertions.shouldContain
 import io.bluetape4k.logging.KLogging
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import kotlin.test.assertTrue
 
 @SpringBootTest
 @ActiveProfiles("s3-presigned")
@@ -17,19 +17,13 @@ class S3PresignedStorageServiceTest : AbstractStorageServiceTest() {
     fun `getUrl returns a presigned URL containing X-Amz-Expires`() = runTest {
         storageService.upload(TEST_KEY, TEST_CONTENT, TEST_CONTENT_TYPE)
         val url = storageService.getUrl(TEST_KEY)
-        assertTrue(
-            url.contains("X-Amz-Expires", ignoreCase = true),
-            "Presigned URL must contain X-Amz-Expires, got: $url"
-        )
+        url.lowercase() shouldContain "x-amz-expires"
     }
 
     @Test
     fun `presigned URL reflects configured expiry of 15 minutes (900 seconds)`() = runTest {
         storageService.upload(TEST_KEY, TEST_CONTENT, TEST_CONTENT_TYPE)
         val url = storageService.getUrl(TEST_KEY)
-        assertTrue(
-            url.contains("X-Amz-Expires=900", ignoreCase = true),
-            "Presigned URL must contain X-Amz-Expires=900, got: $url"
-        )
+        url.lowercase() shouldContain "x-amz-expires=900"
     }
 }

--- a/aws/storage-abstraction/src/test/kotlin/io/bluetape4k/workshop/storage/S3PresignedStorageServiceTest.kt
+++ b/aws/storage-abstraction/src/test/kotlin/io/bluetape4k/workshop/storage/S3PresignedStorageServiceTest.kt
@@ -1,8 +1,8 @@
 package io.bluetape4k.workshop.storage
 
 import io.bluetape4k.assertions.shouldContain
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.logging.KLogging
-import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
@@ -14,14 +14,14 @@ class S3PresignedStorageServiceTest : AbstractStorageServiceTest() {
     companion object : KLogging()
 
     @Test
-    fun `getUrl returns a presigned URL containing X-Amz-Expires`() = runTest {
+    fun `getUrl returns a presigned URL containing X-Amz-Expires`() = runSuspendIO {
         storageService.upload(TEST_KEY, TEST_CONTENT, TEST_CONTENT_TYPE)
         val url = storageService.getUrl(TEST_KEY)
         url.lowercase() shouldContain "x-amz-expires"
     }
 
     @Test
-    fun `presigned URL reflects configured expiry of 15 minutes (900 seconds)`() = runTest {
+    fun `presigned URL reflects configured expiry of 15 minutes (900 seconds)`() = runSuspendIO {
         storageService.upload(TEST_KEY, TEST_CONTENT, TEST_CONTENT_TYPE)
         val url = storageService.getUrl(TEST_KEY)
         url.lowercase() shouldContain "x-amz-expires=900"

--- a/exposed/javers-audit/build.gradle.kts
+++ b/exposed/javers-audit/build.gradle.kts
@@ -26,4 +26,6 @@ dependencies {
     // Test
     testImplementation(libs.bluetape4k.assertions)
     testImplementation(libs.exposed.jdbc.tests)
+    testRuntimeOnly(libs.mysql.connector.j)
+    testRuntimeOnly(libs.postgresql.driver)
 }

--- a/exposed/javers-audit/build.gradle.kts
+++ b/exposed/javers-audit/build.gradle.kts
@@ -25,4 +25,5 @@ dependencies {
 
     // Test
     testImplementation(libs.bluetape4k.assertions)
+    testImplementation(libs.exposed.jdbc.tests)
 }

--- a/exposed/javers-audit/src/main/kotlin/io/bluetape4k/workshop/exposed/javers/service/ProductAuditService.kt
+++ b/exposed/javers-audit/src/main/kotlin/io/bluetape4k/workshop/exposed/javers/service/ProductAuditService.kt
@@ -3,6 +3,7 @@ package io.bluetape4k.workshop.exposed.javers.service
 import io.bluetape4k.javers.latestSnapshotOrNull
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
+import io.bluetape4k.support.requireNotBlank
 import io.bluetape4k.workshop.exposed.javers.model.Product
 import io.bluetape4k.workshop.exposed.javers.model.ProductTable
 import org.javers.core.Javers
@@ -45,7 +46,7 @@ class ProductAuditService(
      * @param product The product to persist and audit.
      */
     fun save(author: String, product: Product) {
-        require(author.isNotBlank()) { "author must not be blank" }
+        author.requireNotBlank("author")
         javers.commit(author, product)
         transaction {
             ProductTable.upsert {
@@ -89,7 +90,7 @@ class ProductAuditService(
      * @param product The product to delete.
      */
     fun delete(author: String, product: Product) {
-        require(author.isNotBlank()) { "author must not be blank" }
+        author.requireNotBlank("author")
         javers.commitShallowDelete(author, product)
         transaction {
             ProductTable.deleteWhere { ProductTable.id eq product.id }

--- a/exposed/javers-audit/src/test/kotlin/io/bluetape4k/workshop/exposed/javers/ProductAuditServiceTest.kt
+++ b/exposed/javers-audit/src/test/kotlin/io/bluetape4k/workshop/exposed/javers/ProductAuditServiceTest.kt
@@ -6,49 +6,31 @@ import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldHaveSize
 import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.exposed.tests.AbstractExposedTest
+import io.bluetape4k.exposed.tests.TestDB
+import io.bluetape4k.exposed.tests.withTables
 import io.bluetape4k.javers.diff.changesByType
-import io.bluetape4k.logging.KLogging
 import io.bluetape4k.workshop.exposed.javers.model.Product
 import io.bluetape4k.workshop.exposed.javers.model.ProductTable
 import io.bluetape4k.workshop.exposed.javers.service.ProductAuditService
 import org.javers.core.JaversBuilder
 import org.javers.core.diff.changetype.ValueChange
 import org.javers.core.metamodel.`object`.SnapshotType
-import org.jetbrains.exposed.v1.jdbc.Database
-import org.jetbrains.exposed.v1.jdbc.SchemaUtils
-import org.jetbrains.exposed.v1.jdbc.transactions.transaction
-import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
 import java.math.BigDecimal
 
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class ProductAuditServiceTest {
+class ProductAuditServiceTest: AbstractExposedTest() {
 
-    companion object: KLogging()
-
-    private val javers = JaversBuilder.javers().build()
-    private lateinit var service: ProductAuditService
-
-    @BeforeEach
-    fun setUp() {
-        Database.connect("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1", driver = "org.h2.Driver")
-        transaction {
-            SchemaUtils.create(ProductTable)
-        }
-        service = ProductAuditService(javers)
-    }
-
-    @AfterEach
-    fun tearDown() {
-        transaction {
-            SchemaUtils.drop(ProductTable)
+    private fun withProductAuditService(testDB: TestDB, statement: (ProductAuditService) -> Unit) {
+        withTables(testDB, ProductTable) {
+            statement(ProductAuditService(JaversBuilder.javers().build()))
         }
     }
 
-    @Test
-    fun `save product creates a single initial snapshot`() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource(ENABLE_DIALECTS_METHOD)
+    fun `save product creates a single initial snapshot`(testDB: TestDB) = withProductAuditService(testDB) { service ->
         val product = Product(id = 1L, name = "Widget", price = BigDecimal("9.99"), category = "Tools")
 
         service.save("alice", product)
@@ -58,22 +40,25 @@ class ProductAuditServiceTest {
         history.first().type shouldBeEqualTo SnapshotType.INITIAL
     }
 
-    @Test
-    fun `save product twice creates two snapshots with second as UPDATE`() {
-        val original = Product(id = 2L, name = "Gadget", price = BigDecimal("19.99"), category = "Electronics")
-        val updated = original.copy(price = BigDecimal("24.99"))
+    @ParameterizedTest(name = "{0}")
+    @MethodSource(ENABLE_DIALECTS_METHOD)
+    fun `save product twice creates two snapshots with second as UPDATE`(testDB: TestDB) =
+        withProductAuditService(testDB) { service ->
+            val original = Product(id = 2L, name = "Gadget", price = BigDecimal("19.99"), category = "Electronics")
+            val updated = original.copy(price = BigDecimal("24.99"))
 
-        service.save("bob", original)
-        service.save("bob", updated)
+            service.save("bob", original)
+            service.save("bob", updated)
 
-        val history = service.getHistory(2L)
-        history shouldHaveSize 2
-        history[0].type shouldBeEqualTo SnapshotType.INITIAL
-        history[1].type shouldBeEqualTo SnapshotType.UPDATE
-    }
+            val history = service.getHistory(2L)
+            history shouldHaveSize 2
+            history[0].type shouldBeEqualTo SnapshotType.INITIAL
+            history[1].type shouldBeEqualTo SnapshotType.UPDATE
+        }
 
-    @Test
-    fun `diff detects price change between two versions`() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource(ENABLE_DIALECTS_METHOD)
+    fun `diff detects price change between two versions`(testDB: TestDB) = withProductAuditService(testDB) { service ->
         val original = Product(id = 3L, name = "Sprocket", price = BigDecimal("5.00"), category = "Parts")
         val updated = original.copy(price = BigDecimal("7.50"))
 
@@ -87,8 +72,9 @@ class ProductAuditServiceTest {
         priceChange.right shouldBeEqualTo BigDecimal("7.50")
     }
 
-    @Test
-    fun `diff reports no changes when product is unchanged`() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource(ENABLE_DIALECTS_METHOD)
+    fun `diff reports no changes when product is unchanged`(testDB: TestDB) = withProductAuditService(testDB) { service ->
         val product = Product(id = 4L, name = "Bolt", price = BigDecimal("0.99"), category = "Hardware")
 
         val diff = service.diff(product, product.copy())
@@ -96,29 +82,33 @@ class ProductAuditServiceTest {
         diff.hasChanges().shouldBeFalse()
     }
 
-    @Test
-    fun `getLatestSnapshot returns null before any save`() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource(ENABLE_DIALECTS_METHOD)
+    fun `getLatestSnapshot returns null before any save`(testDB: TestDB) = withProductAuditService(testDB) { service ->
         service.getLatestSnapshot(999L).shouldBeNull()
     }
 
-    @Test
-    fun `getLatestSnapshot returns most recent state after multiple saves`() {
-        val v1 = Product(id = 5L, name = "Cog", price = BigDecimal("3.00"), category = "Parts")
-        val v2 = v1.copy(category = "Mechanical Parts")
-        val v3 = v2.copy(price = BigDecimal("3.50"))
+    @ParameterizedTest(name = "{0}")
+    @MethodSource(ENABLE_DIALECTS_METHOD)
+    fun `getLatestSnapshot returns most recent state after multiple saves`(testDB: TestDB) =
+        withProductAuditService(testDB) { service ->
+            val v1 = Product(id = 5L, name = "Cog", price = BigDecimal("3.00"), category = "Parts")
+            val v2 = v1.copy(category = "Mechanical Parts")
+            val v3 = v2.copy(price = BigDecimal("3.50"))
 
-        service.save("carol", v1)
-        service.save("carol", v2)
-        service.save("carol", v3)
+            service.save("carol", v1)
+            service.save("carol", v2)
+            service.save("carol", v3)
 
-        val snapshot = service.getLatestSnapshot(5L)
-        snapshot.shouldNotBeNull()
-        snapshot.getPropertyValue("category") shouldBeEqualTo "Mechanical Parts"
-        snapshot.getPropertyValue("price") shouldBeEqualTo BigDecimal("3.50")
-    }
+            val snapshot = service.getLatestSnapshot(5L)
+            snapshot.shouldNotBeNull()
+            snapshot.getPropertyValue("category") shouldBeEqualTo "Mechanical Parts"
+            snapshot.getPropertyValue("price") shouldBeEqualTo BigDecimal("3.50")
+        }
 
-    @Test
-    fun `delete records a TERMINAL snapshot`() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource(ENABLE_DIALECTS_METHOD)
+    fun `delete records a TERMINAL snapshot`(testDB: TestDB) = withProductAuditService(testDB) { service ->
         val product = Product(id = 6L, name = "Pin", price = BigDecimal("0.10"), category = "Hardware")
         service.save("dave", product)
 
@@ -129,8 +119,9 @@ class ProductAuditServiceTest {
         history.last().type shouldBeEqualTo SnapshotType.TERMINAL
     }
 
-    @Test
-    fun `diff detects category change`() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource(ENABLE_DIALECTS_METHOD)
+    fun `diff detects category change`(testDB: TestDB) = withProductAuditService(testDB) { service ->
         val original = Product(id = 7L, name = "Lever", price = BigDecimal("15.00"), category = "Mechanical")
         val updated = original.copy(category = "Industrial")
 

--- a/exposed/mvc-jdbc/build.gradle.kts
+++ b/exposed/mvc-jdbc/build.gradle.kts
@@ -25,7 +25,9 @@ dependencies {
     testImplementation(project(":shared"))
     testImplementation(libs.bluetape4k.junit5)
     testImplementation(libs.bluetape4k.assertions)
-    testImplementation(libs.exposed.jdbc.tests)
+    testImplementation(libs.exposed.jdbc.tests) {
+        exclude(group = "org.jetbrains.exposed", module = "exposed-spring-boot4-starter")
+    }
 
     // Logging
     implementation(libs.bluetape4k.logging)

--- a/exposed/mvc-jdbc/build.gradle.kts
+++ b/exposed/mvc-jdbc/build.gradle.kts
@@ -25,6 +25,7 @@ dependencies {
     testImplementation(project(":shared"))
     testImplementation(libs.bluetape4k.junit5)
     testImplementation(libs.bluetape4k.assertions)
+    testImplementation(libs.exposed.jdbc.tests)
 
     // Logging
     implementation(libs.bluetape4k.logging)

--- a/exposed/mvc-jdbc/src/test/kotlin/io/bluetape4k/workshop/exposed/mvc/jdbc/AbstractMvcJdbcTest.kt
+++ b/exposed/mvc-jdbc/src/test/kotlin/io/bluetape4k/workshop/exposed/mvc/jdbc/AbstractMvcJdbcTest.kt
@@ -1,26 +1,29 @@
 package io.bluetape4k.workshop.exposed.mvc.jdbc
 
-import io.bluetape4k.exposed.tests.Containers
+import io.bluetape4k.exposed.tests.TestDB
 import io.bluetape4k.junit5.faker.Fakers
 import io.bluetape4k.logging.KLogging
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.web.server.LocalServerPort
+import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.DynamicPropertyRegistry
 import org.springframework.test.context.DynamicPropertySource
 import org.springframework.test.web.reactive.server.WebTestClient
 
+@ActiveProfiles("postgres")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 abstract class AbstractMvcJdbcTest {
 
     companion object : KLogging() {
-        val postgres = Containers.Postgres
+        private val testDB = TestDB.POSTGRESQL
 
         @JvmStatic
         @DynamicPropertySource
         fun postgresProperties(registry: DynamicPropertyRegistry) {
-            registry.add("spring.datasource.url") { postgres.jdbcUrl }
-            registry.add("spring.datasource.username") { postgres.username!! }
-            registry.add("spring.datasource.password") { postgres.password!! }
+            registry.add("spring.datasource.url") { testDB.connection() }
+            registry.add("spring.datasource.driver-class-name") { testDB.driver }
+            registry.add("spring.datasource.username") { testDB.user }
+            registry.add("spring.datasource.password") { testDB.pass }
         }
 
         val faker = Fakers.faker

--- a/exposed/mvc-jdbc/src/test/kotlin/io/bluetape4k/workshop/exposed/mvc/jdbc/AbstractMvcJdbcTest.kt
+++ b/exposed/mvc-jdbc/src/test/kotlin/io/bluetape4k/workshop/exposed/mvc/jdbc/AbstractMvcJdbcTest.kt
@@ -1,8 +1,8 @@
 package io.bluetape4k.workshop.exposed.mvc.jdbc
 
+import io.bluetape4k.exposed.tests.Containers
 import io.bluetape4k.junit5.faker.Fakers
 import io.bluetape4k.logging.KLogging
-import io.bluetape4k.testcontainers.database.PostgreSQLServer
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.web.server.LocalServerPort
 import org.springframework.test.context.DynamicPropertyRegistry
@@ -13,12 +13,12 @@ import org.springframework.test.web.reactive.server.WebTestClient
 abstract class AbstractMvcJdbcTest {
 
     companion object : KLogging() {
-        val postgres = PostgreSQLServer.Launcher.postgres
+        val postgres = Containers.Postgres
 
         @JvmStatic
         @DynamicPropertySource
         fun postgresProperties(registry: DynamicPropertyRegistry) {
-            registry.add("spring.datasource.url") { postgres.jdbcUrl!! }
+            registry.add("spring.datasource.url") { postgres.jdbcUrl }
             registry.add("spring.datasource.username") { postgres.username!! }
             registry.add("spring.datasource.password") { postgres.password!! }
         }

--- a/exposed/mvc-virtualthread/build.gradle.kts
+++ b/exposed/mvc-virtualthread/build.gradle.kts
@@ -25,7 +25,9 @@ dependencies {
     testImplementation(project(":shared"))
     testImplementation(libs.bluetape4k.junit5)
     testImplementation(libs.bluetape4k.assertions)
-    testImplementation(libs.exposed.jdbc.tests)
+    testImplementation(libs.exposed.jdbc.tests) {
+        exclude(group = "org.jetbrains.exposed", module = "exposed-spring-boot4-starter")
+    }
 
     // bluetape4k core (provides virtualFuture, ShutdownQueue, KLogging)
     implementation(libs.bluetape4k.core)

--- a/exposed/mvc-virtualthread/build.gradle.kts
+++ b/exposed/mvc-virtualthread/build.gradle.kts
@@ -25,6 +25,7 @@ dependencies {
     testImplementation(project(":shared"))
     testImplementation(libs.bluetape4k.junit5)
     testImplementation(libs.bluetape4k.assertions)
+    testImplementation(libs.exposed.jdbc.tests)
 
     // bluetape4k core (provides virtualFuture, ShutdownQueue, KLogging)
     implementation(libs.bluetape4k.core)

--- a/exposed/mvc-virtualthread/src/test/kotlin/io/bluetape4k/workshop/exposed/mvc/vt/AbstractMvcVirtualThreadTest.kt
+++ b/exposed/mvc-virtualthread/src/test/kotlin/io/bluetape4k/workshop/exposed/mvc/vt/AbstractMvcVirtualThreadTest.kt
@@ -1,8 +1,8 @@
 package io.bluetape4k.workshop.exposed.mvc.vt
 
+import io.bluetape4k.exposed.tests.Containers
 import io.bluetape4k.junit5.faker.Fakers
 import io.bluetape4k.logging.KLogging
-import io.bluetape4k.testcontainers.database.PostgreSQLServer
 import io.bluetape4k.workshop.exposed.mvc.vt.author.schema.AuthorTable
 import io.bluetape4k.workshop.exposed.mvc.vt.author.schema.BookTable
 import io.bluetape4k.workshop.exposed.mvc.vt.order.schema.OrderLineTable
@@ -25,7 +25,7 @@ import java.math.BigDecimal
 abstract class AbstractMvcVirtualThreadTest {
 
     companion object : KLogging() {
-        val postgres = PostgreSQLServer.Launcher.postgres
+        val postgres = Containers.Postgres
 
         @JvmStatic
         @DynamicPropertySource

--- a/exposed/mvc-virtualthread/src/test/kotlin/io/bluetape4k/workshop/exposed/mvc/vt/AbstractMvcVirtualThreadTest.kt
+++ b/exposed/mvc-virtualthread/src/test/kotlin/io/bluetape4k/workshop/exposed/mvc/vt/AbstractMvcVirtualThreadTest.kt
@@ -1,6 +1,6 @@
 package io.bluetape4k.workshop.exposed.mvc.vt
 
-import io.bluetape4k.exposed.tests.Containers
+import io.bluetape4k.exposed.tests.TestDB
 import io.bluetape4k.junit5.faker.Fakers
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.workshop.exposed.mvc.vt.author.schema.AuthorTable
@@ -16,23 +16,26 @@ import org.junit.jupiter.api.BeforeEach
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.web.server.LocalServerPort
+import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.DynamicPropertyRegistry
 import org.springframework.test.context.DynamicPropertySource
 import org.springframework.test.web.reactive.server.WebTestClient
 import java.math.BigDecimal
 
+@ActiveProfiles("postgres")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 abstract class AbstractMvcVirtualThreadTest {
 
     companion object : KLogging() {
-        val postgres = Containers.Postgres
+        private val testDB = TestDB.POSTGRESQL
 
         @JvmStatic
         @DynamicPropertySource
         fun postgresProperties(registry: DynamicPropertyRegistry) {
-            registry.add("spring.datasource.url") { postgres.jdbcUrl as Any }
-            registry.add("spring.datasource.username") { postgres.username as Any }
-            registry.add("spring.datasource.password") { postgres.password as Any }
+            registry.add("spring.datasource.url") { testDB.connection() }
+            registry.add("spring.datasource.driver-class-name") { testDB.driver }
+            registry.add("spring.datasource.username") { testDB.user }
+            registry.add("spring.datasource.password") { testDB.pass }
         }
 
         val faker = Fakers.faker

--- a/exposed/webflux-r2dbc/build.gradle.kts
+++ b/exposed/webflux-r2dbc/build.gradle.kts
@@ -25,6 +25,7 @@ dependencies {
     testImplementation(project(":shared"))
     testImplementation(libs.bluetape4k.junit5)
     testImplementation(libs.bluetape4k.assertions)
+    testImplementation(libs.exposed.r2dbc.tests)
 
     // Logging
     implementation(libs.bluetape4k.logging)

--- a/exposed/webflux-r2dbc/src/main/kotlin/io/bluetape4k/workshop/exposed/webflux/r2dbc/config/DatabaseInitializer.kt
+++ b/exposed/webflux-r2dbc/src/main/kotlin/io/bluetape4k/workshop/exposed/webflux/r2dbc/config/DatabaseInitializer.kt
@@ -32,6 +32,7 @@ class DatabaseInitializer(
         val jdbcUrl = r2dbcUrl
             .replace("r2dbc:pool:postgresql", "jdbc:postgresql")
             .replace("r2dbc:postgresql", "jdbc:postgresql")
+            .replace(Regex("""(jdbc:postgresql://)[^/@]+@"""), "$1")
 
         val hikariConfig = HikariConfig().apply {
             this.jdbcUrl = jdbcUrl

--- a/exposed/webflux-r2dbc/src/test/kotlin/io/bluetape4k/workshop/exposed/webflux/r2dbc/AbstractWebfluxR2dbcTest.kt
+++ b/exposed/webflux-r2dbc/src/test/kotlin/io/bluetape4k/workshop/exposed/webflux/r2dbc/AbstractWebfluxR2dbcTest.kt
@@ -1,28 +1,28 @@
 package io.bluetape4k.workshop.exposed.webflux.r2dbc
 
-import io.bluetape4k.exposed.r2dbc.tests.Containers
+import io.bluetape4k.exposed.r2dbc.tests.TestDB
 import io.bluetape4k.junit5.faker.Fakers
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.web.server.LocalServerPort
+import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.DynamicPropertyRegistry
 import org.springframework.test.context.DynamicPropertySource
 import org.springframework.test.web.reactive.server.WebTestClient
 
+@ActiveProfiles("postgres")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 abstract class AbstractWebfluxR2dbcTest {
 
     companion object : KLoggingChannel() {
-        val postgres = Containers.Postgres
+        private val testDB = TestDB.POSTGRESQL
 
         @JvmStatic
         @DynamicPropertySource
         fun postgresProperties(registry: DynamicPropertyRegistry) {
-            registry.add("spring.r2dbc.url") {
-                "r2dbc:postgresql://${postgres.host}:${postgres.getMappedPort(5432)}/${postgres.databaseName}"
-            }
-            registry.add("spring.r2dbc.username") { postgres.username!! }
-            registry.add("spring.r2dbc.password") { postgres.password!! }
+            registry.add("spring.r2dbc.url") { testDB.connection() }
+            registry.add("spring.r2dbc.username") { testDB.user }
+            registry.add("spring.r2dbc.password") { testDB.pass }
         }
 
         val faker = Fakers.faker

--- a/exposed/webflux-r2dbc/src/test/kotlin/io/bluetape4k/workshop/exposed/webflux/r2dbc/AbstractWebfluxR2dbcTest.kt
+++ b/exposed/webflux-r2dbc/src/test/kotlin/io/bluetape4k/workshop/exposed/webflux/r2dbc/AbstractWebfluxR2dbcTest.kt
@@ -1,8 +1,8 @@
 package io.bluetape4k.workshop.exposed.webflux.r2dbc
 
+import io.bluetape4k.exposed.r2dbc.tests.Containers
 import io.bluetape4k.junit5.faker.Fakers
 import io.bluetape4k.logging.coroutines.KLoggingChannel
-import io.bluetape4k.testcontainers.database.PostgreSQLServer
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.web.server.LocalServerPort
 import org.springframework.test.context.DynamicPropertyRegistry
@@ -13,7 +13,7 @@ import org.springframework.test.web.reactive.server.WebTestClient
 abstract class AbstractWebfluxR2dbcTest {
 
     companion object : KLoggingChannel() {
-        val postgres = PostgreSQLServer.Launcher.postgres
+        val postgres = Containers.Postgres
 
         @JvmStatic
         @DynamicPropertySource

--- a/exposed/webflux-r2dbc/src/test/kotlin/io/bluetape4k/workshop/exposed/webflux/r2dbc/author/AuthorControllerTest.kt
+++ b/exposed/webflux-r2dbc/src/test/kotlin/io/bluetape4k/workshop/exposed/webflux/r2dbc/author/AuthorControllerTest.kt
@@ -1,12 +1,14 @@
 package io.bluetape4k.workshop.exposed.webflux.r2dbc.author
 
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeGreaterThan
+import io.bluetape4k.assertions.shouldNotBeEmpty
 import io.bluetape4k.workshop.exposed.webflux.r2dbc.AbstractWebfluxR2dbcTest
 import io.bluetape4k.workshop.exposed.webflux.r2dbc.author.dto.AuthorDTO
 import io.bluetape4k.workshop.exposed.webflux.r2dbc.author.dto.CreateAuthorRequest
 import org.junit.jupiter.api.Test
 import org.springframework.http.MediaType
 import org.springframework.test.annotation.DirtiesContext
-import org.hamcrest.Matchers
 
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 class AuthorControllerTest : AbstractWebfluxR2dbcTest() {
@@ -28,9 +30,9 @@ class AuthorControllerTest : AbstractWebfluxR2dbcTest() {
             .expectBody(AuthorDTO::class.java)
             .returnResult().responseBody!!
 
-        assert(created.id > 0)
-        assert(created.firstName == req.firstName)
-        assert(created.email == req.email)
+        created.id shouldBeGreaterThan 0L
+        created.firstName shouldBeEqualTo req.firstName
+        created.email shouldBeEqualTo req.email
 
         webTestClient.get()
             .uri("/api/authors/${created.id}")
@@ -59,7 +61,7 @@ class AuthorControllerTest : AbstractWebfluxR2dbcTest() {
             .expectStatus().isOk
             .expectBodyList(AuthorDTO::class.java)
             .returnResult().responseBody!!
-        assert(authors.isNotEmpty())
+        authors.shouldNotBeEmpty()
     }
 
     @Test
@@ -92,7 +94,7 @@ class AuthorControllerTest : AbstractWebfluxR2dbcTest() {
             .expectStatus().isOk
             .expectBody(AuthorDTO::class.java)
             .returnResult().responseBody!!
-        assert(updated.firstName == "UpdatedName")
+        updated.firstName shouldBeEqualTo "UpdatedName"
     }
 
     @Test

--- a/exposed/webflux-r2dbc/src/test/kotlin/io/bluetape4k/workshop/exposed/webflux/r2dbc/order/ConcurrentPlaceOrderTest.kt
+++ b/exposed/webflux-r2dbc/src/test/kotlin/io/bluetape4k/workshop/exposed/webflux/r2dbc/order/ConcurrentPlaceOrderTest.kt
@@ -1,5 +1,7 @@
 package io.bluetape4k.workshop.exposed.webflux.r2dbc.order
 
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeLessOrEqualTo
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.info
 import io.bluetape4k.workshop.exposed.webflux.r2dbc.AbstractWebfluxR2dbcTest
@@ -72,12 +74,8 @@ class ConcurrentPlaceOrderTest : AbstractWebfluxR2dbcTest() {
         log.info { "Concurrent order results: success=$successCount, conflict=$failCount, total=${results.size}" }
 
         // Exactly totalStock orders should succeed, rest should fail with stock error
-        assert(successCount <= totalStock) {
-            "Expected at most $totalStock successful orders but got $successCount"
-        }
-        assert(successCount + failCount == concurrency) {
-            "Total results mismatch: success=$successCount, fail=$failCount, expected=$concurrency"
-        }
+        successCount shouldBeLessOrEqualTo totalStock
+        (successCount + failCount) shouldBeEqualTo concurrency
     }
 
     @Test
@@ -121,8 +119,6 @@ class ConcurrentPlaceOrderTest : AbstractWebfluxR2dbcTest() {
         val successCount = results.count { it == 201 }
         log.info { "Deadlock test results: success=$successCount / $concurrency" }
         // All should succeed (sufficient stock, deadlock prevention via sorted productId)
-        assert(successCount == concurrency) {
-            "Expected all $concurrency orders to succeed but got $successCount. Results: $results"
-        }
+        successCount shouldBeEqualTo concurrency
     }
 }

--- a/exposed/webflux-r2dbc/src/test/kotlin/io/bluetape4k/workshop/exposed/webflux/r2dbc/order/OrderControllerTest.kt
+++ b/exposed/webflux-r2dbc/src/test/kotlin/io/bluetape4k/workshop/exposed/webflux/r2dbc/order/OrderControllerTest.kt
@@ -1,5 +1,9 @@
 package io.bluetape4k.workshop.exposed.webflux.r2dbc.order
 
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeGreaterThan
+import io.bluetape4k.assertions.shouldHaveSize
+import io.bluetape4k.assertions.shouldNotBeEmpty
 import io.bluetape4k.workshop.exposed.webflux.r2dbc.AbstractWebfluxR2dbcTest
 import io.bluetape4k.workshop.exposed.webflux.r2dbc.order.dto.CreateProductRequest
 import io.bluetape4k.workshop.exposed.webflux.r2dbc.order.dto.OrderDTO
@@ -47,17 +51,17 @@ class OrderControllerTest : AbstractWebfluxR2dbcTest() {
             .expectBody(OrderDTO::class.java)
             .returnResult().responseBody!!
 
-        assert(order.id > 0)
-        assert(order.status == OrderStatus.PENDING)
-        assert(order.lines.size == 1)
-        assert(order.lines[0].quantity == 2)
+        order.id shouldBeGreaterThan 0L
+        order.status shouldBeEqualTo OrderStatus.PENDING
+        order.lines shouldHaveSize 1
+        order.lines[0].quantity shouldBeEqualTo 2
 
         val fetched = webTestClient.get().uri("/api/orders/${order.id}")
             .exchange()
             .expectStatus().isOk
             .expectBody(OrderDTO::class.java)
             .returnResult().responseBody!!
-        assert(fetched.lines.isNotEmpty())
+        fetched.lines.shouldNotBeEmpty()
     }
 
     @Test
@@ -80,7 +84,7 @@ class OrderControllerTest : AbstractWebfluxR2dbcTest() {
             .expectStatus().isOk
             .expectBody(OrderDTO::class.java)
             .returnResult().responseBody!!
-        assert(cancelled.status == OrderStatus.CANCELLED)
+        cancelled.status shouldBeEqualTo OrderStatus.CANCELLED
     }
 
     @Test

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -204,6 +204,7 @@ exposed-jdbc = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-jdbc"
 exposed-jackson3 = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-jackson3" }
 exposed-jdbc-tests = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-jdbc-tests" }
 exposed-r2dbc = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-r2dbc" }
+exposed-r2dbc-tests = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-r2dbc-tests" }
 bluetape4k-hibernate = { module = "io.github.bluetape4k:bluetape4k-hibernate" }
 bluetape4k-jdbc = { module = "io.github.bluetape4k:bluetape4k-jdbc" }
 bluetape4k-mongodb = { module = "io.github.bluetape4k:bluetape4k-mongodb" }

--- a/image-processing/advanced-workflow/build.gradle.kts
+++ b/image-processing/advanced-workflow/build.gradle.kts
@@ -51,6 +51,7 @@ tasks.withType<Test>().configureEach {
 dependencies {
     implementation(libs.bluetape4k.core)
     implementation(libs.bluetape4k.coroutines)
+    implementation(libs.bluetape4k.idgenerators)
     implementation(libs.bluetape4k.logging)
     implementation(libs.bluetape4k.micrometer)
     implementation(libs.bluetape4k.jackson3)

--- a/image-processing/advanced-workflow/src/main/kotlin/io/bluetape4k/workshop/imageprocessing/advanced/model/ImagePersistenceModels.kt
+++ b/image-processing/advanced-workflow/src/main/kotlin/io/bluetape4k/workshop/imageprocessing/advanced/model/ImagePersistenceModels.kt
@@ -1,5 +1,6 @@
 package io.bluetape4k.workshop.imageprocessing.advanced.model
 
+import io.bluetape4k.support.requireInRange
 import io.bluetape4k.support.requireNotBlank
 import io.bluetape4k.support.requirePositiveNumber
 import io.bluetape4k.workshop.imageprocessing.advanced.persistence.schema.ImageAssetStatus
@@ -79,7 +80,7 @@ data class JobFailureReason(
 ) : Serializable {
     init {
         errorCode.requireNotBlank("errorCode")
-        require(errorCode.length <= 100) { "errorCode must be ≤ 100 chars, was ${errorCode.length}" }
+        errorCode.length.requireInRange(1, 100, "errorCode.length")
         errorMessage.requireNotBlank("errorMessage")
     }
 

--- a/image-processing/advanced-workflow/src/main/kotlin/io/bluetape4k/workshop/imageprocessing/advanced/persistence/ImagePersistenceServiceImpl.kt
+++ b/image-processing/advanced-workflow/src/main/kotlin/io/bluetape4k/workshop/imageprocessing/advanced/persistence/ImagePersistenceServiceImpl.kt
@@ -1,6 +1,7 @@
 package io.bluetape4k.workshop.imageprocessing.advanced.persistence
 
 import io.bluetape4k.exposed.core.auditable.UserContext
+import io.bluetape4k.idgenerators.uuid.Uuid
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.info
 import io.bluetape4k.logging.warn
@@ -31,7 +32,6 @@ import org.springframework.transaction.support.TransactionTemplate
 import java.time.LocalDateTime
 import java.time.ZoneOffset
 import java.time.temporal.ChronoUnit
-import java.util.UUID
 
 /**
  * Programmatic-transaction implementation of [ImagePersistenceService].
@@ -115,7 +115,7 @@ class ImagePersistenceServiceImpl(
 
                             null -> {
                                 // New asset — insert and create first job
-                                val externalId = UUID.randomUUID().toString()
+                                val externalId = Uuid.V7.nextIdAsString()
                                 val assetId = ImageAssetTable.insertAndGetId {
                                     it[ImageAssetTable.externalId] = externalId
                                     it[ImageAssetTable.originalFilename] = metadata.originalFilename

--- a/image-processing/advanced-workflow/src/test/kotlin/io/bluetape4k/workshop/imageprocessing/advanced/persistence/AbstractImagePersistenceTest.kt
+++ b/image-processing/advanced-workflow/src/test/kotlin/io/bluetape4k/workshop/imageprocessing/advanced/persistence/AbstractImagePersistenceTest.kt
@@ -11,7 +11,7 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.DynamicPropertyRegistry
 import org.springframework.test.context.DynamicPropertySource
-import java.util.UUID
+import io.bluetape4k.codec.Base58
 
 /**
  * Abstract base class for image persistence integration tests.
@@ -37,7 +37,7 @@ abstract class AbstractImagePersistenceTest {
         @JvmStatic
         @DynamicPropertySource
         fun postgresProperties(registry: DynamicPropertyRegistry) {
-            registry.add("spring.datasource.url") { postgres.jdbcUrl!! }
+            registry.add("spring.datasource.url") { postgres.jdbcUrl }
             registry.add("spring.datasource.username") { postgres.username!! }
             registry.add("spring.datasource.password") { postgres.password!! }
         }
@@ -50,7 +50,7 @@ abstract class AbstractImagePersistenceTest {
      * one get test isolation for free.
      */
     protected fun buildMetadata(
-        checksum: String = "sha256-${UUID.randomUUID()}",
+        checksum: String = "sha256-${Base58.randomString(12)}",
         filename: String? = "test.jpg",
         contentType: String? = "image/jpeg",
         byteSize: Long? = 12_345L,

--- a/image-processing/advanced-workflow/src/test/kotlin/io/bluetape4k/workshop/imageprocessing/advanced/persistence/ImageAssetRepositoryTest.kt
+++ b/image-processing/advanced-workflow/src/test/kotlin/io/bluetape4k/workshop/imageprocessing/advanced/persistence/ImageAssetRepositoryTest.kt
@@ -10,7 +10,7 @@ import io.bluetape4k.workshop.imageprocessing.advanced.model.JobStartResult
 import io.bluetape4k.workshop.imageprocessing.advanced.persistence.schema.ImageAssetStatus
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import java.util.UUID
+import io.bluetape4k.codec.Base58
 
 /**
  * Integration tests for [ImageAssetRepository] low-level operations.
@@ -26,13 +26,13 @@ class ImageAssetRepositoryTest : AbstractImagePersistenceTest() {
 
     @Test
     fun `findByExternalId - returns null when asset does not exist`() {
-        val result = service.findAssetByExternalId(UUID.randomUUID().toString())
+        val result = service.findAssetByExternalId(Base58.randomString(12))
         result.shouldBeNull()
     }
 
     @Test
     fun `findByExternalId - returns asset after creation via recordJobStart`() {
-        val checksum = "sha256-${UUID.randomUUID()}"
+        val checksum = "sha256-${Base58.randomString(12)}"
         val metadata = buildMetadata(checksum = checksum)
 
         val startResult = service.recordJobStart(metadata)
@@ -46,7 +46,7 @@ class ImageAssetRepositoryTest : AbstractImagePersistenceTest() {
 
     @Test
     fun `updateStatus - changes asset status to READY via recordJobSuccess`() {
-        val checksum = "sha256-${UUID.randomUUID()}"
+        val checksum = "sha256-${Base58.randomString(12)}"
         val metadata = buildMetadata(checksum = checksum)
 
         val startResult = service.recordJobStart(metadata)

--- a/image-processing/advanced-workflow/src/test/kotlin/io/bluetape4k/workshop/imageprocessing/advanced/persistence/ImagePersistenceServiceImplTest.kt
+++ b/image-processing/advanced-workflow/src/test/kotlin/io/bluetape4k/workshop/imageprocessing/advanced/persistence/ImagePersistenceServiceImplTest.kt
@@ -16,7 +16,7 @@ import io.bluetape4k.workshop.imageprocessing.advanced.persistence.schema.ImageP
 import io.bluetape4k.workshop.imageprocessing.advanced.persistence.schema.ImageProcessingStep
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import java.util.UUID
+import io.bluetape4k.codec.Base58
 
 /**
  * Integration tests for [ImagePersistenceService] — covers all saga steps and query paths.
@@ -37,7 +37,7 @@ class ImagePersistenceServiceImplTest : AbstractImagePersistenceTest() {
 
     @Test
     fun `recordJobStart - new asset creates NewAsset result`() {
-        val checksum = "sha256-${UUID.randomUUID()}"
+        val checksum = "sha256-${Base58.randomString(12)}"
         val metadata = buildMetadata(checksum = checksum)
 
         val result = service.recordJobStart(metadata)
@@ -51,7 +51,7 @@ class ImagePersistenceServiceImplTest : AbstractImagePersistenceTest() {
 
     @Test
     fun `recordJobStart - duplicate checksum READY returns AlreadyReady`() {
-        val checksum = "sha256-${UUID.randomUUID()}"
+        val checksum = "sha256-${Base58.randomString(12)}"
         val metadata = buildMetadata(checksum = checksum)
 
         val firstResult = service.recordJobStart(metadata)
@@ -69,7 +69,7 @@ class ImagePersistenceServiceImplTest : AbstractImagePersistenceTest() {
 
     @Test
     fun `recordJobStart - duplicate checksum PROCESSING returns ConcurrentProcessing`() {
-        val checksum = "sha256-${UUID.randomUUID()}"
+        val checksum = "sha256-${Base58.randomString(12)}"
         val metadata = buildMetadata(checksum = checksum)
 
         val firstResult = service.recordJobStart(metadata)
@@ -85,7 +85,7 @@ class ImagePersistenceServiceImplTest : AbstractImagePersistenceTest() {
 
     @Test
     fun `recordJobStart - duplicate checksum FAILED returns RecoveredFromFailed`() {
-        val checksum = "sha256-${UUID.randomUUID()}"
+        val checksum = "sha256-${Base58.randomString(12)}"
         val metadata = buildMetadata(checksum = checksum)
 
         val firstResult = service.recordJobStart(metadata)
@@ -112,7 +112,7 @@ class ImagePersistenceServiceImplTest : AbstractImagePersistenceTest() {
 
     @Test
     fun `recordJobSuccess - updates asset READY and persists image objects`() {
-        val checksum = "sha256-${UUID.randomUUID()}"
+        val checksum = "sha256-${Base58.randomString(12)}"
         val startResult = service.recordJobStart(buildMetadata(checksum = checksum))
         (startResult is JobStartResult.NewAsset).shouldBeTrue()
 
@@ -133,7 +133,7 @@ class ImagePersistenceServiceImplTest : AbstractImagePersistenceTest() {
 
     @Test
     fun `recordJobFailure - updates asset FAILED`() {
-        val checksum = "sha256-${UUID.randomUUID()}"
+        val checksum = "sha256-${Base58.randomString(12)}"
         val startResult = service.recordJobStart(buildMetadata(checksum = checksum))
         (startResult is JobStartResult.NewAsset).shouldBeTrue()
 
@@ -155,7 +155,7 @@ class ImagePersistenceServiceImplTest : AbstractImagePersistenceTest() {
 
     @Test
     fun `appendEvent - stores event row`() {
-        val checksum = "sha256-${UUID.randomUUID()}"
+        val checksum = "sha256-${Base58.randomString(12)}"
         val startResult = service.recordJobStart(buildMetadata(checksum = checksum))
         (startResult is JobStartResult.NewAsset).shouldBeTrue()
 
@@ -178,7 +178,7 @@ class ImagePersistenceServiceImplTest : AbstractImagePersistenceTest() {
 
     @Test
     fun `findAssetByExternalId - returns null for unknown externalId`() {
-        service.findAssetByExternalId(UUID.randomUUID().toString()).shouldBeNull()
+        service.findAssetByExternalId(Base58.randomString(12)).shouldBeNull()
     }
 
     // -------------------------------------------------------------------------
@@ -187,7 +187,7 @@ class ImagePersistenceServiceImplTest : AbstractImagePersistenceTest() {
 
     @Test
     fun `findAssetHistory - returns null for unknown externalId`() {
-        service.findAssetHistory(UUID.randomUUID().toString()).shouldBeNull()
+        service.findAssetHistory(Base58.randomString(12)).shouldBeNull()
     }
 
     // -------------------------------------------------------------------------
@@ -196,7 +196,7 @@ class ImagePersistenceServiceImplTest : AbstractImagePersistenceTest() {
 
     @Test
     fun `findAssetHistory - returns full job and event history`() {
-        val checksum = "sha256-${UUID.randomUUID()}"
+        val checksum = "sha256-${Base58.randomString(12)}"
         val startResult = service.recordJobStart(buildMetadata(checksum = checksum))
         (startResult is JobStartResult.NewAsset).shouldBeTrue()
         val identity = JobIdentity(jobId = startResult.jobId, assetId = startResult.assetId)

--- a/image-processing/advanced-workflow/src/test/kotlin/io/bluetape4k/workshop/imageprocessing/advanced/persistence/ImageProcessingJobRepositoryTest.kt
+++ b/image-processing/advanced-workflow/src/test/kotlin/io/bluetape4k/workshop/imageprocessing/advanced/persistence/ImageProcessingJobRepositoryTest.kt
@@ -11,7 +11,7 @@ import io.bluetape4k.workshop.imageprocessing.advanced.model.JobStartResult
 import io.bluetape4k.workshop.imageprocessing.advanced.persistence.schema.ImageJobStatus
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import java.util.UUID
+import io.bluetape4k.codec.Base58
 
 /**
  * Integration tests for the processing-job history path exposed through [ImagePersistenceService].
@@ -30,14 +30,14 @@ class ImageProcessingJobRepositoryTest : AbstractImagePersistenceTest() {
 
     @Test
     fun `findAssetHistory - returns null for unknown externalId`() {
-        val history = service.findAssetHistory(UUID.randomUUID().toString())
+        val history = service.findAssetHistory(Base58.randomString(12))
         // Soft assert: result is null — history is absent for unknown asset
         (history == null).shouldBeTrue()
     }
 
     @Test
     fun `findAssetHistory - contains one RUNNING job after recordJobStart`() {
-        val checksum = "sha256-${UUID.randomUUID()}"
+        val checksum = "sha256-${Base58.randomString(12)}"
         val startResult = service.recordJobStart(buildMetadata(checksum = checksum))
         (startResult is JobStartResult.NewAsset).shouldBeTrue()
 
@@ -50,7 +50,7 @@ class ImageProcessingJobRepositoryTest : AbstractImagePersistenceTest() {
 
     @Test
     fun `findAssetHistory - job status is SUCCEEDED after recordJobSuccess`() {
-        val checksum = "sha256-${UUID.randomUUID()}"
+        val checksum = "sha256-${Base58.randomString(12)}"
         val startResult = service.recordJobStart(buildMetadata(checksum = checksum))
         (startResult is JobStartResult.NewAsset).shouldBeTrue()
 
@@ -66,7 +66,7 @@ class ImageProcessingJobRepositoryTest : AbstractImagePersistenceTest() {
 
     @Test
     fun `findAssetHistory - job status is FAILED after recordJobFailure`() {
-        val checksum = "sha256-${UUID.randomUUID()}"
+        val checksum = "sha256-${Base58.randomString(12)}"
         val startResult = service.recordJobStart(buildMetadata(checksum = checksum))
         (startResult is JobStartResult.NewAsset).shouldBeTrue()
 

--- a/image-processing/advanced-workflow/src/test/kotlin/io/bluetape4k/workshop/imageprocessing/advanced/service/ImageProcessingTestSupport.kt
+++ b/image-processing/advanced-workflow/src/test/kotlin/io/bluetape4k/workshop/imageprocessing/advanced/service/ImageProcessingTestSupport.kt
@@ -25,7 +25,7 @@ import kotlinx.coroutines.flow.emptyFlow
 import java.nio.file.Path
 import java.time.Duration
 import java.time.Instant
-import java.util.UUID
+import io.bluetape4k.codec.Base58
 
 internal fun testProperties(
     publicBaseUrl: String = "http://localhost:8080/public-images",
@@ -119,7 +119,7 @@ internal class StubImagePersistenceService(
         startResultFn?.invoke() ?: JobStartResult.NewAsset(
             assetId = 1L,
             jobId = 1L,
-            externalId = UUID.randomUUID().toString(),
+            externalId = Base58.randomString(12),
         )
 
     override fun recordJobSuccess(identity: JobIdentity, objects: List<ImageObjectInput>) {}

--- a/io/okio-examples/src/main/kotlin/io/bluetape4k/okio/coroutines/RealBufferedSuspendedSink.kt
+++ b/io/okio-examples/src/main/kotlin/io/bluetape4k/okio/coroutines/RealBufferedSuspendedSink.kt
@@ -3,6 +3,7 @@ package io.bluetape4k.okio.coroutines
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.okio.SEGMENT_SIZE
 import kotlinx.atomicfu.atomic
+import kotlinx.coroutines.CancellationException
 import okio.Buffer
 import okio.ByteString
 import okio.Timeout
@@ -149,11 +150,15 @@ internal class RealBufferedSuspendedSink(private val sink: SuspendedSink): Buffe
             if (buffer.size > 0L) {
                 sink.write(buffer, buffer.size)
             }
+        } catch (e: CancellationException) {
+            thrown = e
         } catch (e: Throwable) {
             thrown = e
         }
         try {
             sink.close()
+        } catch (e: CancellationException) {
+            thrown = thrown ?: e
         } catch (e: Throwable) {
             thrown = thrown ?: e
         }

--- a/io/okio-examples/src/main/kotlin/io/bluetape4k/okio/coroutines/SuspendedSocketChannelSource.kt
+++ b/io/okio-examples/src/main/kotlin/io/bluetape4k/okio/coroutines/SuspendedSocketChannelSource.kt
@@ -4,6 +4,7 @@ import io.bluetape4k.coroutines.support.awaitSuspending
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
 import io.bluetape4k.okio.SEGMENT_SIZE
+import io.bluetape4k.support.requireZeroOrPositiveNumber
 import kotlinx.coroutines.coroutineScope
 import okio.Buffer
 import java.nio.ByteBuffer
@@ -21,7 +22,7 @@ class SuspendedSocketChannelSource(
     private val byteBuffer = ByteBuffer.allocateDirect(SEGMENT_SIZE.toInt())
 
     override suspend fun read(sink: Buffer, byteCount: Long): Long {
-        require(byteCount >= 0) { "byteCount must be zero or positive, but was $byteCount" }
+        byteCount.requireZeroOrPositiveNumber("byteCount")
 
         if (!channel.isOpen) return -1L
 

--- a/io/okio-examples/src/main/kotlin/io/bluetape4k/okio/coroutines/internal/ForwardBlockingSink.kt
+++ b/io/okio-examples/src/main/kotlin/io/bluetape4k/okio/coroutines/internal/ForwardBlockingSink.kt
@@ -35,9 +35,7 @@ internal class ForwardBlockingSink(
 
     override fun close() = runBlocking(context) {
         withTimeoutOrNull(timeout) {
-            runBlocking(context) {
-                delegate.close()
-            }
+            delegate.close()
         } ?: Unit
     }
 }

--- a/io/okio-examples/src/test/kotlin/io/bluetape4k/okio/BufferCursorTest.kt
+++ b/io/okio-examples/src/test/kotlin/io/bluetape4k/okio/BufferCursorTest.kt
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 import java.util.*
-import kotlin.test.assertFailsWith
+import io.bluetape4k.assertions.assertFailsWith
 
 class BufferCursorTest: AbstractOkioTest() {
 

--- a/io/okio-examples/src/test/kotlin/io/bluetape4k/okio/BufferKotlinTest.kt
+++ b/io/okio-examples/src/test/kotlin/io/bluetape4k/okio/BufferKotlinTest.kt
@@ -7,7 +7,7 @@ import io.bluetape4k.support.asByte
 import okio.Buffer
 import io.bluetape4k.assertions.shouldBeEqualTo
 import org.junit.jupiter.api.Test
-import kotlin.test.assertFailsWith
+import io.bluetape4k.assertions.assertFailsWith
 
 class BufferKotlinTest: AbstractOkioTest() {
 

--- a/io/okio-examples/src/test/kotlin/io/bluetape4k/okio/BufferTest.kt
+++ b/io/okio-examples/src/test/kotlin/io/bluetape4k/okio/BufferTest.kt
@@ -15,7 +15,7 @@ import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.nio.ByteBuffer
 import java.util.*
-import kotlin.test.assertFailsWith
+import io.bluetape4k.assertions.assertFailsWith
 
 class BufferTest: AbstractOkioTest() {
 

--- a/io/okio-examples/src/test/kotlin/io/bluetape4k/okio/DeflaterSinkTest.kt
+++ b/io/okio-examples/src/test/kotlin/io/bluetape4k/okio/DeflaterSinkTest.kt
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.RepeatedTest
 import org.junit.jupiter.api.Test
 import java.util.zip.InflaterInputStream
 import kotlin.random.Random
-import kotlin.test.assertFailsWith
+import io.bluetape4k.assertions.assertFailsWith
 
 class DeflaterSinkTest: AbstractOkioTest() {
 

--- a/io/okio-examples/src/test/kotlin/io/bluetape4k/okio/coroutines/BufferedSuspendedSinkTest.kt
+++ b/io/okio-examples/src/test/kotlin/io/bluetape4k/okio/coroutines/BufferedSuspendedSinkTest.kt
@@ -7,7 +7,7 @@ import okio.Buffer
 import okio.Timeout
 import io.bluetape4k.assertions.shouldBeEqualTo
 import org.junit.jupiter.api.Test
-import kotlin.test.assertFailsWith
+import io.bluetape4k.assertions.assertFailsWith
 
 class BufferedSuspendedSinkTest: AbstractOkioTest() {
 

--- a/io/okio-examples/src/test/kotlin/io/bluetape4k/okio/coroutines/BufferedSuspendedSourceTest.kt
+++ b/io/okio-examples/src/test/kotlin/io/bluetape4k/okio/coroutines/BufferedSuspendedSourceTest.kt
@@ -11,7 +11,7 @@ import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.assertions.shouldBeTrue
 import org.junit.jupiter.api.Test
-import kotlin.test.assertFailsWith
+import io.bluetape4k.assertions.assertFailsWith
 
 class BufferedSuspendedSourceTest: AbstractOkioTest() {
 

--- a/io/okio-examples/src/test/kotlin/io/bluetape4k/okio/coroutines/SuspendedFileChannelSinkTest.kt
+++ b/io/okio-examples/src/test/kotlin/io/bluetape4k/okio/coroutines/SuspendedFileChannelSinkTest.kt
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.RepeatedTest
 import java.nio.ByteBuffer
 import java.nio.channels.AsynchronousFileChannel
 import java.nio.file.StandardOpenOption
-import kotlin.test.assertFailsWith
+import io.bluetape4k.assertions.assertFailsWith
 
 @TempFolderTest
 class SuspendedFileChannelSinkTest: AbstractOkioTest() {

--- a/io/okio-examples/src/test/kotlin/io/bluetape4k/okio/coroutines/SuspendedPipeTest.kt
+++ b/io/okio-examples/src/test/kotlin/io/bluetape4k/okio/coroutines/SuspendedPipeTest.kt
@@ -10,7 +10,7 @@ import okio.Buffer
 import okio.IOException
 import io.bluetape4k.assertions.shouldBeEqualTo
 import org.junit.jupiter.api.Test
-import kotlin.test.assertFailsWith
+import io.bluetape4k.assertions.assertFailsWith
 
 class SuspendedPipeTest: AbstractOkioTest() {
 

--- a/io/okio-examples/src/test/kotlin/io/bluetape4k/okio/coroutines/SuspendedSocketTest.kt
+++ b/io/okio-examples/src/test/kotlin/io/bluetape4k/okio/coroutines/SuspendedSocketTest.kt
@@ -19,7 +19,7 @@ import java.nio.channels.SelectionKey
 import java.nio.channels.ServerSocketChannel
 import java.nio.channels.SocketChannel
 import java.util.concurrent.TimeUnit
-import kotlin.test.assertFailsWith
+import io.bluetape4k.assertions.assertFailsWith
 import kotlin.test.junit5.JUnit5Asserter.fail
 
 class SuspendedSocketTest: AbstractOkioTest() {

--- a/kotlin/coroutines/src/test/kotlin/io/bluetape4k/workshop/coroutines/channels/ChannelExamples.kt
+++ b/kotlin/coroutines/src/test/kotlin/io/bluetape4k/workshop/coroutines/channels/ChannelExamples.kt
@@ -1,6 +1,6 @@
 package io.bluetape4k.workshop.coroutines.channels
 
-import io.bluetape4k.codec.encodeBase62
+import io.bluetape4k.codec.Base58
 import io.bluetape4k.coroutines.support.log
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
@@ -20,7 +20,6 @@ import kotlinx.coroutines.test.runTest
 import io.bluetape4k.assertions.shouldBeEqualTo
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import java.util.*
 import java.util.concurrent.CopyOnWriteArrayList
 
 class ChannelExamples {
@@ -332,7 +331,7 @@ class ChannelExamples {
 
             channels.forEachIndexed { index, channel ->
                 launch {
-                    sendString(channel, UUID.randomUUID().encodeBase62(), 200L)
+                    sendString(channel, Base58.randomString(8), 200L)
                 }.log(index)
             }
 

--- a/kotlin/coroutines/src/test/kotlin/io/bluetape4k/workshop/coroutines/flow/CallbackFlowExamples.kt
+++ b/kotlin/coroutines/src/test/kotlin/io/bluetape4k/workshop/coroutines/flow/CallbackFlowExamples.kt
@@ -1,7 +1,7 @@
 package io.bluetape4k.workshop.coroutines.flow
 
 import io.bluetape4k.coroutines.flow.extensions.log
-import io.bluetape4k.coroutines.tests.assertResult
+import io.bluetape4k.assertions.coroutines.assertResult
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
 import kotlinx.coroutines.delay

--- a/kotlin/coroutines/src/test/kotlin/io/bluetape4k/workshop/coroutines/flow/FlowBuilderExamples.kt
+++ b/kotlin/coroutines/src/test/kotlin/io/bluetape4k/workshop/coroutines/flow/FlowBuilderExamples.kt
@@ -2,7 +2,7 @@ package io.bluetape4k.workshop.coroutines.flow
 
 import app.cash.turbine.test
 import io.bluetape4k.coroutines.flow.extensions.log
-import io.bluetape4k.coroutines.tests.assertResult
+import io.bluetape4k.assertions.coroutines.assertResult
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
 import kotlinx.coroutines.coroutineScope

--- a/kotlin/coroutines/src/test/kotlin/io/bluetape4k/workshop/coroutines/tests/TurbineExamples.kt
+++ b/kotlin/coroutines/src/test/kotlin/io/bluetape4k/workshop/coroutines/tests/TurbineExamples.kt
@@ -14,7 +14,7 @@ import kotlinx.coroutines.withContext
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeInstanceOf
 import org.junit.jupiter.api.Test
-import kotlin.test.assertFailsWith
+import io.bluetape4k.assertions.assertFailsWith
 import kotlin.time.Duration.Companion.milliseconds
 
 class TurbineExamples {

--- a/kotlin/design-patterns/src/test/kotlin/io/bluetape4k/workshop/kotlin/designPatterns/singleton/SingletonTest.kt
+++ b/kotlin/design-patterns/src/test/kotlin/io/bluetape4k/workshop/kotlin/designPatterns/singleton/SingletonTest.kt
@@ -16,7 +16,6 @@ import org.junit.jupiter.api.condition.JRE
 import org.junit.jupiter.api.parallel.Execution
 import org.junit.jupiter.api.parallel.ExecutionMode
 import java.util.concurrent.CopyOnWriteArrayList
-import kotlin.test.assertTrue
 
 /**
  * Singleton Instance를 생성하는 테스트를 제공합니다.
@@ -35,9 +34,9 @@ abstract class AbstractSingletonTest<T>(private val singletonInstanceMethod: () 
         val instance2 = singletonInstanceMethod()
         val instance3 = singletonInstanceMethod()
 
-        assertTrue { instance1 === instance2 }
-        assertTrue { instance2 === instance3 }
-        assertTrue { instance1 === instance3 }
+        (instance1 === instance2).shouldBeTrue()
+        (instance2 === instance3).shouldBeTrue()
+        (instance1 === instance3).shouldBeTrue()
     }
 
     @Test

--- a/ktor/rest-coroutines/src/test/kotlin/io/bluetape4k/workshop/ktor/repository/InMemoryBookRepositoryTest.kt
+++ b/ktor/rest-coroutines/src/test/kotlin/io/bluetape4k/workshop/ktor/repository/InMemoryBookRepositoryTest.kt
@@ -13,7 +13,7 @@ import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.assertions.shouldNotBeNull
 import org.junit.jupiter.api.Test
-import kotlin.test.assertFailsWith
+import io.bluetape4k.assertions.assertFailsWith
 
 class InMemoryBookRepositoryTest : AbstractKtorTest() {
 

--- a/ktor/rest-coroutines/src/test/kotlin/io/bluetape4k/workshop/ktor/service/BookServiceTest.kt
+++ b/ktor/rest-coroutines/src/test/kotlin/io/bluetape4k/workshop/ktor/service/BookServiceTest.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.test.runTest
 import io.bluetape4k.assertions.shouldBeEqualTo
 import org.junit.jupiter.api.Test
-import kotlin.test.assertFailsWith
+import io.bluetape4k.assertions.assertFailsWith
 
 class BookServiceTest : AbstractKtorTest() {
 

--- a/leader/leader-election/src/test/kotlin/io/bluetape4k/workshop/leader/DuplicateLockNameTest.kt
+++ b/leader/leader-election/src/test/kotlin/io/bluetape4k/workshop/leader/DuplicateLockNameTest.kt
@@ -5,7 +5,7 @@ import io.bluetape4k.workshop.leader.job.LeaderGuardedJob
 import io.bluetape4k.workshop.leader.job.LeaderScheduledJobService
 import io.mockk.mockk
 import org.junit.jupiter.api.Test
-import kotlin.test.assertFailsWith
+import io.bluetape4k.assertions.assertFailsWith
 
 /**
  * P3-11: Duplicate lockName detection unit test.

--- a/leader/leader-election/src/test/kotlin/io/bluetape4k/workshop/leader/LeaderElectionJobRecoveryTest.kt
+++ b/leader/leader-election/src/test/kotlin/io/bluetape4k/workshop/leader/LeaderElectionJobRecoveryTest.kt
@@ -4,7 +4,7 @@ import io.bluetape4k.assertions.shouldNotBeNull
 import io.bluetape4k.assertions.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 import java.util.UUID
-import kotlin.test.assertFailsWith
+import io.bluetape4k.assertions.assertFailsWith
 
 /**
  * T3: Leader re-election after job failure.

--- a/leader/leader-election/src/test/kotlin/io/bluetape4k/workshop/leader/LockAssertTest.kt
+++ b/leader/leader-election/src/test/kotlin/io/bluetape4k/workshop/leader/LockAssertTest.kt
@@ -5,7 +5,7 @@ import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldNotBeNull
 import io.bluetape4k.leader.LockAssert
 import io.bluetape4k.workshop.leader.job.LockAssertJob
-import kotlin.test.assertFailsWith
+import io.bluetape4k.assertions.assertFailsWith
 import org.junit.jupiter.api.Test
 import java.util.UUID
 

--- a/leader/leader-election/src/test/kotlin/io/bluetape4k/workshop/leader/PropertiesValidationTest.kt
+++ b/leader/leader-election/src/test/kotlin/io/bluetape4k/workshop/leader/PropertiesValidationTest.kt
@@ -4,7 +4,7 @@ import io.bluetape4k.workshop.leader.config.LeaderElectionProperties
 import io.bluetape4k.assertions.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 import java.time.Duration
-import kotlin.test.assertFailsWith
+import io.bluetape4k.assertions.assertFailsWith
 
 /**
  * P3-13: [LeaderElectionProperties] `init {}` validation test.

--- a/leader/leader-election/src/test/kotlin/io/bluetape4k/workshop/leader/RedisFailureTest.kt
+++ b/leader/leader-election/src/test/kotlin/io/bluetape4k/workshop/leader/RedisFailureTest.kt
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test
 import org.testcontainers.containers.GenericContainer
 import java.time.Duration
 import java.util.UUID
-import kotlin.test.assertFailsWith
+import io.bluetape4k.assertions.assertFailsWith
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 

--- a/ratelimit/bucker4j-bluetape4k-webflux/src/test/kotlin/io/bluetape4k/workshop/bucket4j/controller/CoroutineControllerTest.kt
+++ b/ratelimit/bucker4j-bluetape4k-webflux/src/test/kotlin/io/bluetape4k/workshop/bucket4j/controller/CoroutineControllerTest.kt
@@ -1,16 +1,16 @@
 package io.bluetape4k.workshop.bucket4j.controller
 
+import io.bluetape4k.assertions.shouldContain
+import io.bluetape4k.codec.Base58
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.workshop.bucket4j.AbstractRateLimiterApplicationTest
 import io.bluetape4k.workshop.bucket4j.utils.HeaderUtils
 import kotlinx.coroutines.reactive.awaitSingle
-import kotlinx.coroutines.test.runTest
-import io.bluetape4k.assertions.shouldContain
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus
 import org.springframework.test.web.reactive.server.returnResult
-import org.testcontainers.utility.Base58
 
 class CoroutineControllerTest: AbstractRateLimiterApplicationTest() {
 
@@ -21,7 +21,7 @@ class CoroutineControllerTest: AbstractRateLimiterApplicationTest() {
     }
 
     @Test
-    fun `사용자 ID 기분으로 RateLimit이 적용됩니다`() = runTest {
+    fun `사용자 ID 기분으로 RateLimit이 적용됩니다`() = runSuspendIO {
         val userId = "coroutines.debop." + Base58.randomString(6)
 
         // 10초 동안 10번으로 Rate Limit이 걸려 있음
@@ -48,7 +48,7 @@ class CoroutineControllerTest: AbstractRateLimiterApplicationTest() {
 
     @Disabled("IP 로 Rate Limit을 거는 것은 /coroutines/v1, /reactive/v1 둘 다 걸려서 동시에 테스트 할 수 없습니다.")
     @Test
-    fun `사용자 ID가 없으면 IP Address 기준으로 RateLimit이 적용됩니다`() = runTest {
+    fun `사용자 ID가 없으면 IP Address 기준으로 RateLimit이 적용됩니다`() = runSuspendIO {
         // 10초 동안 10번으로 Rate Limit이 걸려 있음
         // WebFilter 2개가 걸려있어서, 5번만 호출해도 10개의 Token이 소비됩니다.
         repeat(LIMIT_COUNT) {
@@ -70,7 +70,7 @@ class CoroutineControllerTest: AbstractRateLimiterApplicationTest() {
     }
 
     @Test
-    fun `RateLimit에 적용되지 않은 경로에는 제한이 없습니다`() = runTest {
+    fun `RateLimit에 적용되지 않은 경로에는 제한이 없습니다`() = runSuspendIO {
         val userId = "coroutines.debop." + Base58.randomString(6)
 
         // 10초 동안 10번으로 Rate Limit이 걸려 있음

--- a/ratelimit/bucker4j-bluetape4k-webflux/src/test/kotlin/io/bluetape4k/workshop/bucket4j/controller/ReactiveControllerTest.kt
+++ b/ratelimit/bucker4j-bluetape4k-webflux/src/test/kotlin/io/bluetape4k/workshop/bucket4j/controller/ReactiveControllerTest.kt
@@ -1,12 +1,12 @@
 package io.bluetape4k.workshop.bucket4j.controller
 
+import io.bluetape4k.assertions.shouldContain
 import io.bluetape4k.codec.Base58
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.workshop.bucket4j.AbstractRateLimiterApplicationTest
 import io.bluetape4k.workshop.bucket4j.utils.HeaderUtils
 import kotlinx.coroutines.reactive.awaitSingle
-import kotlinx.coroutines.test.runTest
-import io.bluetape4k.assertions.shouldContain
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus
@@ -21,7 +21,7 @@ class ReactiveControllerTest: AbstractRateLimiterApplicationTest() {
     }
 
     @Test
-    fun `사용자 ID 기분으로 RateLimit이 적용됩니다`() = runTest {
+    fun `사용자 ID 기분으로 RateLimit이 적용됩니다`() = runSuspendIO {
         val userId = "coroutines.debop." + Base58.randomString(6)
 
         // 10초 동안 10번으로 Rate Limit이 걸려 있음
@@ -48,7 +48,7 @@ class ReactiveControllerTest: AbstractRateLimiterApplicationTest() {
 
     @Disabled("IP 로 Rate Limit을 거는 것은 /coroutines/v1, /reactive/v1 둘 다 걸려서 동시에 테스트 할 수 없습니다.")
     @Test
-    fun `사용자 ID가 없으면 IP Address 기준으로 RateLimit이 적용됩니다`() = runTest {
+    fun `사용자 ID가 없으면 IP Address 기준으로 RateLimit이 적용됩니다`() = runSuspendIO {
         // 10초 동안 10번으로 Rate Limit이 걸려 있음
         // WebFilter 2개가 걸려있어서, 5번만 호출해도 10개의 Token이 소비됩니다.
         repeat(LIMIT_COUNT) {
@@ -70,7 +70,7 @@ class ReactiveControllerTest: AbstractRateLimiterApplicationTest() {
     }
 
     @Test
-    fun `RateLimit에 적용되지 않은 경로에는 제한이 없습니다`() = runTest {
+    fun `RateLimit에 적용되지 않은 경로에는 제한이 없습니다`() = runSuspendIO {
         val userId = "coroutines.debop." + Base58.randomString(6)
 
         // 10초 동안 10번으로 Rate Limit이 걸려 있음

--- a/ratelimit/bucket4j-advanced/src/test/kotlin/io/bluetape4k/workshop/bucket4j/advanced/RateLimitDemoControllerTest.kt
+++ b/ratelimit/bucket4j-advanced/src/test/kotlin/io/bluetape4k/workshop/bucket4j/advanced/RateLimitDemoControllerTest.kt
@@ -1,15 +1,18 @@
 package io.bluetape4k.workshop.bucket4j.advanced
 
+import io.bluetape4k.assertions.shouldBeGreaterOrEqualTo
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.codec.Base58
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
 import io.bluetape4k.workshop.bucket4j.advanced.utils.HeaderConstants
-import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.MethodOrderer
 import org.junit.jupiter.api.Order
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestMethodOrder
 import org.springframework.http.HttpStatus
-import org.testcontainers.utility.Base58
 
 /**
  * Integration tests for [RateLimitDemoController] validating all three rate-limit strategies.
@@ -38,7 +41,7 @@ class RateLimitDemoControllerTest : AbstractBucket4jAdvancedTest() {
 
     @Test
     @Order(10)
-    fun `IP rate limit - anonymous endpoint returns 200 with remaining header`() = runTest {
+    fun `IP rate limit - anonymous endpoint returns 200 with remaining header`() = runSuspendIO {
         val response = client.get()
             .uri(ANONYMOUS_PATH)
             .exchange()
@@ -50,12 +53,12 @@ class RateLimitDemoControllerTest : AbstractBucket4jAdvancedTest() {
 
         val remaining = response.responseHeaders.getFirst(HeaderConstants.X_RATELIMIT_REMAINING)?.toLongOrNull()
         log.debug { "IP remaining=$remaining" }
-        assert(remaining != null && remaining >= 0) { "X-RateLimit-Remaining must be a non-negative number" }
+        remaining.shouldNotBeNull() shouldBeGreaterOrEqualTo 0L
     }
 
     @Test
     @Order(11)
-    fun `IP rate limit - X-Forwarded-For is ignored when trust-proxy is false (default)`() = runTest {
+    fun `IP rate limit - X-Forwarded-For is ignored when trust-proxy is false (default)`() = runSuspendIO {
         // When trust-proxy=false, the X-Forwarded-For header is ignored.
         // The real TCP remote address (127.0.0.1) is used instead.
         // We verify that the spoofed IP has no effect: response is 200 or 429 (real-IP bucket),
@@ -67,14 +70,12 @@ class RateLimitDemoControllerTest : AbstractBucket4jAdvancedTest() {
             .returnResult(String::class.java)
 
         val status = result.status
-        assert(status == HttpStatus.OK || status == HttpStatus.TOO_MANY_REQUESTS) {
-            "Expected 200 or 429 (real-IP bucket), but got $status — spoofed XFF must not cause 4xx/5xx errors"
-        }
+        (status == HttpStatus.OK || status == HttpStatus.TOO_MANY_REQUESTS).shouldBeTrue()
     }
 
     @Test
     @Order(99)  // runs last — drains the shared 127.0.0.1 IP bucket
-    fun `IP rate limit - exhausts bucket and returns 429`() = runTest {
+    fun `IP rate limit - exhausts bucket and returns 429`() = runSuspendIO {
         var exhausted = false
         repeat(30) {
             val status = client.get()
@@ -88,12 +89,12 @@ class RateLimitDemoControllerTest : AbstractBucket4jAdvancedTest() {
                 return@repeat
             }
         }
-        assert(exhausted) { "Expected HTTP 429 after exhausting IP rate limit bucket" }
+        exhausted.shouldBeTrue()
     }
 
     @Test
     @Order(100) // runs after exhaustion — verifies Retry-After is in the 429 response
-    fun `IP rate limit - 429 response includes Retry-After header`() = runTest {
+    fun `IP rate limit - 429 response includes Retry-After header`() = runSuspendIO {
         // Bucket is already exhausted from previous test; any request should return 429.
         repeat(30) {
             val result = client.get()
@@ -102,10 +103,9 @@ class RateLimitDemoControllerTest : AbstractBucket4jAdvancedTest() {
                 .returnResult(String::class.java)
 
             if (result.status == HttpStatus.TOO_MANY_REQUESTS) {
-                val retryAfter = result.responseHeaders.getFirst(HeaderConstants.RETRY_AFTER)
-                assert(retryAfter != null) { "Retry-After header must be present in 429 response" }
-                assert(retryAfter!!.toLong() >= 1) { "Retry-After must be at least 1 second" }
-                return@runTest
+                val retryAfter = result.responseHeaders.getFirst(HeaderConstants.RETRY_AFTER).shouldNotBeNull()
+                retryAfter.toLong() shouldBeGreaterOrEqualTo 1L
+                return@runSuspendIO
             }
         }
     }
@@ -116,7 +116,7 @@ class RateLimitDemoControllerTest : AbstractBucket4jAdvancedTest() {
 
     @Test
     @Order(20)
-    fun `user rate limit - authenticated endpoint returns 200 for valid user`() = runTest {
+    fun `user rate limit - authenticated endpoint returns 200 for valid user`() = runSuspendIO {
         val userId = "user-" + Base58.randomString(8)
 
         client.get()
@@ -129,7 +129,7 @@ class RateLimitDemoControllerTest : AbstractBucket4jAdvancedTest() {
 
     @Test
     @Order(21)
-    fun `user rate limit - missing X-User-ID returns 401`() = runTest {
+    fun `user rate limit - missing X-User-ID returns 401`() = runSuspendIO {
         client.get()
             .uri(AUTHENTICATED_PATH)
             .exchange()
@@ -138,7 +138,7 @@ class RateLimitDemoControllerTest : AbstractBucket4jAdvancedTest() {
 
     @Test
     @Order(22)
-    fun `user rate limit - different users have independent buckets`() = runTest {
+    fun `user rate limit - different users have independent buckets`() = runSuspendIO {
         val userId1 = "independent-a-" + Base58.randomString(6)
         val userId2 = "independent-b-" + Base58.randomString(6)
 
@@ -157,7 +157,7 @@ class RateLimitDemoControllerTest : AbstractBucket4jAdvancedTest() {
 
     @Test
     @Order(23)
-    fun `user rate limit - exhausts per-user bucket and returns 429`() = runTest {
+    fun `user rate limit - exhausts per-user bucket and returns 429`() = runSuspendIO {
         val userId = "exhaust-" + Base58.randomString(8)
         var exhausted = false
 
@@ -174,7 +174,7 @@ class RateLimitDemoControllerTest : AbstractBucket4jAdvancedTest() {
                 return@repeat
             }
         }
-        assert(exhausted) { "Expected HTTP 429 after exhausting user rate limit bucket for userId=$userId" }
+        exhausted.shouldBeTrue()
     }
 
     // ------------------------------------------------------------------
@@ -183,7 +183,7 @@ class RateLimitDemoControllerTest : AbstractBucket4jAdvancedTest() {
 
     @Test
     @Order(30)
-    fun `combined rate limit - sensitive endpoint returns 200 with both ip and user`() = runTest {
+    fun `combined rate limit - sensitive endpoint returns 200 with both ip and user`() = runSuspendIO {
         val userId = "combined-" + Base58.randomString(8)
 
         client.get()
@@ -196,7 +196,7 @@ class RateLimitDemoControllerTest : AbstractBucket4jAdvancedTest() {
 
     @Test
     @Order(31)
-    fun `combined rate limit - missing X-User-ID returns 400`() = runTest {
+    fun `combined rate limit - missing X-User-ID returns 400`() = runSuspendIO {
         client.get()
             .uri(SENSITIVE_PATH)
             .exchange()
@@ -205,7 +205,7 @@ class RateLimitDemoControllerTest : AbstractBucket4jAdvancedTest() {
 
     @Test
     @Order(32)
-    fun `combined rate limit - different user IDs have independent combined buckets`() = runTest {
+    fun `combined rate limit - different user IDs have independent combined buckets`() = runSuspendIO {
         val userId1 = "combo-a-" + Base58.randomString(6)
         val userId2 = "combo-b-" + Base58.randomString(6)
 
@@ -227,7 +227,7 @@ class RateLimitDemoControllerTest : AbstractBucket4jAdvancedTest() {
 
     @Test
     @Order(33)
-    fun `combined rate limit - exhausts combined bucket and returns 429`() = runTest {
+    fun `combined rate limit - exhausts combined bucket and returns 429`() = runSuspendIO {
         val userId = "combined-exhaust-" + Base58.randomString(8)
         var exhausted = false
 
@@ -244,6 +244,6 @@ class RateLimitDemoControllerTest : AbstractBucket4jAdvancedTest() {
                 return@repeat
             }
         }
-        assert(exhausted) { "Expected HTTP 429 after exhausting combined rate limit bucket for userId=$userId" }
+        exhausted.shouldBeTrue()
     }
 }

--- a/redis/distributed-lock/src/test/kotlin/io/bluetape4k/workshop/lock/AbstractDistributedLockTest.kt
+++ b/redis/distributed-lock/src/test/kotlin/io/bluetape4k/workshop/lock/AbstractDistributedLockTest.kt
@@ -1,5 +1,6 @@
 package io.bluetape4k.workshop.lock
 
+import io.bluetape4k.codec.Base58
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.testcontainers.storage.RedisServer
 import io.bluetape4k.workshop.lock.domain.InventoryStore
@@ -13,7 +14,6 @@ import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.TestInstance
 import org.redisson.api.RedissonClient
-import java.util.UUID
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 abstract class AbstractDistributedLockTest {
@@ -52,5 +52,5 @@ abstract class AbstractDistributedLockTest {
         runCatching { redisson.shutdown() }
     }
 
-    protected fun randomName(prefix: String = "test") = "$prefix-${UUID.randomUUID()}"
+    protected fun randomName(prefix: String = "test") = "$prefix-${Base58.randomString(8)}"
 }

--- a/redis/redisson-examples/src/test/kotlin/io/bluetape4k/workshop/redisson/collections/LocalCachedMapExamples.kt
+++ b/redis/redisson-examples/src/test/kotlin/io/bluetape4k/workshop/redisson/collections/LocalCachedMapExamples.kt
@@ -1,5 +1,6 @@
 package io.bluetape4k.workshop.redisson.collections
 
+import io.bluetape4k.codec.Base58
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.redis.redisson.cache.localCachedMap
 import io.bluetape4k.workshop.redisson.AbstractRedissonTest
@@ -13,7 +14,6 @@ import io.bluetape4k.assertions.shouldContainSame
 import org.junit.jupiter.api.Test
 import org.redisson.api.RLocalCachedMap
 import org.redisson.api.options.LocalCachedMapOptions
-import java.util.*
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.toJavaDuration
 
@@ -30,7 +30,7 @@ class LocalCachedMapExamples: AbstractRedissonTest() {
     @Test
     fun `simple local cached map`() = runTest {
         // Local cache 설정
-        val cachedMapName = "local:" + UUID.randomUUID().toString()
+        val cachedMapName = "local:${Base58.randomString(8)}"
         val cachedMap: RLocalCachedMap<String, Int> = localCachedMap(cachedMapName, redisson) {
             cacheSize(10000)
             evictionPolicy(LocalCachedMapOptions.EvictionPolicy.LRU)

--- a/shared/src/test/kotlin/io/bluetape4k/workshop/shared/web/RestClientExtensionsTest.kt
+++ b/shared/src/test/kotlin/io/bluetape4k/workshop/shared/web/RestClientExtensionsTest.kt
@@ -13,7 +13,7 @@ import org.springframework.web.client.HttpClientErrorException
 import org.springframework.web.client.RestClient
 import org.springframework.web.client.toEntity
 import kotlin.test.Test
-import kotlin.test.assertFailsWith
+import io.bluetape4k.assertions.assertFailsWith
 
 class RestClientExtensionsTest: AbstractSpringTest() {
 

--- a/shared/src/test/kotlin/io/bluetape4k/workshop/shared/web/WebClientExtensionsTest.kt
+++ b/shared/src/test/kotlin/io/bluetape4k/workshop/shared/web/WebClientExtensionsTest.kt
@@ -12,7 +12,7 @@ import org.springframework.web.reactive.function.client.WebClientResponseExcepti
 import org.springframework.web.reactive.function.client.awaitBody
 import org.springframework.web.reactive.function.client.awaitBodyOrNull
 import kotlin.test.Test
-import kotlin.test.assertFailsWith
+import io.bluetape4k.assertions.assertFailsWith
 
 class WebClientExtensionsTest: AbstractSpringTest() {
 

--- a/spring-boot/idempotency/build.gradle.kts
+++ b/spring-boot/idempotency/build.gradle.kts
@@ -14,7 +14,9 @@ configurations {
 dependencies {
     // bluetape4k
     implementation(libs.bluetape4k.jackson3)
+    implementation(libs.bluetape4k.core)
     implementation(libs.bluetape4k.coroutines)
+    implementation(libs.bluetape4k.idgenerators)
     implementation(libs.bluetape4k.redis)
     implementation(libs.bluetape4k.redisson)
     implementation(libs.bluetape4k.testcontainers)

--- a/spring-boot/idempotency/src/main/kotlin/io/bluetape4k/workshop/idempotency/service/IdempotencyService.kt
+++ b/spring-boot/idempotency/src/main/kotlin/io/bluetape4k/workshop/idempotency/service/IdempotencyService.kt
@@ -1,5 +1,6 @@
 package io.bluetape4k.workshop.idempotency.service
 
+import io.bluetape4k.idgenerators.uuid.Uuid
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.info
@@ -11,7 +12,6 @@ import kotlinx.coroutines.withContext
 import org.redisson.api.RedissonClient
 import org.springframework.stereotype.Service
 import java.time.Instant
-import java.util.UUID
 import java.util.concurrent.TimeUnit
 
 /**
@@ -53,7 +53,7 @@ class IdempotencyService(private val redisson: RedissonClient) {
 
             // Create a new order response
             val newResponse = OrderResponse(
-                orderId = UUID.randomUUID().toString(),
+                orderId = Uuid.V7.nextIdAsString(),
                 status = "CREATED",
                 processedAt = Instant.now(),
             )

--- a/spring-boot/idempotency/src/test/kotlin/io/bluetape4k/workshop/idempotency/controller/OrderControllerTest.kt
+++ b/spring-boot/idempotency/src/test/kotlin/io/bluetape4k/workshop/idempotency/controller/OrderControllerTest.kt
@@ -1,15 +1,15 @@
 package io.bluetape4k.workshop.idempotency.controller
 
-import io.bluetape4k.codec.Base58
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldHaveSize
 import io.bluetape4k.assertions.shouldNotBeEmpty
 import io.bluetape4k.assertions.shouldNotBeEqualTo
+import io.bluetape4k.codec.Base58
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.workshop.idempotency.AbstractIdempotencyTest
 import io.bluetape4k.workshop.idempotency.model.OrderRequest
 import io.bluetape4k.workshop.idempotency.model.OrderResponse
-import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
@@ -32,7 +32,7 @@ class OrderControllerTest : AbstractIdempotencyTest() {
     )
 
     @Test
-    fun `새 요청은 201 Created를 반환한다`() = runTest {
+    fun `새 요청은 201 Created를 반환한다`() = runSuspendIO {
         client.post()
             .uri(ORDERS_PATH)
             .header(IDEMPOTENCY_KEY_HEADER, newIdempotencyKey())
@@ -51,7 +51,7 @@ class OrderControllerTest : AbstractIdempotencyTest() {
     }
 
     @Test
-    fun `동일한 Idempotency-Key로 재전송하면 200 OK와 동일 응답을 반환한다`() = runTest {
+    fun `동일한 Idempotency-Key로 재전송하면 200 OK와 동일 응답을 반환한다`() = runSuspendIO {
         val key = newIdempotencyKey()
 
         // First request → 201 Created
@@ -85,7 +85,7 @@ class OrderControllerTest : AbstractIdempotencyTest() {
     }
 
     @Test
-    fun `다른 Idempotency-Key는 새로운 주문을 생성한다`() = runTest {
+    fun `다른 Idempotency-Key는 새로운 주문을 생성한다`() = runSuspendIO {
         val keyA = newIdempotencyKey()
         val keyB = newIdempotencyKey()
 
@@ -114,7 +114,7 @@ class OrderControllerTest : AbstractIdempotencyTest() {
     }
 
     @Test
-    fun `Idempotency-Key 헤더가 없으면 400 Bad Request를 반환한다`() = runTest {
+    fun `Idempotency-Key 헤더가 없으면 400 Bad Request를 반환한다`() = runSuspendIO {
         client.post()
             .uri(ORDERS_PATH)
             .contentType(MediaType.APPLICATION_JSON)
@@ -124,7 +124,7 @@ class OrderControllerTest : AbstractIdempotencyTest() {
     }
 
     @Test
-    fun `빈 Idempotency-Key 헤더는 400 Bad Request를 반환한다`() = runTest {
+    fun `빈 Idempotency-Key 헤더는 400 Bad Request를 반환한다`() = runSuspendIO {
         client.post()
             .uri(ORDERS_PATH)
             .header(IDEMPOTENCY_KEY_HEADER, "   ")
@@ -135,7 +135,7 @@ class OrderControllerTest : AbstractIdempotencyTest() {
     }
 
     @Test
-    fun `세 번 재전송해도 항상 동일한 응답을 반환한다`() = runTest {
+    fun `세 번 재전송해도 항상 동일한 응답을 반환한다`() = runSuspendIO {
         val key = newIdempotencyKey()
 
         val responses = (1..3).map {

--- a/spring-boot/idempotency/src/test/kotlin/io/bluetape4k/workshop/idempotency/controller/OrderControllerTest.kt
+++ b/spring-boot/idempotency/src/test/kotlin/io/bluetape4k/workshop/idempotency/controller/OrderControllerTest.kt
@@ -1,5 +1,6 @@
 package io.bluetape4k.workshop.idempotency.controller
 
+import io.bluetape4k.codec.Base58
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldHaveSize
 import io.bluetape4k.assertions.shouldNotBeEmpty
@@ -14,7 +15,6 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.test.web.reactive.server.returnResult
 import reactor.kotlin.core.publisher.toMono
-import java.util.UUID
 
 class OrderControllerTest : AbstractIdempotencyTest() {
 
@@ -23,7 +23,7 @@ class OrderControllerTest : AbstractIdempotencyTest() {
         private const val IDEMPOTENCY_KEY_HEADER = "Idempotency-Key"
     }
 
-    private fun newIdempotencyKey(): String = UUID.randomUUID().toString()
+    private fun newIdempotencyKey(): String = Base58.randomString(16)
 
     private val sampleRequest = OrderRequest(
         productId = "prod-001",

--- a/spring-boot/multi-tenant-data-isolation/src/main/kotlin/io/bluetape4k/workshop/multitenant/domain/TenantId.kt
+++ b/spring-boot/multi-tenant-data-isolation/src/main/kotlin/io/bluetape4k/workshop/multitenant/domain/TenantId.kt
@@ -1,5 +1,6 @@
 package io.bluetape4k.workshop.multitenant.domain
 
+import io.bluetape4k.support.requireNotBlank
 import java.io.Serializable
 
 /**
@@ -9,8 +10,8 @@ import java.io.Serializable
 value class TenantId(val value: String) : Serializable {
 
     init {
-        require(value.isNotBlank()) { "tenantId must not be blank" }
-        require(value.matches(Regex("[a-z0-9][a-z0-9-]{1,62}"))) {
+        value.requireNotBlank("tenantId")
+        require(value.matches(TENANT_ID_PATTERN)) {
             "tenantId must use lowercase letters, digits, or hyphens"
         }
     }
@@ -24,6 +25,7 @@ value class TenantId(val value: String) : Serializable {
 
     companion object {
         private const val serialVersionUID: Long = 104L
+        private val TENANT_ID_PATTERN = Regex("[a-z0-9][a-z0-9-]{1,62}")
 
         val ALPHA: TenantId = TenantId("tenant-alpha")
         val BETA: TenantId = TenantId("tenant-beta")

--- a/spring-boot/multi-tenant-data-isolation/src/main/kotlin/io/bluetape4k/workshop/multitenant/service/TenantRateLimiter.kt
+++ b/spring-boot/multi-tenant-data-isolation/src/main/kotlin/io/bluetape4k/workshop/multitenant/service/TenantRateLimiter.kt
@@ -27,10 +27,10 @@ class TenantRateLimiter(
         window: Duration = DEFAULT_WINDOW,
     ): RateLimitDecision {
         limit.requirePositiveNumber("limit")
-        require(!window.isZero && !window.isNegative) { "window must be positive" }
+        val windowMillis = window.toMillis()
+        windowMillis.requirePositiveNumber("windowMillis")
 
         val key = keyFactory.rateLimitKey(tenantId, principal)
-        val windowMillis = window.toMillis()
         val windowStart = (System.currentTimeMillis() / windowMillis) * windowMillis
         val bucket = buckets.compute(key) { _, current ->
             if (current?.windowStartEpochMillis == windowStart) {

--- a/spring-boot/multi-tenant-data-isolation/src/main/kotlin/io/bluetape4k/workshop/multitenant/service/TenantRateLimiter.kt
+++ b/spring-boot/multi-tenant-data-isolation/src/main/kotlin/io/bluetape4k/workshop/multitenant/service/TenantRateLimiter.kt
@@ -1,5 +1,6 @@
 package io.bluetape4k.workshop.multitenant.service
 
+import io.bluetape4k.support.requirePositiveNumber
 import io.bluetape4k.workshop.multitenant.domain.TenantId
 import org.springframework.stereotype.Component
 import java.io.Serializable
@@ -25,7 +26,7 @@ class TenantRateLimiter(
         limit: Int = DEFAULT_LIMIT,
         window: Duration = DEFAULT_WINDOW,
     ): RateLimitDecision {
-        require(limit > 0) { "limit must be positive" }
+        limit.requirePositiveNumber("limit")
         require(!window.isZero && !window.isNegative) { "window must be positive" }
 
         val key = keyFactory.rateLimitKey(tenantId, principal)

--- a/spring-boot/resilience4j-coroutines/src/main/kotlin/io/bluetape4k/workshop/resilience/service/coroutines/BackendBCoService.kt
+++ b/spring-boot/resilience4j-coroutines/src/main/kotlin/io/bluetape4k/workshop/resilience/service/coroutines/BackendBCoService.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.workshop.resilience.service.coroutines
 
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.workshop.resilience.exception.BusinessException
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
@@ -20,7 +21,13 @@ class BackendBCoService: CoService {
     }
 
     override suspend fun suspendFailureWithFallback(): String {
-        return runCatching { suspendFailure() }.getOrElse { "This is a fallback" }
+        return try {
+            suspendFailure()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            "This is a fallback"
+        }
     }
 
     override suspend fun suspendSuccessWithException(): String {

--- a/spring-data/elasticsearch-webflux/src/test/kotlin/io/bluetape4k/workshop/elasticsearch/domain/service/DefaultBookServiceTest.kt
+++ b/spring-data/elasticsearch-webflux/src/test/kotlin/io/bluetape4k/workshop/elasticsearch/domain/service/DefaultBookServiceTest.kt
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.data.elasticsearch.core.ReactiveElasticsearchOperations
-import kotlin.test.assertFailsWith
+import io.bluetape4k.assertions.assertFailsWith
 
 @Disabled("Elasticsearch Client 가 Jackson2 를 사용합니다. Spring Boot 4 는 Jackson 3를 사용해서 충돌이 발생합니다.")
 class DefaultBookServiceTest(

--- a/spring-data/r2dbc-examples/src/test/kotlin/io/bluetape4k/workshop/r2dbc/basics/TransactionalServiceIntegrationTest.kt
+++ b/spring-data/r2dbc-examples/src/test/kotlin/io/bluetape4k/workshop/r2dbc/basics/TransactionalServiceIntegrationTest.kt
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.r2dbc.core.DatabaseClient
-import kotlin.test.assertFailsWith
+import io.bluetape4k.assertions.assertFailsWith
 
 @SpringBootTest(classes = [InfrastructureConfiguration::class])
 class TransactionalServiceIntegrationTest @Autowired constructor(

--- a/spring-data/r2dbc-webflux-exposed/build.gradle.kts
+++ b/spring-data/r2dbc-webflux-exposed/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
 
     testImplementation(project(":shared"))
     testImplementation(libs.bluetape4k.junit5)
+    testImplementation(libs.exposed.r2dbc.tests)
 
     // R2DBC
     implementation(libs.r2dbc.h2)

--- a/spring-data/r2dbc-webflux-exposed/build.gradle.kts
+++ b/spring-data/r2dbc-webflux-exposed/build.gradle.kts
@@ -29,6 +29,8 @@ dependencies {
     testImplementation(project(":shared"))
     testImplementation(libs.bluetape4k.junit5)
     testImplementation(libs.exposed.r2dbc.tests)
+    testRuntimeOnly(libs.mysql.connector.j)
+    testRuntimeOnly(libs.postgresql.driver)
 
     // R2DBC
     implementation(libs.r2dbc.h2)

--- a/spring-data/r2dbc-webflux-exposed/src/main/kotlin/io/bluetape4k/workshop/exposed/r2dbc/config/ExposedR2dbcConfig.kt
+++ b/spring-data/r2dbc-webflux-exposed/src/main/kotlin/io/bluetape4k/workshop/exposed/r2dbc/config/ExposedR2dbcConfig.kt
@@ -7,11 +7,11 @@ import io.r2dbc.pool.ConnectionPool
 import io.r2dbc.pool.ConnectionPoolConfiguration
 import io.r2dbc.spi.ConnectionFactories
 import io.r2dbc.spi.ConnectionFactoryOptions
-import io.r2dbc.spi.Option
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import org.jetbrains.exposed.v1.r2dbc.R2dbcDatabase
 import org.jetbrains.exposed.v1.r2dbc.R2dbcDatabaseConfig
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Primary
@@ -33,21 +33,23 @@ class ExposedR2dbcConfig {
         // return Executors.newVirtualThreadPerTaskExecutor().asCoroutineDispatcher()
     }
 
-    /**
-     * H2 인메모리 데이터베이스용 ConnectionFactory를 생성합니다.
-     */
     @Bean
-    fun h2ConnectionFactoryOptions(): ConnectionFactoryOptions {
-        val options = ConnectionFactoryOptions.builder()
-            .option(ConnectionFactoryOptions.DRIVER, "h2")
-            .option(ConnectionFactoryOptions.PROTOCOL, "mem")
-            .option(ConnectionFactoryOptions.DATABASE, "test")
-            .option(Option.valueOf("DB_CLOSE_DELAY"), "-1")
-            .option(Option.valueOf("DB_CLOSE_ON_EXIT"), "FALSE")
-            //.option(Option.valueOf("MODE"), "PostgreSQL") // R2DBC 에서는 Mode 옵션이 제대로 동작하지 않음
+    fun connectionFactoryOptions(
+        @Value("\${spring.r2dbc.url:r2dbc:h2:mem:///test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE}") r2dbcUrl: String,
+        @Value("\${spring.r2dbc.username:}") username: String,
+        @Value("\${spring.r2dbc.password:}") password: String,
+    ): ConnectionFactoryOptions {
+        val builder = ConnectionFactoryOptions.parse(r2dbcUrl).mutate()
+        if (username.isNotBlank()) {
+            builder.option(ConnectionFactoryOptions.USER, username)
+        }
+        if (password.isNotBlank()) {
+            builder.option(ConnectionFactoryOptions.PASSWORD, password)
+        }
+        val options = builder
             .build()
 
-        log.info { "H2 연결 설정: ${options.toString().replace(Regex("password=.*?,"), "password=****,")}" }
+        log.info { "R2DBC 연결 설정: driver=${options.getValue(ConnectionFactoryOptions.DRIVER)}" }
         return options
     }
 

--- a/spring-data/r2dbc-webflux-exposed/src/main/kotlin/io/bluetape4k/workshop/exposed/r2dbc/handler/UserHandler.kt
+++ b/spring-data/r2dbc-webflux-exposed/src/main/kotlin/io/bluetape4k/workshop/exposed/r2dbc/handler/UserHandler.kt
@@ -6,6 +6,7 @@ import io.bluetape4k.support.asIntOrNull
 import io.bluetape4k.workshop.exposed.r2dbc.domain.ErrorMessage
 import io.bluetape4k.workshop.exposed.r2dbc.domain.model.UserRecord
 import io.bluetape4k.workshop.exposed.r2dbc.service.UserService
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.reactor.awaitSingleOrNull
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Component
@@ -59,11 +60,7 @@ class UserHandler(private val service: UserService) {
     }
 
     suspend fun addUser(request: ServerRequest): ServerResponse {
-        val newUser: UserRecord = runCatching {
-            request.bodyToMono<UserRecord>().awaitSingleOrNull()
-        }.onFailure {
-            log.error(it) { "Fail to decode body" }
-        }.getOrNull()
+        val newUser = request.decodeBodyOrNull<UserRecord>()
             ?: return errorResponse(HttpStatus.BAD_REQUEST, "Invalid body")
 
         return service.addUser(newUser)?.let { user ->
@@ -77,9 +74,7 @@ class UserHandler(private val service: UserService) {
             "`id` must be numeric"
         )
 
-        val userToUpdate: UserRecord = runCatching {
-            request.bodyToMono<UserRecord>().awaitSingleOrNull()
-        }.onFailure { log.error(it) { "Fail to decode body" } }.getOrNull()
+        val userToUpdate = request.decodeBodyOrNull<UserRecord>()
             ?: return errorResponse(HttpStatus.BAD_REQUEST, "Invalid body")
 
         return service.updateUser(id, userToUpdate)?.let { user ->
@@ -102,5 +97,16 @@ class UserHandler(private val service: UserService) {
         message: String,
     ): ServerResponse {
         return ServerResponse.status(status).json().bodyValueAndAwait(ErrorMessage(message))
+    }
+
+    private suspend inline fun <reified T: Any> ServerRequest.decodeBodyOrNull(): T? {
+        return try {
+            bodyToMono<T>().awaitSingleOrNull()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            log.error(e) { "Fail to decode body" }
+            null
+        }
     }
 }

--- a/spring-data/r2dbc-webflux-exposed/src/main/kotlin/io/bluetape4k/workshop/exposed/r2dbc/service/UserService.kt
+++ b/spring-data/r2dbc-webflux-exposed/src/main/kotlin/io/bluetape4k/workshop/exposed/r2dbc/service/UserService.kt
@@ -5,38 +5,42 @@ import io.bluetape4k.logging.debug
 import io.bluetape4k.workshop.exposed.r2dbc.domain.model.UserRecord
 import io.bluetape4k.workshop.exposed.r2dbc.domain.repository.UserExposedRepository
 import kotlinx.coroutines.flow.toList
+import org.jetbrains.exposed.v1.r2dbc.R2dbcDatabase
 import org.jetbrains.exposed.v1.r2dbc.transactions.suspendTransaction
 import org.springframework.stereotype.Service
 
 @Service
-class UserService(private val repository: UserExposedRepository) {
+class UserService(
+    private val database: R2dbcDatabase,
+    private val repository: UserExposedRepository,
+) {
 
     companion object: KLoggingChannel()
 
-    suspend fun findAll(): List<UserRecord> = suspendTransaction {
+    suspend fun findAll(): List<UserRecord> = suspendTransaction(db = database) {
         repository.findAll().toList()
     }
 
-    suspend fun findByIdOrNull(id: Int): UserRecord? = suspendTransaction {
+    suspend fun findByIdOrNull(id: Int): UserRecord? = suspendTransaction(db = database) {
         repository.findByIdOrNull(id)
     }
 
-    suspend fun findByEmail(email: String): List<UserRecord> = suspendTransaction {
+    suspend fun findByEmail(email: String): List<UserRecord> = suspendTransaction(db = database) {
         repository.findByEmail(email).toList()
     }
 
-    suspend fun addUser(user: UserRecord): UserRecord? = suspendTransaction {
+    suspend fun addUser(user: UserRecord): UserRecord? = suspendTransaction(db = database) {
         log.debug { "Save new user. $user" }
         val newId = repository.save(user)
         user.withId(newId.value)
     }
 
-    suspend fun updateUser(id: Int, user: UserRecord): UserRecord? = suspendTransaction {
+    suspend fun updateUser(id: Int, user: UserRecord): UserRecord? = suspendTransaction(db = database) {
         val count = repository.update(user.withId(id))
         if (count > 0) user else null
     }
 
-    suspend fun deleteUser(id: Int): Boolean = suspendTransaction {
+    suspend fun deleteUser(id: Int): Boolean = suspendTransaction(db = database) {
         repository.deleteById(id) > 0
     }
 }

--- a/spring-data/r2dbc-webflux-exposed/src/test/kotlin/io/bluetape4k/workshop/exposed/r2dbc/AbstractWebfluxR2dbcExposedApplicationTest.kt
+++ b/spring-data/r2dbc-webflux-exposed/src/test/kotlin/io/bluetape4k/workshop/exposed/r2dbc/AbstractWebfluxR2dbcExposedApplicationTest.kt
@@ -1,5 +1,6 @@
 package io.bluetape4k.workshop.exposed.r2dbc
 
+import io.bluetape4k.exposed.r2dbc.tests.TestDB
 import io.bluetape4k.junit5.faker.Fakers
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.support.uninitialized
@@ -7,14 +8,28 @@ import io.bluetape4k.workshop.exposed.r2dbc.domain.model.UserRecord
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.context.ApplicationContext
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
 import org.springframework.test.web.reactive.server.WebTestClient
 
+@ActiveProfiles("postgres")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 abstract class AbstractWebfluxR2dbcExposedApplicationTest {
 
     companion object: KLoggingChannel() {
+        private val testDB = TestDB.POSTGRESQL
+
         @JvmStatic
         val faker = Fakers.faker
+
+        @JvmStatic
+        @DynamicPropertySource
+        fun r2dbcProperties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.r2dbc.url") { testDB.connection() }
+            registry.add("spring.r2dbc.username") { testDB.user }
+            registry.add("spring.r2dbc.password") { testDB.pass }
+        }
     }
 
     @Autowired

--- a/spring-data/r2dbc-webflux-exposed/src/test/kotlin/io/bluetape4k/workshop/exposed/r2dbc/controller/UserControllerTest.kt
+++ b/spring-data/r2dbc-webflux-exposed/src/test/kotlin/io/bluetape4k/workshop/exposed/r2dbc/controller/UserControllerTest.kt
@@ -12,7 +12,7 @@ import io.bluetape4k.workshop.shared.web.httpPut
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.reactive.asFlow
 import kotlinx.coroutines.reactive.awaitSingle
-import kotlinx.coroutines.test.runTest
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldContain
@@ -34,7 +34,7 @@ class UserControllerTest(
     @Nested
     inner class Find {
         @Test
-        fun `find all users as Flow`() = runTest {
+        fun `find all users as Flow`() = runSuspendIO {
             val users = webTestClient
                 .httpGet("/api/users")
                 .expectStatus().is2xxSuccessful
@@ -47,7 +47,7 @@ class UserControllerTest(
         }
 
         @Test
-        fun `find by id - existing user`() = runTest {
+        fun `find by id - existing user`() = runSuspendIO {
             val user = webTestClient
                 .httpGet("/api/users/1")
                 .expectStatus().is2xxSuccessful
@@ -59,7 +59,7 @@ class UserControllerTest(
         }
 
         @Test
-        fun `find by id - non-existing user`() = runTest {
+        fun `find by id - non-existing user`() = runSuspendIO {
             val message = webTestClient
                 .httpGet("/api/users/9999")
                 .expectStatus().isNotFound
@@ -71,7 +71,7 @@ class UserControllerTest(
         }
 
         @Test
-        fun `find by id - non-numeric id`() = runTest {
+        fun `find by id - non-numeric id`() = runSuspendIO {
             val message = webTestClient
                 .httpGet("/api/users/abc")
                 .expectStatus().isBadRequest
@@ -86,7 +86,7 @@ class UserControllerTest(
     @Nested
     inner class Search {
         @Test
-        fun `search by valid email returns Users`() = runTest {
+        fun `search by valid email returns Users`() = runSuspendIO {
             val searchEmail = "user2@users.com"
 
             val searchedUsers = webTestClient
@@ -101,7 +101,7 @@ class UserControllerTest(
         }
 
         @Test
-        fun `search by empty email returns Users`() = runTest {
+        fun `search by empty email returns Users`() = runSuspendIO {
             val searchEmail = ""
 
             webTestClient
@@ -112,7 +112,7 @@ class UserControllerTest(
         }
 
         @Test
-        fun `search without email returns Users`() = runTest {
+        fun `search without email returns Users`() = runSuspendIO {
             webTestClient
                 .get()
                 .uri("/api/users/search")
@@ -124,7 +124,7 @@ class UserControllerTest(
     @Nested
     inner class Add {
         @Test
-        fun `add new user`() = runTest {
+        fun `add new user`() = runSuspendIO {
             val newUser = createUserRecord()
 
             val savedUser = webTestClient
@@ -138,7 +138,7 @@ class UserControllerTest(
         }
 
         @Test
-        fun `add new user with invalid format`() = runTest {
+        fun `add new user with invalid format`() = runSuspendIO {
             val newUser = "new user"
 
             webTestClient
@@ -150,7 +150,7 @@ class UserControllerTest(
     @Nested
     inner class Update {
         @Test
-        fun `update existing user`() = runTest {
+        fun `update existing user`() = runSuspendIO {
             val newUser = createUserRecord()
             val savedUser = service.addUser(newUser)!!
 
@@ -167,7 +167,7 @@ class UserControllerTest(
         }
 
         @Test
-        fun `update non-existing user`() = runTest {
+        fun `update non-existing user`() = runSuspendIO {
             val userToUpdate = createUserRecord()
 
             webTestClient
@@ -176,7 +176,7 @@ class UserControllerTest(
         }
 
         @Test
-        fun `update user with invalid format`() = runTest {
+        fun `update user with invalid format`() = runSuspendIO {
             val userToUpdate = "new user"
             webTestClient
                 .httpPut("/api/users/2", userToUpdate)
@@ -184,7 +184,7 @@ class UserControllerTest(
         }
 
         @Test
-        fun `update user with invalid id`() = runTest {
+        fun `update user with invalid id`() = runSuspendIO {
             val userToUpdate = "new user"
             webTestClient
                 .httpPut("/api/users/abc", userToUpdate)
@@ -195,7 +195,7 @@ class UserControllerTest(
     @Nested
     inner class Delete {
         @Test
-        fun `delete existing user`() = runTest {
+        fun `delete existing user`() = runSuspendIO {
             val newUser = createUserRecord()
             val savedUser = service.addUser(newUser)!!
 
@@ -208,14 +208,14 @@ class UserControllerTest(
         }
 
         @Test
-        fun `delete non-existing user`() = runTest {
+        fun `delete non-existing user`() = runSuspendIO {
             webTestClient
                 .httpDelete("/api/users/9999")
                 .expectStatus().isNotFound
         }
 
         @Test
-        fun `delete by non-numeric id`() = runTest {
+        fun `delete by non-numeric id`() = runSuspendIO {
             webTestClient
                 .httpDelete("/api/users/abc")
                 .expectStatus().isBadRequest

--- a/spring-data/r2dbc-webflux-exposed/src/test/kotlin/io/bluetape4k/workshop/exposed/r2dbc/domain/repository/UserExposedRepositoryHarnessTest.kt
+++ b/spring-data/r2dbc-webflux-exposed/src/test/kotlin/io/bluetape4k/workshop/exposed/r2dbc/domain/repository/UserExposedRepositoryHarnessTest.kt
@@ -1,0 +1,54 @@
+package io.bluetape4k.workshop.exposed.r2dbc.domain.repository
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldHaveSize
+import io.bluetape4k.exposed.r2dbc.tests.AbstractExposedR2dbcTest
+import io.bluetape4k.exposed.r2dbc.tests.TestDB
+import io.bluetape4k.exposed.r2dbc.tests.withTables
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.workshop.exposed.r2dbc.domain.model.UserRecord
+import io.bluetape4k.workshop.exposed.r2dbc.domain.schema.UserSchema.UserTable
+import kotlinx.coroutines.flow.toList
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+
+class UserExposedRepositoryHarnessTest: AbstractExposedR2dbcTest() {
+
+    private fun createUser(testDB: TestDB) = UserRecord(
+        name = faker.name().fullName(),
+        login = "${testDB.name.lowercase()}-${faker.credentials().username()}",
+        email = faker.internet().emailAddress(),
+        avatar = faker.avatar().image()
+    )
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource(ENABLE_DIALECTS_METHOD)
+    fun `repository saves and finds users across enabled r2dbc dialects`(testDB: TestDB) = runSuspendIO {
+        withTables(testDB, UserTable) {
+            val repository = UserExposedRepository()
+            val newUser = createUser(testDB)
+
+            val savedId = repository.save(newUser).value
+            val saved = repository.findById(savedId)
+
+            saved shouldBeEqualTo newUser.withId(savedId)
+            repository.existsById(savedId).shouldBeTrue()
+            repository.findByEmail(newUser.email).toList() shouldHaveSize 1
+        }
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource(ENABLE_DIALECTS_METHOD)
+    fun `repository updates users across enabled r2dbc dialects`(testDB: TestDB) = runSuspendIO {
+        withTables(testDB, UserTable) {
+            val repository = UserExposedRepository()
+            val savedId = repository.save(createUser(testDB)).value
+            val changed = repository.findById(savedId).copy(avatar = "updated-avatar.jpg")
+
+            repository.update(changed) shouldBeEqualTo 1
+
+            repository.findById(savedId) shouldBeEqualTo changed
+        }
+    }
+}

--- a/spring-data/r2dbc-webflux-exposed/src/test/kotlin/io/bluetape4k/workshop/exposed/r2dbc/handler/UserHandlerIT.kt
+++ b/spring-data/r2dbc-webflux-exposed/src/test/kotlin/io/bluetape4k/workshop/exposed/r2dbc/handler/UserHandlerIT.kt
@@ -12,7 +12,7 @@ import io.bluetape4k.workshop.shared.web.httpPut
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.reactive.asFlow
 import kotlinx.coroutines.reactive.awaitSingle
-import kotlinx.coroutines.test.runTest
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldHaveSize
@@ -37,7 +37,7 @@ class UserHandlerIT(
     @Nested
     inner class Find {
         @Test
-        fun `find all users`() = runTest {
+        fun `find all users`() = runSuspendIO {
             val users = webTestClient
                 .httpGet("/users")
                 .expectStatus().is2xxSuccessful
@@ -51,7 +51,7 @@ class UserHandlerIT(
         }
 
         @Test
-        fun `find by id - exsting user`() = runTest {
+        fun `find by id - exsting user`() = runSuspendIO {
             val user = webTestClient
                 .httpGet("/users/1")
                 .expectStatus().is2xxSuccessful
@@ -63,14 +63,14 @@ class UserHandlerIT(
         }
 
         @Test
-        fun `find by id - non-exsting user`() = runTest {
+        fun `find by id - non-exsting user`() = runSuspendIO {
             webTestClient
                 .httpGet("/users/9999")
                 .expectStatus().isNotFound
         }
 
         @Test
-        fun `find by id - invalid user id`() = runTest {
+        fun `find by id - invalid user id`() = runSuspendIO {
             webTestClient
                 .httpGet("/users/user_id")
                 .expectStatus().isBadRequest
@@ -82,7 +82,7 @@ class UserHandlerIT(
     @Nested
     inner class Search {
         @Test
-        fun `search by email`() = runTest {
+        fun `search by email`() = runSuspendIO {
             val searchEmail = "user2@users.com"
 
             val searchedUsers = webTestClient
@@ -96,7 +96,7 @@ class UserHandlerIT(
         }
 
         @Test
-        fun `search by empty email returns BadReqeust`() = runTest {
+        fun `search by empty email returns BadReqeust`() = runSuspendIO {
             val searchEmail = ""
             webTestClient
                 .httpGet("/users/search?email=$searchEmail")
@@ -106,7 +106,7 @@ class UserHandlerIT(
         }
 
         @Test
-        fun `search without params return BadRequest`() = runTest {
+        fun `search without params return BadRequest`() = runSuspendIO {
             webTestClient
                 .httpGet("/users/search")
                 .expectStatus().isBadRequest
@@ -118,7 +118,7 @@ class UserHandlerIT(
     @Nested
     inner class Add {
         @Test
-        fun `add new user`() = runTest {
+        fun `add new user`() = runSuspendIO {
             val newUser = createUserRecord()
 
             val savedUser = webTestClient
@@ -132,7 +132,7 @@ class UserHandlerIT(
         }
 
         @Test
-        fun `add new user with bad format`() = runTest {
+        fun `add new user with bad format`() = runSuspendIO {
             val newUser = "bad format"
 
             webTestClient
@@ -146,7 +146,7 @@ class UserHandlerIT(
     @Nested
     inner class Update {
         @Test
-        fun `update existing user`() = runTest {
+        fun `update existing user`() = runSuspendIO {
             val newUser = createUserRecord()
             val savedUser = service.addUser(newUser)!!
 
@@ -162,7 +162,7 @@ class UserHandlerIT(
         }
 
         @Test
-        fun `update with non-numeric id`() = runTest {
+        fun `update with non-numeric id`() = runSuspendIO {
             val userToUpdate = createUserRecord()
 
             webTestClient
@@ -173,7 +173,7 @@ class UserHandlerIT(
         }
 
         @Test
-        fun `update with invalid userDTO`() = runTest {
+        fun `update with invalid userDTO`() = runSuspendIO {
             val userToUpdate = "bad format"
 
             webTestClient
@@ -185,7 +185,7 @@ class UserHandlerIT(
 
 
         @Test
-        fun `update non-existing user`() = runTest {
+        fun `update non-existing user`() = runSuspendIO {
             val userToUpdate = createUserRecord()
 
             webTestClient
@@ -199,7 +199,7 @@ class UserHandlerIT(
     @Nested
     inner class Delete {
         @Test
-        fun `delete existing user`() = runTest {
+        fun `delete existing user`() = runSuspendIO {
             val newUser = createUserRecord()
             val savedUser = service.addUser(newUser)!!
 
@@ -212,7 +212,7 @@ class UserHandlerIT(
         }
 
         @Test
-        fun `delete non-existing user`() = runTest {
+        fun `delete non-existing user`() = runSuspendIO {
             webTestClient
                 .httpDelete("/users/9999")
                 .expectStatus().isNotFound
@@ -221,7 +221,7 @@ class UserHandlerIT(
         }
 
         @Test
-        fun `delete user with non-numeric id`() = runTest {
+        fun `delete user with non-numeric id`() = runSuspendIO {
             webTestClient
                 .httpDelete("/users/abc")
                 .expectStatus().isBadRequest

--- a/spring-data/r2dbc-webflux-exposed/src/test/kotlin/io/bluetape4k/workshop/exposed/r2dbc/handler/UserHandlerTest.kt
+++ b/spring-data/r2dbc-webflux-exposed/src/test/kotlin/io/bluetape4k/workshop/exposed/r2dbc/handler/UserHandlerTest.kt
@@ -8,7 +8,7 @@ import io.mockk.clearMocks
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
-import kotlinx.coroutines.test.runTest
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.assertions.shouldBeEqualTo
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -33,7 +33,7 @@ class UserHandlerTest: AbstractWebfluxR2dbcExposedApplicationTest() {
     }
 
     @Test
-    fun `find all users`() = runTest {
+    fun `find all users`() = runSuspendIO {
         coEvery { service.findAll() } returns listOf(createUser(id = 1), createUser(id = 2))
 
         val response = handler.findAll(request)
@@ -41,7 +41,7 @@ class UserHandlerTest: AbstractWebfluxR2dbcExposedApplicationTest() {
     }
 
     @Test
-    fun `when user is not exists, returns empty flow`() = runTest {
+    fun `when user is not exists, returns empty flow`() = runSuspendIO {
         coEvery { service.findAll() } returns emptyList()
 
         val response = handler.findAll(request)
@@ -49,7 +49,7 @@ class UserHandlerTest: AbstractWebfluxR2dbcExposedApplicationTest() {
     }
 
     @Test
-    fun `find by id return OK`() = runTest {
+    fun `find by id return OK`() = runSuspendIO {
         coEvery { request.pathVariable("id") } returns "1"
         coEvery { service.findByIdOrNull(1) } returns createUser(1)
 
@@ -59,7 +59,7 @@ class UserHandlerTest: AbstractWebfluxR2dbcExposedApplicationTest() {
     }
 
     @Test
-    fun `find by id non exists return NotFound`() = runTest {
+    fun `find by id non exists return NotFound`() = runSuspendIO {
         coEvery { request.pathVariable("id") } returns "-1"
         coEvery { service.findByIdOrNull(-1) } returns null
 
@@ -68,7 +68,7 @@ class UserHandlerTest: AbstractWebfluxR2dbcExposedApplicationTest() {
     }
 
     @Test
-    fun `when path variable is not numeric returns BadRequest`() = runTest {
+    fun `when path variable is not numeric returns BadRequest`() = runSuspendIO {
         coEvery { request.pathVariable("id") } returns "id"
         coEvery { service.findByIdOrNull(any()) } returns createUser(id = 1)
 
@@ -78,7 +78,7 @@ class UserHandlerTest: AbstractWebfluxR2dbcExposedApplicationTest() {
     }
 
     @Test
-    fun `add new user returns OK`() = runTest {
+    fun `add new user returns OK`() = runSuspendIO {
         coEvery { request.bodyToMono<UserRecord>() } returns createUserRecord().toMono()
         coEvery { service.addUser(any()) } answers {
             firstArg<UserRecord>().copy(id = 999)
@@ -89,7 +89,7 @@ class UserHandlerTest: AbstractWebfluxR2dbcExposedApplicationTest() {
     }
 
     @Test
-    fun `when invalid body to addUser returns BadRequest`() = runTest {
+    fun `when invalid body to addUser returns BadRequest`() = runSuspendIO {
         coEvery { request.bodyToMono<UserRecord>() } returns Mono.empty()
 
         val response = handler.addUser(request)
@@ -97,7 +97,7 @@ class UserHandlerTest: AbstractWebfluxR2dbcExposedApplicationTest() {
     }
 
     @Test
-    fun `when error in saveUser returns InternalServerError`() = runTest {
+    fun `when error in saveUser returns InternalServerError`() = runSuspendIO {
         coEvery { service.addUser(any()) } returns null
         coEvery { request.bodyToMono<UserRecord>() } returns createUserRecord().toMono()
 
@@ -106,7 +106,7 @@ class UserHandlerTest: AbstractWebfluxR2dbcExposedApplicationTest() {
     }
 
     @Test
-    fun `when update existing user returns OK`() = runTest {
+    fun `when update existing user returns OK`() = runSuspendIO {
         coEvery { request.pathVariable("id") } returns "2"
         coEvery { request.bodyToMono<UserRecord>() } returns createUserRecord().toMono()
         coEvery { service.updateUser(2, any()) } answers {
@@ -118,7 +118,7 @@ class UserHandlerTest: AbstractWebfluxR2dbcExposedApplicationTest() {
     }
 
     @Test
-    fun `when provide non numeric id to updateUser returns BadRequest`() = runTest {
+    fun `when provide non numeric id to updateUser returns BadRequest`() = runSuspendIO {
         coEvery { request.pathVariable("id") } returns "NOT-NUMERIC"
 
         val response = handler.updateUser(request)
@@ -126,7 +126,7 @@ class UserHandlerTest: AbstractWebfluxR2dbcExposedApplicationTest() {
     }
 
     @Test
-    fun `when empty body to updateUser returns BadRequest`() = runTest {
+    fun `when empty body to updateUser returns BadRequest`() = runSuspendIO {
         coEvery { request.pathVariable("id") } returns "2"
         coEvery { request.bodyToMono<UserRecord>() } returns Mono.empty()
 
@@ -135,7 +135,7 @@ class UserHandlerTest: AbstractWebfluxR2dbcExposedApplicationTest() {
     }
 
     @Test
-    fun `when update non-existing user returns BadRequest`() = runTest {
+    fun `when update non-existing user returns BadRequest`() = runSuspendIO {
         coEvery { request.pathVariable("id") } returns "2"
         coEvery { request.bodyToMono<UserRecord>() } returns createUserRecord().toMono()
         coEvery { service.updateUser(2, any()) } returns null
@@ -145,7 +145,7 @@ class UserHandlerTest: AbstractWebfluxR2dbcExposedApplicationTest() {
     }
 
     @Test
-    fun `when delete user is success returns NoContent`() = runTest {
+    fun `when delete user is success returns NoContent`() = runSuspendIO {
         coEvery { request.pathVariable("id") } returns "2"
         coEvery { service.deleteUser(2) } returns true
 
@@ -154,7 +154,7 @@ class UserHandlerTest: AbstractWebfluxR2dbcExposedApplicationTest() {
     }
 
     @Test
-    fun `when delete non-existing user returns NotFound`() = runTest {
+    fun `when delete non-existing user returns NotFound`() = runSuspendIO {
         coEvery { request.pathVariable("id") } returns "999"
         coEvery { service.deleteUser(999) } returns false
 
@@ -163,7 +163,7 @@ class UserHandlerTest: AbstractWebfluxR2dbcExposedApplicationTest() {
     }
 
     @Test
-    fun `when delete user with invalid id type returns BadRequest`() = runTest {
+    fun `when delete user with invalid id type returns BadRequest`() = runSuspendIO {
         coEvery { request.pathVariable("id") } returns "NON-NUMERIC"
 
         val response = handler.deleteUser(request)

--- a/spring-data/r2dbc-webflux-exposed/src/test/kotlin/io/bluetape4k/workshop/exposed/r2dbc/service/UserServiceTest.kt
+++ b/spring-data/r2dbc-webflux-exposed/src/test/kotlin/io/bluetape4k/workshop/exposed/r2dbc/service/UserServiceTest.kt
@@ -5,7 +5,7 @@ import io.bluetape4k.logging.debug
 import io.bluetape4k.workshop.exposed.r2dbc.AbstractWebfluxR2dbcExposedApplicationTest
 import io.bluetape4k.workshop.exposed.r2dbc.domain.repository.UserExposedRepository
 import io.r2dbc.spi.ConnectionFactory
-import kotlinx.coroutines.test.runTest
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.assertions.shouldBeEmpty
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeFalse
@@ -39,7 +39,7 @@ class UserServiceTest(
 
     @Test
     @Order(2)
-    fun `find all users`() = runTest {
+    fun `find all users`() = runSuspendIO {
         val users = service.findAll()
         users.forEach {
             log.debug { it }
@@ -49,7 +49,7 @@ class UserServiceTest(
 
     @Test
     @Order(3)
-    fun `find user by id`() = runTest {
+    fun `find user by id`() = runSuspendIO {
         val expected = service.findAll().random()
 
         val actual = service.findByIdOrNull(expected.id)
@@ -59,14 +59,14 @@ class UserServiceTest(
 
     @Test
     @Order(4)
-    fun `find user by invalid id`() = runTest {
+    fun `find user by invalid id`() = runSuspendIO {
         val actual = service.findByIdOrNull(-1)
         actual.shouldBeNull()
     }
 
     @Test
     @Order(5)
-    fun `find user by email`() = runTest {
+    fun `find user by email`() = runSuspendIO {
         val expected = service.findAll().random()
 
         val actual = service.findByEmail(expected.email).single()
@@ -76,14 +76,14 @@ class UserServiceTest(
 
     @Test
     @Order(6)
-    fun `find user by invalid email`() = runTest {
+    fun `find user by invalid email`() = runSuspendIO {
         val notFounds = service.findByEmail("not-exists@example.com").toList()
         notFounds.shouldBeEmpty()
     }
 
     @Test
     @Order(7)
-    fun `add new user`() = runTest {
+    fun `add new user`() = runSuspendIO {
         val newUser = createUserRecord()
         val savedUser = service.addUser(newUser)
 
@@ -94,7 +94,7 @@ class UserServiceTest(
 
     @Test
     @Order(8)
-    fun `update existing user`() = runTest {
+    fun `update existing user`() = runSuspendIO {
         val user = service.findAll().random()
 
         val updated = service.updateUser(user.id, user.copy(avatar = "updated-avatar.jpg"))
@@ -110,7 +110,7 @@ class UserServiceTest(
 
     @Test
     @Order(9)
-    fun `update non existing user`() = runTest {
+    fun `update non existing user`() = runSuspendIO {
         val nonExists = createUserRecord()
         val actual = service.updateUser(-1, nonExists)
         actual.shouldBeNull()
@@ -118,7 +118,7 @@ class UserServiceTest(
 
     @Test
     @Order(10)
-    fun `delete existing user`() = runTest {
+    fun `delete existing user`() = runSuspendIO {
         val user = createUserRecord()
         val saved = service.addUser(user)
 
@@ -131,7 +131,7 @@ class UserServiceTest(
 
     @Test
     @Order(11)
-    fun `delete non-existing user`() = runTest {
+    fun `delete non-existing user`() = runSuspendIO {
         service.deleteUser(-1).shouldBeFalse()
     }
 }

--- a/spring-data/r2dbc-webflux/src/main/kotlin/io/bluetape4k/workshop/r2dbc/handler/UserHandler.kt
+++ b/spring-data/r2dbc-webflux/src/main/kotlin/io/bluetape4k/workshop/r2dbc/handler/UserHandler.kt
@@ -6,6 +6,7 @@ import io.bluetape4k.support.asIntOrNull
 import io.bluetape4k.workshop.r2dbc.domain.ErrorMessage
 import io.bluetape4k.workshop.r2dbc.domain.UserDTO
 import io.bluetape4k.workshop.r2dbc.service.UserService
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.reactor.awaitSingleOrNull
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Component
@@ -60,11 +61,7 @@ class UserHandler(private val service: UserService) {
     }
 
     suspend fun addUser(request: ServerRequest): ServerResponse {
-        val newUser: UserDTO = runCatching {
-            request.bodyToMono<UserDTO>().awaitSingleOrNull()
-        }.onFailure {
-            log.error(it) { "Fail to decode body" }
-        }.getOrNull()
+        val newUser = request.decodeBodyOrNull<UserDTO>()
             ?: return errorResponse(HttpStatus.BAD_REQUEST, "Invalid body")
 
         return service.addUser(newUser)?.let { user ->
@@ -78,9 +75,7 @@ class UserHandler(private val service: UserService) {
             "`id` must be numeric"
         )
 
-        val userToUpdate: UserDTO = runCatching {
-            request.bodyToMono<UserDTO>().awaitSingleOrNull()
-        }.onFailure { log.error(it) { "Fail to decode body" } }.getOrNull()
+        val userToUpdate = request.decodeBodyOrNull<UserDTO>()
             ?: return errorResponse(HttpStatus.BAD_REQUEST, "Invalid body")
 
         return service.updateUser(id, userToUpdate)?.let { user ->
@@ -103,5 +98,16 @@ class UserHandler(private val service: UserService) {
         message: String,
     ): ServerResponse {
         return ServerResponse.status(status).json().bodyValueAndAwait(ErrorMessage(message))
+    }
+
+    private suspend inline fun <reified T: Any> ServerRequest.decodeBodyOrNull(): T? {
+        return try {
+            bodyToMono<T>().awaitSingleOrNull()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            log.error(e) { "Fail to decode body" }
+            null
+        }
     }
 }

--- a/spring-data/r2dbc-webflux/src/test/kotlin/io/bluetape4k/workshop/r2dbc/controller/UserControllerTest.kt
+++ b/spring-data/r2dbc-webflux/src/test/kotlin/io/bluetape4k/workshop/r2dbc/controller/UserControllerTest.kt
@@ -9,7 +9,7 @@ import io.bluetape4k.workshop.r2dbc.service.UserService
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.reactive.asFlow
 import kotlinx.coroutines.reactive.awaitSingle
-import kotlinx.coroutines.test.runTest
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldContain
@@ -31,7 +31,7 @@ class UserControllerTest(
     @Nested
     inner class Find {
         @Test
-        fun `find all users as Flow`() = runTest {
+        fun `find all users as Flow`() = runSuspendIO {
             val users = webTestClient
                 .get()
                 .uri("/api/users")
@@ -46,7 +46,7 @@ class UserControllerTest(
         }
 
         @Test
-        fun `find by id - existing user`() = runTest {
+        fun `find by id - existing user`() = runSuspendIO {
             val user = webTestClient
                 .get()
                 .uri("/api/users/1")
@@ -60,7 +60,7 @@ class UserControllerTest(
         }
 
         @Test
-        fun `find by id - non-existing user`() = runTest {
+        fun `find by id - non-existing user`() = runSuspendIO {
             val message = webTestClient
                 .get()
                 .uri("/api/users/9999")
@@ -74,7 +74,7 @@ class UserControllerTest(
         }
 
         @Test
-        fun `find by id - non-numeric id`() = runTest {
+        fun `find by id - non-numeric id`() = runSuspendIO {
             val message = webTestClient
                 .get()
                 .uri("/api/users/abc")
@@ -91,7 +91,7 @@ class UserControllerTest(
     @Nested
     inner class Search {
         @Test
-        fun `search by valid email returns Users`() = runTest {
+        fun `search by valid email returns Users`() = runSuspendIO {
             val searchEmail = "user2@users.com"
 
             val searchedUsers = webTestClient
@@ -108,7 +108,7 @@ class UserControllerTest(
         }
 
         @Test
-        fun `search by empty email returns Users`() = runTest {
+        fun `search by empty email returns Users`() = runSuspendIO {
             val searchEmail = ""
 
             webTestClient
@@ -119,7 +119,7 @@ class UserControllerTest(
         }
 
         @Test
-        fun `search without email returns Users`() = runTest {
+        fun `search without email returns Users`() = runSuspendIO {
             webTestClient
                 .get()
                 .uri("/api/users/search")
@@ -131,7 +131,7 @@ class UserControllerTest(
     @Nested
     inner class Add {
         @Test
-        fun `add new user`() = runTest {
+        fun `add new user`() = runSuspendIO {
             val newUser = createUserDTO()
 
             val savedUser = webTestClient
@@ -148,7 +148,7 @@ class UserControllerTest(
         }
 
         @Test
-        fun `add new user with invalid format`() = runTest {
+        fun `add new user with invalid format`() = runSuspendIO {
             val newUser = "new user"
 
             webTestClient
@@ -163,7 +163,7 @@ class UserControllerTest(
     @Nested
     inner class Update {
         @Test
-        fun `update existing user`() = runTest {
+        fun `update existing user`() = runSuspendIO {
             val newUser = createUserDTO()
             val savedUser = service.addUser(newUser)!!
 
@@ -183,7 +183,7 @@ class UserControllerTest(
         }
 
         @Test
-        fun `update non-existing user`() = runTest {
+        fun `update non-existing user`() = runSuspendIO {
             val userToUpdate = createUserDTO()
             webTestClient
                 .put()
@@ -194,7 +194,7 @@ class UserControllerTest(
         }
 
         @Test
-        fun `update user with invalid format`() = runTest {
+        fun `update user with invalid format`() = runSuspendIO {
             val userToUpdate = "new user"
             webTestClient
                 .put()
@@ -205,7 +205,7 @@ class UserControllerTest(
         }
 
         @Test
-        fun `update user with invalid id`() = runTest {
+        fun `update user with invalid id`() = runSuspendIO {
             val userToUpdate = "new user"
             webTestClient
                 .put()
@@ -219,7 +219,7 @@ class UserControllerTest(
     @Nested
     inner class Delete {
         @Test
-        fun `delete existing user`() = runTest {
+        fun `delete existing user`() = runSuspendIO {
             val newUser = createUserDTO()
             val savedUser = service.addUser(newUser)!!
 
@@ -234,7 +234,7 @@ class UserControllerTest(
         }
 
         @Test
-        fun `delete non-existing user`() = runTest {
+        fun `delete non-existing user`() = runSuspendIO {
             webTestClient
                 .delete()
                 .uri("/api/users/9999")
@@ -243,7 +243,7 @@ class UserControllerTest(
         }
 
         @Test
-        fun `delete by non-numeric id`() = runTest {
+        fun `delete by non-numeric id`() = runSuspendIO {
             webTestClient
                 .delete()
                 .uri("/api/users/abc")

--- a/spring-data/r2dbc-webflux/src/test/kotlin/io/bluetape4k/workshop/r2dbc/handler/UserHandlerIT.kt
+++ b/spring-data/r2dbc-webflux/src/test/kotlin/io/bluetape4k/workshop/r2dbc/handler/UserHandlerIT.kt
@@ -10,7 +10,7 @@ import io.bluetape4k.workshop.r2dbc.service.UserService
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.reactive.asFlow
 import kotlinx.coroutines.reactive.awaitSingle
-import kotlinx.coroutines.test.runTest
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldHaveSize
@@ -35,7 +35,7 @@ class UserHandlerIT(
     @Nested
     inner class Find {
         @Test
-        fun `find all users`() = runTest {
+        fun `find all users`() = runSuspendIO {
             val users = webTestClient
                 .get()
                 .uri("/users")
@@ -51,7 +51,7 @@ class UserHandlerIT(
         }
 
         @Test
-        fun `find by id - exsting user`() = runTest {
+        fun `find by id - exsting user`() = runSuspendIO {
             val user = webTestClient
                 .get()
                 .uri("/users/1")
@@ -65,7 +65,7 @@ class UserHandlerIT(
         }
 
         @Test
-        fun `find by id - non-exsting user`() = runTest {
+        fun `find by id - non-exsting user`() = runSuspendIO {
             webTestClient
                 .get()
                 .uri("/users/9999")
@@ -74,7 +74,7 @@ class UserHandlerIT(
         }
 
         @Test
-        fun `find by id - invalid user id`() = runTest {
+        fun `find by id - invalid user id`() = runSuspendIO {
             webTestClient
                 .get()
                 .uri("/users/user_id")
@@ -88,7 +88,7 @@ class UserHandlerIT(
     @Nested
     inner class Search {
         @Test
-        fun `search by email`() = runTest {
+        fun `search by email`() = runSuspendIO {
             val searchEmail = "user2@users.com"
 
             val searchedUsers = webTestClient
@@ -104,7 +104,7 @@ class UserHandlerIT(
         }
 
         @Test
-        fun `search by empty email returns BadReqeust`() = runTest {
+        fun `search by empty email returns BadReqeust`() = runSuspendIO {
             val searchEmail = ""
             webTestClient
                 .get()
@@ -116,7 +116,7 @@ class UserHandlerIT(
         }
 
         @Test
-        fun `search without params return BadRequest`() = runTest {
+        fun `search without params return BadRequest`() = runSuspendIO {
             webTestClient
                 .get()
                 .uri("/users/search")
@@ -130,7 +130,7 @@ class UserHandlerIT(
     @Nested
     inner class Add {
         @Test
-        fun `add new user`() = runTest {
+        fun `add new user`() = runSuspendIO {
             val newUser = createUserDTO()
 
             val savedUser = webTestClient
@@ -146,7 +146,7 @@ class UserHandlerIT(
         }
 
         @Test
-        fun `add new user with bad format`() = runTest {
+        fun `add new user with bad format`() = runSuspendIO {
             val newUser = "bad format"
 
             webTestClient
@@ -163,7 +163,7 @@ class UserHandlerIT(
     @Nested
     inner class Update {
         @Test
-        fun `update existing user`() = runTest {
+        fun `update existing user`() = runSuspendIO {
             val newUser = createUserDTO()
             val savedUser = service.addUser(newUser)!!
 
@@ -182,7 +182,7 @@ class UserHandlerIT(
         }
 
         @Test
-        fun `update with non-numeric id`() = runTest {
+        fun `update with non-numeric id`() = runSuspendIO {
             val userToUpdate = createUserDTO()
 
             webTestClient
@@ -196,7 +196,7 @@ class UserHandlerIT(
         }
 
         @Test
-        fun `update with invalid userDTO`() = runTest {
+        fun `update with invalid userDTO`() = runSuspendIO {
             val userToUpdate = "bad format"
 
             webTestClient
@@ -211,7 +211,7 @@ class UserHandlerIT(
 
 
         @Test
-        fun `update non-existing user`() = runTest {
+        fun `update non-existing user`() = runSuspendIO {
             val userToUpdate = createUserDTO()
 
             webTestClient
@@ -228,7 +228,7 @@ class UserHandlerIT(
     @Nested
     inner class Delete {
         @Test
-        fun `delete existing user`() = runTest {
+        fun `delete existing user`() = runSuspendIO {
             val newUser = createUserDTO()
             val savedUser = service.addUser(newUser)!!
 
@@ -240,7 +240,7 @@ class UserHandlerIT(
         }
 
         @Test
-        fun `delete non-existing user`() = runTest {
+        fun `delete non-existing user`() = runSuspendIO {
             webTestClient
                 .delete()
                 .uri("/users/9999")
@@ -251,7 +251,7 @@ class UserHandlerIT(
         }
 
         @Test
-        fun `delete user with non-numeric id`() = runTest {
+        fun `delete user with non-numeric id`() = runSuspendIO {
             webTestClient
                 .delete()
                 .uri("/users/abc")

--- a/spring-data/r2dbc-webflux/src/test/kotlin/io/bluetape4k/workshop/r2dbc/handler/UserHandlerTest.kt
+++ b/spring-data/r2dbc-webflux/src/test/kotlin/io/bluetape4k/workshop/r2dbc/handler/UserHandlerTest.kt
@@ -11,7 +11,7 @@ import io.mockk.coVerify
 import io.mockk.mockk
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.test.runTest
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.assertions.shouldBeEqualTo
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -36,7 +36,7 @@ class UserHandlerTest: AbstractWebfluxR2dbcApplicationTest() {
     }
 
     @Test
-    fun `find all users`() = runTest {
+    fun `find all users`() = runSuspendIO {
         coEvery { service.findAll() } returns flowOf(createUser(id = 1), createUser(id = 2))
 
         val response = handler.findAll(request)
@@ -44,7 +44,7 @@ class UserHandlerTest: AbstractWebfluxR2dbcApplicationTest() {
     }
 
     @Test
-    fun `when user is not exists, returns empty flow`() = runTest {
+    fun `when user is not exists, returns empty flow`() = runSuspendIO {
         coEvery { service.findAll() } returns emptyFlow()
 
         val response = handler.findAll(request)
@@ -52,7 +52,7 @@ class UserHandlerTest: AbstractWebfluxR2dbcApplicationTest() {
     }
 
     @Test
-    fun `find by id return OK`() = runTest {
+    fun `find by id return OK`() = runSuspendIO {
         coEvery { request.pathVariable("id") } returns "1"
         coEvery { service.findById(1) } returns createUser(1)
 
@@ -62,7 +62,7 @@ class UserHandlerTest: AbstractWebfluxR2dbcApplicationTest() {
     }
 
     @Test
-    fun `find by id non exists return NotFound`() = runTest {
+    fun `find by id non exists return NotFound`() = runSuspendIO {
         coEvery { request.pathVariable("id") } returns "-1"
         coEvery { service.findById(-1) } returns null
 
@@ -71,7 +71,7 @@ class UserHandlerTest: AbstractWebfluxR2dbcApplicationTest() {
     }
 
     @Test
-    fun `when path variable is not numeric returns BadRequest`() = runTest {
+    fun `when path variable is not numeric returns BadRequest`() = runSuspendIO {
         coEvery { request.pathVariable("id") } returns "id"
         coEvery { service.findById(any()) } returns createUser(id = 1)
 
@@ -81,7 +81,7 @@ class UserHandlerTest: AbstractWebfluxR2dbcApplicationTest() {
     }
 
     @Test
-    fun `add new user returns OK`() = runTest {
+    fun `add new user returns OK`() = runSuspendIO {
         coEvery { request.bodyToMono<UserDTO>() } returns createUserDTO().toMono()
         coEvery { service.addUser(any()) } answers {
             firstArg<UserDTO>().toModel().copy(id = 999)
@@ -92,7 +92,7 @@ class UserHandlerTest: AbstractWebfluxR2dbcApplicationTest() {
     }
 
     @Test
-    fun `when invalid body to addUser returns BadRequest`() = runTest {
+    fun `when invalid body to addUser returns BadRequest`() = runSuspendIO {
         coEvery { request.bodyToMono<UserDTO>() } returns Mono.empty()
 
         val response = handler.addUser(request)
@@ -100,7 +100,7 @@ class UserHandlerTest: AbstractWebfluxR2dbcApplicationTest() {
     }
 
     @Test
-    fun `when error in saveUser returns InternalServerError`() = runTest {
+    fun `when error in saveUser returns InternalServerError`() = runSuspendIO {
         coEvery { service.addUser(any()) } returns null
         coEvery { request.bodyToMono<UserDTO>() } returns createUserDTO().toMono()
 
@@ -109,7 +109,7 @@ class UserHandlerTest: AbstractWebfluxR2dbcApplicationTest() {
     }
 
     @Test
-    fun `when update existing user returns OK`() = runTest {
+    fun `when update existing user returns OK`() = runSuspendIO {
         coEvery { request.pathVariable("id") } returns "2"
         coEvery { request.bodyToMono<UserDTO>() } returns createUserDTO().toMono()
         coEvery { service.updateUser(2, any()) } answers {
@@ -121,7 +121,7 @@ class UserHandlerTest: AbstractWebfluxR2dbcApplicationTest() {
     }
 
     @Test
-    fun `when provide non numeric id to updateUser returns BadRequest`() = runTest {
+    fun `when provide non numeric id to updateUser returns BadRequest`() = runSuspendIO {
         coEvery { request.pathVariable("id") } returns "NOT-NUMERIC"
 
         val response = handler.updateUser(request)
@@ -129,7 +129,7 @@ class UserHandlerTest: AbstractWebfluxR2dbcApplicationTest() {
     }
 
     @Test
-    fun `when empty body to updateUser returns BadRequest`() = runTest {
+    fun `when empty body to updateUser returns BadRequest`() = runSuspendIO {
         coEvery { request.pathVariable("id") } returns "2"
         coEvery { request.bodyToMono<UserDTO>() } returns Mono.empty()
 
@@ -138,7 +138,7 @@ class UserHandlerTest: AbstractWebfluxR2dbcApplicationTest() {
     }
 
     @Test
-    fun `when update non-existing user returns BadRequest`() = runTest {
+    fun `when update non-existing user returns BadRequest`() = runSuspendIO {
         coEvery { request.pathVariable("id") } returns "2"
         coEvery { request.bodyToMono<UserDTO>() } returns createUserDTO().toMono()
         coEvery { service.updateUser(2, any()) } returns null
@@ -148,7 +148,7 @@ class UserHandlerTest: AbstractWebfluxR2dbcApplicationTest() {
     }
 
     @Test
-    fun `when delete user is success returns NoContent`() = runTest {
+    fun `when delete user is success returns NoContent`() = runSuspendIO {
         coEvery { request.pathVariable("id") } returns "2"
         coEvery { service.deleteUser(2) } returns true
 
@@ -157,7 +157,7 @@ class UserHandlerTest: AbstractWebfluxR2dbcApplicationTest() {
     }
 
     @Test
-    fun `when delete non-existing user returns NotFound`() = runTest {
+    fun `when delete non-existing user returns NotFound`() = runSuspendIO {
         coEvery { request.pathVariable("id") } returns "999"
         coEvery { service.deleteUser(999) } returns false
 
@@ -166,7 +166,7 @@ class UserHandlerTest: AbstractWebfluxR2dbcApplicationTest() {
     }
 
     @Test
-    fun `when delete user with invalid id type returns BadRequest`() = runTest {
+    fun `when delete user with invalid id type returns BadRequest`() = runSuspendIO {
         coEvery { request.pathVariable("id") } returns "NON-NUMERIC"
 
         val response = handler.deleteUser(request)

--- a/spring-data/r2dbc-webflux/src/test/kotlin/io/bluetape4k/workshop/r2dbc/service/UserServiceTest.kt
+++ b/spring-data/r2dbc-webflux/src/test/kotlin/io/bluetape4k/workshop/r2dbc/service/UserServiceTest.kt
@@ -9,7 +9,7 @@ import io.r2dbc.spi.ConnectionFactory
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.single
 import kotlinx.coroutines.flow.toList
-import kotlinx.coroutines.test.runTest
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.assertions.shouldBeEmpty
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeFalse
@@ -43,7 +43,7 @@ class UserServiceTest(
 
     @Test
     @Order(2)
-    fun `find all users`() = runTest {
+    fun `find all users`() = runSuspendIO {
         val users = service.findAll().toList()
         users.forEach {
             log.debug { it }
@@ -53,7 +53,7 @@ class UserServiceTest(
 
     @Test
     @Order(3)
-    fun `find user by id`() = runTest {
+    fun `find user by id`() = runSuspendIO {
         val expected = service.findAll().toList().random()
 
         val actual = service.findById(expected.id!!)
@@ -63,14 +63,14 @@ class UserServiceTest(
 
     @Test
     @Order(4)
-    fun `find user by invalid id`() = runTest {
+    fun `find user by invalid id`() = runSuspendIO {
         val actual = service.findById(-1)
         actual.shouldBeNull()
     }
 
     @Test
     @Order(5)
-    fun `find user by email`() = runTest {
+    fun `find user by email`() = runSuspendIO {
         val expected = service.findAll().toList().random()
 
         val actual = service.findByEmail(expected.email).single()
@@ -80,14 +80,14 @@ class UserServiceTest(
 
     @Test
     @Order(6)
-    fun `find user by invalid email`() = runTest {
+    fun `find user by invalid email`() = runSuspendIO {
         val notFounds = service.findByEmail("not-exists@example.com").toList()
         notFounds.shouldBeEmpty()
     }
 
     @Test
     @Order(7)
-    fun `add new user`() = runTest {
+    fun `add new user`() = runSuspendIO {
         val newUser = createUserDTO()
         val savedUser = service.addUser(newUser)
 
@@ -98,7 +98,7 @@ class UserServiceTest(
 
     @Test
     @Order(8)
-    fun `update existing user`() = runTest {
+    fun `update existing user`() = runSuspendIO {
         val user = service.findAll().toList().random()
 
         val updated = service.updateUser(user.id!!, user.copy(avatar = "updated-avatar.jpg").toDto())
@@ -114,7 +114,7 @@ class UserServiceTest(
 
     @Test
     @Order(9)
-    fun `update non existing user`() = runTest {
+    fun `update non existing user`() = runSuspendIO {
         val nonExists = createUserDTO()
         val actual = service.updateUser(-1, nonExists)
         actual.shouldBeNull()
@@ -122,7 +122,7 @@ class UserServiceTest(
 
     @Test
     @Order(10)
-    fun `delete existing user`() = runTest {
+    fun `delete existing user`() = runSuspendIO {
         val user = createUserDTO()
         val saved = service.addUser(user)
 
@@ -135,7 +135,7 @@ class UserServiceTest(
 
     @Test
     @Order(11)
-    fun `delete non-existing user`() = runTest {
+    fun `delete non-existing user`() = runSuspendIO {
         service.deleteUser(-1).shouldBeFalse()
     }
 }

--- a/spring-data/redis-examples/src/test/kotlin/io/bluetape4k/workshop/redis/movie/MovieRepositoryTest.kt
+++ b/spring-data/redis-examples/src/test/kotlin/io/bluetape4k/workshop/redis/movie/MovieRepositoryTest.kt
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.data.domain.Example
 import org.springframework.data.domain.ExampleMatcher
-import kotlin.test.assertFailsWith
+import io.bluetape4k.assertions.assertFailsWith
 
 class MovieRepositoryTest @Autowired constructor(
     private val actorRepo: ActorRepository,

--- a/spring-data/redis-examples/src/test/kotlin/io/bluetape4k/workshop/redis/stream/sync/SyncStreamApiTest.kt
+++ b/spring-data/redis-examples/src/test/kotlin/io/bluetape4k/workshop/redis/stream/sync/SyncStreamApiTest.kt
@@ -19,7 +19,7 @@ import org.springframework.data.redis.connection.stream.StreamOffset
 import org.springframework.data.redis.core.StreamOperations
 import org.springframework.data.redis.core.StringRedisTemplate
 import org.springframework.data.redis.stream.StreamMessageListenerContainer
-import kotlin.test.assertFailsWith
+import io.bluetape4k.assertions.assertFailsWith
 
 @SpringBootTest(classes = [RedisStreamConfiguration::class])
 class SyncStreamApiTest @Autowired constructor(

--- a/spring-modulith/events-deep-dive/src/test/kotlin/io/bluetape4k/workshop/spring/modulith/events/b/transactions/OrderEventPublicationTests.kt
+++ b/spring-modulith/events-deep-dive/src/test/kotlin/io/bluetape4k/workshop/spring/modulith/events/b/transactions/OrderEventPublicationTests.kt
@@ -5,7 +5,7 @@ import io.bluetape4k.workshop.spring.modulith.events.util.IntegrationTest
 import io.bluetape4k.assertions.shouldBeTrue
 import org.springframework.beans.factory.annotation.Autowired
 import kotlin.test.Test
-import kotlin.test.assertFailsWith
+import io.bluetape4k.assertions.assertFailsWith
 
 @IntegrationTest
 class OrderEventPublicationTests(

--- a/spring-security/webflux/hello-security/src/test/kotlin/io/bluetape4k/workshop/spring/security/webflux/MainControllerTest.kt
+++ b/spring-security/webflux/hello-security/src/test/kotlin/io/bluetape4k/workshop/spring/security/webflux/MainControllerTest.kt
@@ -1,11 +1,11 @@
 package io.bluetape4k.workshop.spring.security.webflux
 
+import io.bluetape4k.assertions.shouldContain
+import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
 import io.bluetape4k.workshop.shared.web.httpGet
-import kotlinx.coroutines.test.runTest
-import io.bluetape4k.assertions.shouldContain
-import io.bluetape4k.assertions.shouldNotBeNull
 import org.junit.jupiter.api.Test
 import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.test.web.reactive.server.expectBody
@@ -15,7 +15,7 @@ class MainControllerTest: AbstractSecurityApplicationTest() {
     companion object: KLoggingChannel()
 
     @Test
-    fun `index page is not protected`() = runTest {
+    fun `index page is not protected`() = runSuspendIO {
         val response = client
             .httpGet("/")
             .expectStatus().is2xxSuccessful
@@ -28,7 +28,7 @@ class MainControllerTest: AbstractSecurityApplicationTest() {
     }
 
     @Test
-    fun `protected page when unauthenticated then redirects to login`() = runTest {
+    fun `protected page when unauthenticated then redirects to login`() = runSuspendIO {
         client
             .httpGet("/user/index")
             .expectStatus().is3xxRedirection
@@ -37,7 +37,7 @@ class MainControllerTest: AbstractSecurityApplicationTest() {
 
     @Test
     @WithMockUser
-    fun `protected page can be accessed when authenticated`() = runTest {
+    fun `protected page can be accessed when authenticated`() = runSuspendIO {
         val response = client
             .httpGet("/user/index")
             .expectStatus().is2xxSuccessful

--- a/spring-security/webflux/jwt/src/test/kotlin/io/bluetape4k/workshop/spring/security/webflux/jwt/controller/HelloControllerTest.kt
+++ b/spring-security/webflux/jwt/src/test/kotlin/io/bluetape4k/workshop/spring/security/webflux/jwt/controller/HelloControllerTest.kt
@@ -1,13 +1,13 @@
 package io.bluetape4k.workshop.spring.security.webflux.jwt.controller
 
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
 import io.bluetape4k.workshop.shared.web.httpPost
 import io.bluetape4k.workshop.spring.security.webflux.jwt.AbstractJwtApplicationTest
 import kotlinx.coroutines.reactive.awaitSingle
-import kotlinx.coroutines.test.runTest
-import io.bluetape4k.assertions.shouldBeEqualTo
-import io.bluetape4k.assertions.shouldNotBeNull
 import org.junit.jupiter.api.Test
 import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.test.web.reactive.server.returnResult
@@ -18,7 +18,7 @@ class HelloControllerTest: AbstractJwtApplicationTest() {
 
     // NOTE: "이렇게 plain password 를 전달하면, password encoder 설정을 막아야 하기 때문에 @WithMockUser 를 사용하는 것을 추천합니다"
     @Test
-    fun `인증된 user가 새로운 토큰 발급을 요청하면 발급되고 인증되어야 한다`() = runTest {
+    fun `인증된 user가 새로운 토큰 발급을 요청하면 발급되고 인증되어야 한다`() = runSuspendIO {
         // 인증 정보로 토큰을 발급 받는다 
         val token = webTestClient
             .post()
@@ -51,7 +51,7 @@ class HelloControllerTest: AbstractJwtApplicationTest() {
 
     @Test
     @WithMockUser
-    fun `MockUser로 인증된 사용자는 서버 접근이 되어야 합니다`() = runTest {
+    fun `MockUser로 인증된 사용자는 서버 접근이 되어야 합니다`() = runSuspendIO {
         // 인증 정보로 토큰을 발급 받는다
         val token = webTestClient
             .post()
@@ -87,7 +87,7 @@ class HelloControllerTest: AbstractJwtApplicationTest() {
     }
 
     @Test
-    fun `인증 안된 사용자는 서버 접근이 안되어야 합니다`() = runTest {
+    fun `인증 안된 사용자는 서버 접근이 안되어야 합니다`() = runSuspendIO {
         webTestClient
             .httpPost("/")
             .expectStatus().isUnauthorized


### PR DESCRIPTION
## Summary

- Refactor workshop examples to reuse bluetape4k helpers, assertions, coroutine patterns, and Exposed test fixtures.
- Replace ad hoc Exposed database setup with bluetape4k `TestDB` / `AbstractExposedTest` / `AbstractExposedR2dbcTest` harness coverage.
- Bind Spring Exposed R2DBC service transactions to the injected `R2dbcDatabase` so Spring Boot tests are isolated from parameterized harness default database state.

## Why

The workshop should demonstrate the bluetape4k ecosystem instead of rebuilding infrastructure that already exists in `bluetape4k-*` modules. Full repo build exposed an R2DBC transaction-boundary issue: after the parameterized harness ran against MySQL, Spring service methods using bare `suspendTransaction` could hit the wrong default database.

## Validation

- `./gradlew :spring-data-r2dbc-webflux-exposed:test` (`67 passing`)
- `./gradlew build` (`BUILD SUCCESSFUL in 2m 18s`)
