### PR TITLE
[codex] Tighten workshop tests around bluetape4k helpers

### DIFF
--- a/exposed/webflux-r2dbc/src/test/kotlin/io/bluetape4k/workshop/exposed/webflux/r2dbc/order/ConcurrentPlaceOrderTest.kt
+++ b/exposed/webflux-r2dbc/src/test/kotlin/io/bluetape4k/workshop/exposed/webflux/r2dbc/order/ConcurrentPlaceOrderTest.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.workshop.exposed.webflux.r2dbc.order
 
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeLessOrEqualTo
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.info
 import io.bluetape4k.workshop.exposed.webflux.r2dbc.AbstractWebfluxR2dbcTest
@@ -14,7 +15,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Test
 import org.springframework.http.MediaType
 import org.springframework.test.annotation.DirtiesContext
@@ -41,32 +41,30 @@ class ConcurrentPlaceOrderTest : AbstractWebfluxR2dbcTest() {
     }
 
     @Test
-    fun `concurrent orders deplete stock correctly without overselling`() {
+    fun `concurrent orders deplete stock correctly without overselling`() = runSuspendIO {
         val totalStock = 10
         val concurrency = 20  // more requests than stock
         val product = createProduct(stock = totalStock)
 
-        val results = runBlocking {
-            coroutineScope {
-                List(concurrency) { i ->
-                    async(Dispatchers.IO) {
-                        val req = PlaceOrderRequest(
-                            customerId = (i + 1).toLong(),
-                            lines = listOf(OrderLineRequest(productId = product.id, quantity = 1)),
-                        )
-                        runCatching {
-                            webTestClient.post().uri("/api/orders")
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .bodyValue(req)
-                                .exchange()
-                                .expectBody(OrderDTO::class.java)
-                                .returnResult()
-                                .status
-                                .value()
-                        }.getOrDefault(409)
-                    }
-                }.awaitAll()
-            }
+        val results = coroutineScope {
+            List(concurrency) { i ->
+                async(Dispatchers.IO) {
+                    val req = PlaceOrderRequest(
+                        customerId = (i + 1).toLong(),
+                        lines = listOf(OrderLineRequest(productId = product.id, quantity = 1)),
+                    )
+                    runCatching {
+                        webTestClient.post().uri("/api/orders")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .bodyValue(req)
+                            .exchange()
+                            .expectBody(OrderDTO::class.java)
+                            .returnResult()
+                            .status
+                            .value()
+                    }.getOrDefault(409)
+                }
+            }.awaitAll()
         }
 
         val successCount = results.count { it == 201 }
@@ -79,41 +77,39 @@ class ConcurrentPlaceOrderTest : AbstractWebfluxR2dbcTest() {
     }
 
     @Test
-    fun `concurrent orders on multiple products do not deadlock`() {
+    fun `concurrent orders on multiple products do not deadlock`() = runSuspendIO {
         val productA = createProduct(stock = 50)
         val productB = createProduct(stock = 50)
         val concurrency = 10
 
-        val results = runBlocking {
-            coroutineScope {
-                List(concurrency) { i ->
-                    async(Dispatchers.IO) {
-                        // Alternate between (A then B) and (B then A) orders to stress deadlock prevention
-                        val lines = if (i % 2 == 0) {
-                            listOf(
-                                OrderLineRequest(productId = productA.id, quantity = 1),
-                                OrderLineRequest(productId = productB.id, quantity = 1),
-                            )
-                        } else {
-                            listOf(
-                                OrderLineRequest(productId = productB.id, quantity = 1),
-                                OrderLineRequest(productId = productA.id, quantity = 1),
-                            )
-                        }
-                        val req = PlaceOrderRequest(customerId = (i + 1).toLong(), lines = lines)
-                        runCatching {
-                            webTestClient.post().uri("/api/orders")
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .bodyValue(req)
-                                .exchange()
-                                .expectBody(OrderDTO::class.java)
-                                .returnResult()
-                                .status
-                                .value()
-                        }.getOrDefault(500)
+        val results = coroutineScope {
+            List(concurrency) { i ->
+                async(Dispatchers.IO) {
+                    // Alternate between (A then B) and (B then A) orders to stress deadlock prevention
+                    val lines = if (i % 2 == 0) {
+                        listOf(
+                            OrderLineRequest(productId = productA.id, quantity = 1),
+                            OrderLineRequest(productId = productB.id, quantity = 1),
+                        )
+                    } else {
+                        listOf(
+                            OrderLineRequest(productId = productB.id, quantity = 1),
+                            OrderLineRequest(productId = productA.id, quantity = 1),
+                        )
                     }
-                }.awaitAll()
-            }
+                    val req = PlaceOrderRequest(customerId = (i + 1).toLong(), lines = lines)
+                    runCatching {
+                        webTestClient.post().uri("/api/orders")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .bodyValue(req)
+                            .exchange()
+                            .expectBody(OrderDTO::class.java)
+                            .returnResult()
+                            .status
+                            .value()
+                    }.getOrDefault(500)
+                }
+            }.awaitAll()
         }
 
         val successCount = results.count { it == 201 }

--- a/leader/leader-election/src/test/kotlin/io/bluetape4k/workshop/leader/ConcurrentLeaderElectionTest.kt
+++ b/leader/leader-election/src/test/kotlin/io/bluetape4k/workshop/leader/ConcurrentLeaderElectionTest.kt
@@ -4,7 +4,7 @@ import io.bluetape4k.junit5.concurrency.MultithreadingTester
 import io.bluetape4k.leader.LeaderElectionOptions
 import io.bluetape4k.assertions.shouldBeEqualTo
 import org.junit.jupiter.api.Test
-import java.util.UUID
+import io.bluetape4k.codec.Base58
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
@@ -23,7 +23,7 @@ class ConcurrentLeaderElectionTest : AbstractLeaderElectionTest() {
 
     @Test
     fun `exactly one instance wins the lock among 3 concurrent attempts`() {
-        val lockName = "test:t2:${UUID.randomUUID()}"
+        val lockName = "test:t2:${Base58.randomString(8)}"
         val executions = AtomicInteger(0)   // java.util.concurrent.atomic — local variable
         val attemptCount = AtomicInteger(0)
 

--- a/leader/leader-election/src/test/kotlin/io/bluetape4k/workshop/leader/JobIsolationTest.kt
+++ b/leader/leader-election/src/test/kotlin/io/bluetape4k/workshop/leader/JobIsolationTest.kt
@@ -4,7 +4,7 @@ import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.workshop.leader.job.LeaderGuardedJob
 import io.bluetape4k.workshop.leader.job.LeaderScheduledJobService
 import org.junit.jupiter.api.Test
-import java.util.UUID
+import io.bluetape4k.codec.Base58
 import java.util.concurrent.atomic.AtomicInteger
 
 /**
@@ -23,13 +23,13 @@ class JobIsolationTest : AbstractLeaderElectionTest() {
         val successCount = AtomicInteger(0)
 
         val failingJob = object : LeaderGuardedJob {
-            override val lockName = "test:isolate:fail:${UUID.randomUUID()}"
+            override val lockName = "test:isolate:fail:${Base58.randomString(8)}"
             override fun execute() {
                 throw RuntimeException("intentional failure in failingJob")
             }
         }
         val successJob = object : LeaderGuardedJob {
-            override val lockName = "test:isolate:success:${UUID.randomUUID()}"
+            override val lockName = "test:isolate:success:${Base58.randomString(8)}"
             override fun execute() {
                 successCount.incrementAndGet()
             }

--- a/leader/leader-election/src/test/kotlin/io/bluetape4k/workshop/leader/LeaderElectionJobRecoveryTest.kt
+++ b/leader/leader-election/src/test/kotlin/io/bluetape4k/workshop/leader/LeaderElectionJobRecoveryTest.kt
@@ -3,7 +3,7 @@ package io.bluetape4k.workshop.leader
 import io.bluetape4k.assertions.shouldNotBeNull
 import io.bluetape4k.assertions.shouldBeEqualTo
 import org.junit.jupiter.api.Test
-import java.util.UUID
+import io.bluetape4k.codec.Base58
 import io.bluetape4k.assertions.assertFailsWith
 
 /**
@@ -17,7 +17,7 @@ class LeaderElectionJobRecoveryTest : AbstractLeaderElectionTest() {
 
     @Test
     fun `lock is released after job throws exception, allowing re-election`() {
-        val lockName = "test:t3:${UUID.randomUUID()}"
+        val lockName = "test:t3:${Base58.randomString(8)}"
         val elector1 = newElector()
         val elector2 = newElector()
 

--- a/leader/leader-election/src/test/kotlin/io/bluetape4k/workshop/leader/LeaderElectionSingleRunnerTest.kt
+++ b/leader/leader-election/src/test/kotlin/io/bluetape4k/workshop/leader/LeaderElectionSingleRunnerTest.kt
@@ -3,7 +3,7 @@ package io.bluetape4k.workshop.leader
 import io.bluetape4k.assertions.shouldNotBeNull
 import io.bluetape4k.assertions.shouldBeEqualTo
 import org.junit.jupiter.api.Test
-import java.util.UUID
+import io.bluetape4k.codec.Base58
 
 /**
  * T1: Single-instance leader election test.
@@ -15,7 +15,7 @@ class LeaderElectionSingleRunnerTest : AbstractLeaderElectionTest() {
 
     @Test
     fun `single instance acquires leadership and executes action`() {
-        val lockName = "test:t1:${UUID.randomUUID()}"
+        val lockName = "test:t1:${Base58.randomString(8)}"
         val elector = newElector()
 
         val result = elector.runIfLeader(lockName) { "executed" }
@@ -27,8 +27,8 @@ class LeaderElectionSingleRunnerTest : AbstractLeaderElectionTest() {
     fun `single instance can run multiple actions with different lockNames`() {
         val elector = newElector()
 
-        val result1 = elector.runIfLeader("test:t1:a:${UUID.randomUUID()}") { 1 }
-        val result2 = elector.runIfLeader("test:t1:b:${UUID.randomUUID()}") { 2 }
+        val result1 = elector.runIfLeader("test:t1:a:${Base58.randomString(8)}") { 1 }
+        val result2 = elector.runIfLeader("test:t1:b:${Base58.randomString(8)}") { 2 }
 
         result1.shouldNotBeNull() shouldBeEqualTo 1
         result2.shouldNotBeNull() shouldBeEqualTo 2

--- a/leader/leader-election/src/test/kotlin/io/bluetape4k/workshop/leader/LeaderEventListenerTest.kt
+++ b/leader/leader-election/src/test/kotlin/io/bluetape4k/workshop/leader/LeaderEventListenerTest.kt
@@ -14,9 +14,9 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
-import kotlinx.coroutines.runBlocking
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import org.junit.jupiter.api.Test
-import java.util.UUID
+import io.bluetape4k.codec.Base58
 import java.util.concurrent.atomic.AtomicInteger
 
 /**
@@ -41,7 +41,7 @@ class LeaderEventListenerTest : AbstractLeaderElectionTest() {
             }
         })
 
-        val lockName = "test:event:elected:${UUID.randomUUID()}"
+        val lockName = "test:event:elected:${Base58.randomString(8)}"
         repeat(3) {
             listeningElector.runIfLeader(lockName) { "work" }
         }
@@ -53,7 +53,7 @@ class LeaderEventListenerTest : AbstractLeaderElectionTest() {
 
     @Test
     fun `onSkipped callback is called when lock is held by another elector`() {
-        val lockName = "test:event:skipped:${UUID.randomUUID()}"
+        val lockName = "test:event:skipped:${Base58.randomString(8)}"
         val followerElector = newListeningElector()
         val skippedCount = AtomicInteger(0)
 
@@ -73,9 +73,9 @@ class LeaderEventListenerTest : AbstractLeaderElectionTest() {
     }
 
     @Test
-    fun `events Flow emits Elected event when lock is acquired`() {
+    fun `events Flow emits Elected event when lock is acquired`() = runSuspendIO {
         val listeningElector = newListeningElector()
-        val lockName = "test:event:flow:${UUID.randomUUID()}"
+        val lockName = "test:event:flow:${Base58.randomString(8)}"
         val receivedEvents = Channel<LeaderElectionEvent>(Channel.BUFFERED)
         val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
 
@@ -92,9 +92,7 @@ class LeaderEventListenerTest : AbstractLeaderElectionTest() {
         listeningElector.runIfLeader(lockName) { "work" }
 
         // Allow the shared flow emission to propagate to the collector.
-        val received = runBlocking {
-            withTimeoutOrNull(2_000) { receivedEvents.receive() }
-        }
+        val received = withTimeoutOrNull(2_000) { receivedEvents.receive() }
 
         received.shouldNotBeNull()
         (received is LeaderElectionEvent.Elected) shouldBeEqualTo true
@@ -109,7 +107,7 @@ class LeaderEventListenerTest : AbstractLeaderElectionTest() {
         val service = LeaderEventListenerService(listeningElector)
         service.init()
 
-        val lockName = "test:event:service:${UUID.randomUUID()}"
+        val lockName = "test:event:service:${Base58.randomString(8)}"
         repeat(3) {
             listeningElector.runIfLeader(lockName) { "work" }
         }

--- a/leader/leader-election/src/test/kotlin/io/bluetape4k/workshop/leader/LeaseExpiryTest.kt
+++ b/leader/leader-election/src/test/kotlin/io/bluetape4k/workshop/leader/LeaseExpiryTest.kt
@@ -4,7 +4,7 @@ import io.bluetape4k.leader.LeaderElectionOptions
 import io.bluetape4k.logging.*
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
-import java.util.UUID
+import io.bluetape4k.codec.Base58
 import kotlin.time.Duration.Companion.milliseconds
 
 /**
@@ -22,7 +22,7 @@ class LeaseExpiryTest : AbstractLeaderElectionTest() {
 
     @Test
     fun `leader holding lock beyond leaseTime allows second elector to attempt acquisition`() {
-        val lockName = "test:t5:${UUID.randomUUID()}"
+        val lockName = "test:t5:${Base58.randomString(8)}"
         val shortLeaseOptions = LeaderElectionOptions(
             waitTime = 50.milliseconds,
             leaseTime = 200.milliseconds,

--- a/leader/leader-election/src/test/kotlin/io/bluetape4k/workshop/leader/LockAssertTest.kt
+++ b/leader/leader-election/src/test/kotlin/io/bluetape4k/workshop/leader/LockAssertTest.kt
@@ -7,7 +7,7 @@ import io.bluetape4k.leader.LockAssert
 import io.bluetape4k.workshop.leader.job.LockAssertJob
 import io.bluetape4k.assertions.assertFailsWith
 import org.junit.jupiter.api.Test
-import java.util.UUID
+import io.bluetape4k.codec.Base58
 
 /**
  * Tests for [LockAssertJob] and the [LockAssert] API.
@@ -22,7 +22,7 @@ class LockAssertTest : AbstractLeaderElectionTest() {
 
     @Test
     fun `assertLocked passes silently inside runIfLeader`() {
-        val lockName = "test:assert:${UUID.randomUUID()}"
+        val lockName = "test:assert:${Base58.randomString(8)}"
         val elector = newElector()
 
         val result = elector.runIfLeader(lockName) {
@@ -43,7 +43,7 @@ class LockAssertTest : AbstractLeaderElectionTest() {
 
     @Test
     fun `isLocked returns true inside runIfLeader`() {
-        val lockName = "test:assert:locked:${UUID.randomUUID()}"
+        val lockName = "test:assert:locked:${Base58.randomString(8)}"
         val elector = newElector()
 
         val isLocked = elector.runIfLeader(lockName) {

--- a/leader/leader-election/src/test/kotlin/io/bluetape4k/workshop/leader/LockExtenderTest.kt
+++ b/leader/leader-election/src/test/kotlin/io/bluetape4k/workshop/leader/LockExtenderTest.kt
@@ -6,7 +6,7 @@ import io.bluetape4k.assertions.shouldNotBeNull
 import io.bluetape4k.leader.LockExtender
 import io.bluetape4k.workshop.leader.job.LockExtenderJob
 import org.junit.jupiter.api.Test
-import java.util.UUID
+import io.bluetape4k.codec.Base58
 
 /**
  * Tests for [LockExtenderJob] and the [LockExtender] API.
@@ -20,7 +20,7 @@ class LockExtenderTest : AbstractLeaderElectionTest() {
 
     @Test
     fun `extendActiveLock returns true inside runIfLeader`() {
-        val lockName = "test:extend:${UUID.randomUUID()}"
+        val lockName = "test:extend:${Base58.randomString(8)}"
         val elector = newElector()
 
         val extended = elector.runIfLeader(lockName) {

--- a/leader/leader-election/src/test/kotlin/io/bluetape4k/workshop/leader/LockReleaseTest.kt
+++ b/leader/leader-election/src/test/kotlin/io/bluetape4k/workshop/leader/LockReleaseTest.kt
@@ -4,7 +4,7 @@ import io.bluetape4k.leader.LeaderElectionOptions
 import io.bluetape4k.assertions.shouldNotBeNull
 import io.bluetape4k.assertions.shouldBeEqualTo
 import org.junit.jupiter.api.Test
-import java.util.UUID
+import io.bluetape4k.codec.Base58
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
@@ -23,7 +23,7 @@ class LockReleaseTest : AbstractLeaderElectionTest() {
 
     @Test
     fun `lock is released immediately after action completes, enabling instant re-acquisition`() {
-        val lockName = "test:t7:${UUID.randomUUID()}"
+        val lockName = "test:t7:${Base58.randomString(8)}"
         // Long leaseTime — if finally-unlock does NOT run, elector2 would wait 30s
         val longLeaseOptions = LeaderElectionOptions(
             waitTime = 100.milliseconds,

--- a/leader/leader-election/src/test/kotlin/io/bluetape4k/workshop/leader/MultiJobIndependenceTest.kt
+++ b/leader/leader-election/src/test/kotlin/io/bluetape4k/workshop/leader/MultiJobIndependenceTest.kt
@@ -3,7 +3,7 @@ package io.bluetape4k.workshop.leader
 import io.bluetape4k.assertions.shouldNotBeNull
 import io.bluetape4k.assertions.shouldBeEqualTo
 import org.junit.jupiter.api.Test
-import java.util.UUID
+import io.bluetape4k.codec.Base58
 
 /**
  * T4: Multiple jobs with independent lock names.
@@ -15,8 +15,8 @@ class MultiJobIndependenceTest : AbstractLeaderElectionTest() {
 
     @Test
     fun `two jobs with different lockNames are both executed by the same elector`() {
-        val lockA = "test:t4:job-a:${UUID.randomUUID()}"
-        val lockB = "test:t4:job-b:${UUID.randomUUID()}"
+        val lockA = "test:t4:job-a:${Base58.randomString(8)}"
+        val lockB = "test:t4:job-b:${Base58.randomString(8)}"
         val elector = newElector()
 
         val resultA = elector.runIfLeader(lockA) { "A" }

--- a/leader/leader-election/src/test/kotlin/io/bluetape4k/workshop/leader/RedisFailureTest.kt
+++ b/leader/leader-election/src/test/kotlin/io/bluetape4k/workshop/leader/RedisFailureTest.kt
@@ -1,16 +1,16 @@
 package io.bluetape4k.workshop.leader
 
-import io.bluetape4k.leader.lettuce.LettuceLeaderElector
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.codec.Base58
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.leader.LeaderElectionOptions
+import io.bluetape4k.leader.lettuce.LettuceLeaderElector
 import io.bluetape4k.logging.*
+import io.bluetape4k.testcontainers.storage.RedisServer
 import io.lettuce.core.RedisClient
 import io.lettuce.core.codec.StringCodec
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
-import org.testcontainers.containers.GenericContainer
-import java.time.Duration
-import java.util.UUID
-import io.bluetape4k.assertions.assertFailsWith
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
@@ -29,29 +29,21 @@ import kotlin.time.Duration.Companion.seconds
 class RedisFailureTest {
 
     @Test
-    fun `runIfLeader throws exception when Redis is unavailable`() {
+    fun `runIfLeader throws exception when Redis is unavailable`() = runSuspendIO(timeout = 10.seconds) {
         // Use a dedicated container — NOT the shared singleton
-        @Suppress("HttpUrlsUsage")
-        val redisContainer = GenericContainer("redis:7-alpine")
-            .withExposedPorts(6379)
-            .apply { start() }
+        val redisContainer = RedisServer(image = RedisServer.IMAGE, tag = "7-alpine").apply { start() }
 
-        val redisUrl = "redis://${redisContainer.host}:${redisContainer.getMappedPort(6379)}"
-        val connection = RedisClient.create(redisUrl).connect(StringCodec.UTF8)
+        val connection = RedisClient.create(redisContainer.url).connect(StringCodec.UTF8)
         val options = LeaderElectionOptions(waitTime = 100.milliseconds, leaseTime = 5.seconds)
         val elector = LettuceLeaderElector(connection, options)
-        val lockName = "test:t6:${UUID.randomUUID()}"
+        val lockName = "test:t6:${Base58.randomString(8)}"
 
         // Stop Redis before attempting lock acquisition
         redisContainer.stop()
 
-        // Library must not hang silently — must throw within 10 seconds
-        // Outer: assertTimeoutPreemptively guards against infinite hang (throws AssertionError on timeout)
-        // Inner: assertFailsWith<Exception> verifies Redis failure propagates as an exception
-        org.junit.jupiter.api.Assertions.assertTimeoutPreemptively(Duration.ofSeconds(10)) {
-            assertFailsWith<Exception> {
-                elector.runIfLeader(lockName) { "should-not-execute" }
-            }
+        // runSuspendIO timeout guards against infinite hang; assertFailsWith verifies Redis failure propagation.
+        assertFailsWith<Exception> {
+            elector.runIfLeader(lockName) { "should-not-execute" }
         }
 
         log.info { "[T6] Redis failure correctly propagated as exception — no silent hang" }

--- a/leader/leader-election/src/test/kotlin/io/bluetape4k/workshop/leader/SuspendLeaderServiceTest.kt
+++ b/leader/leader-election/src/test/kotlin/io/bluetape4k/workshop/leader/SuspendLeaderServiceTest.kt
@@ -7,10 +7,9 @@ import io.bluetape4k.junit5.coroutines.SuspendedJobTester
 import io.bluetape4k.leader.LeaderElectionOptions
 import io.bluetape4k.workshop.leader.service.SuspendLeaderService
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.runTest
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import org.junit.jupiter.api.Test
-import java.util.UUID
+import io.bluetape4k.codec.Base58
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
@@ -26,7 +25,7 @@ import kotlin.time.Duration.Companion.seconds
 class SuspendLeaderServiceTest : AbstractLeaderElectionTest() {
 
     @Test
-    fun `single coroutine acquires leadership and executes action`() = runTest {
+    fun `single coroutine acquires leadership and executes action`() = runSuspendIO {
         val elector = newSuspendElector()
         val service = SuspendLeaderService(elector)
 
@@ -37,8 +36,8 @@ class SuspendLeaderServiceTest : AbstractLeaderElectionTest() {
     }
 
     @Test
-    fun `second elector receives null while first holds the lock`() = runBlocking {
-        val lockName = "test:suspend:contention:${UUID.randomUUID()}"
+    fun `second elector receives null while first holds the lock`() = runSuspendIO {
+        val lockName = "test:suspend:contention:${Base58.randomString(8)}"
         val shortWait = LeaderElectionOptions(waitTime = 50.milliseconds, leaseTime = 5.seconds)
         val elector1 = newSuspendElector(shortWait)
         val elector2 = newSuspendElector(shortWait)
@@ -55,8 +54,8 @@ class SuspendLeaderServiceTest : AbstractLeaderElectionTest() {
     }
 
     @Test
-    fun `exactly one coroutine wins among concurrent suspend attempts`() = runBlocking {
-        val lockName = "test:suspend:concurrent:${UUID.randomUUID()}"
+    fun `exactly one coroutine wins among concurrent suspend attempts`() = runSuspendIO {
+        val lockName = "test:suspend:concurrent:${Base58.randomString(8)}"
         val winCount = AtomicInteger(0)
 
         // SuspendedJobTester — coroutine concurrency harness from bluetape4k-junit5.

--- a/leader/leader-zookeeper/src/test/kotlin/io/bluetape4k/workshop/leader/zookeeper/AbstractLeaderZookeeperTest.kt
+++ b/leader/leader-zookeeper/src/test/kotlin/io/bluetape4k/workshop/leader/zookeeper/AbstractLeaderZookeeperTest.kt
@@ -11,7 +11,7 @@ import io.bluetape4k.testcontainers.infra.ZooKeeperServer
 import io.bluetape4k.utils.ShutdownQueue
 import org.apache.curator.framework.CuratorFramework
 import org.junit.jupiter.api.TestInstance
-import java.util.UUID
+import io.bluetape4k.codec.Base58
 import java.util.concurrent.TimeUnit
 import kotlin.time.Duration.Companion.milliseconds
 
@@ -63,5 +63,5 @@ abstract class AbstractLeaderZookeeperTest {
             basePath = basePath
         )
 
-    fun randomLockName(prefix: String = "t") = "$prefix:${UUID.randomUUID()}"
+    fun randomLockName(prefix: String = "t") = "$prefix:${Base58.randomString(8)}"
 }

--- a/leader/leader-zookeeper/src/test/kotlin/io/bluetape4k/workshop/leader/zookeeper/SessionLossFailoverTest.kt
+++ b/leader/leader-zookeeper/src/test/kotlin/io/bluetape4k/workshop/leader/zookeeper/SessionLossFailoverTest.kt
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import java.time.Duration
-import java.util.UUID
+import io.bluetape4k.codec.Base58
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import kotlin.time.Duration.Companion.milliseconds
@@ -47,7 +47,7 @@ class SessionLossFailoverTest {
     private lateinit var clientA: CuratorFramework
     private lateinit var clientB: CuratorFramework
 
-    fun randomLockName(prefix: String = "t8") = "$prefix:${UUID.randomUUID()}"
+    fun randomLockName(prefix: String = "t8") = "$prefix:${Base58.randomString(8)}"
 
     @BeforeAll
     fun startIsolatedZk() {

--- a/leader/leader-zookeeper/src/test/kotlin/io/bluetape4k/workshop/leader/zookeeper/SuspendGroupLeaderTest.kt
+++ b/leader/leader-zookeeper/src/test/kotlin/io/bluetape4k/workshop/leader/zookeeper/SuspendGroupLeaderTest.kt
@@ -2,8 +2,8 @@ package io.bluetape4k.workshop.leader.zookeeper
 
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.junit5.coroutines.SuspendedJobTester
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.logging.coroutines.KLoggingChannel
-import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Test
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
@@ -19,7 +19,7 @@ import kotlin.math.max
  * ## Behavior / Contract
  * - Same CountDownLatch handshake as T4, but workers run as coroutines via [SuspendedJobTester].
  * - Orchestrator thread MUST start BEFORE `SuspendedJobTester.run()` — `run()` is blocking
- *   from the calling thread's perspective (the suspend builder is wrapped in `runBlocking`).
+ *   from the calling thread's perspective (the suspend builder is wrapped in `runSuspendIO`).
  * - `CountDownLatch` is safe to use from inside coroutines too — it does not require structured
  *   suspension and provides a deterministic synchronization barrier.
  */
@@ -31,7 +31,7 @@ class SuspendGroupLeaderTest: AbstractLeaderZookeeperTest() {
     }
 
     @Test
-    fun `maxLeaders=2 admits exactly 2 simultaneous suspend holders`(): Unit = runBlocking {
+    fun `maxLeaders=2 admits exactly 2 simultaneous suspend holders`(): Unit = runSuspendIO {
         val groupElector = newSuspendGroupElector(MAX_LEADERS)
         val lockName = randomLockName("t5")
         val enteredLatch = CountDownLatch(MAX_LEADERS)

--- a/leader/leader-zookeeper/src/test/kotlin/io/bluetape4k/workshop/leader/zookeeper/SuspendSingleLeaderTest.kt
+++ b/leader/leader-zookeeper/src/test/kotlin/io/bluetape4k/workshop/leader/zookeeper/SuspendSingleLeaderTest.kt
@@ -4,10 +4,9 @@ import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeGreaterThan
 import io.bluetape4k.assertions.shouldBeLessOrEqualTo
 import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.junit5.coroutines.SuspendedJobTester
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.math.max
@@ -22,13 +21,13 @@ import kotlin.math.max
  *   `peakConcurrent` never exceeds 1 (strict mutual exclusion) and at least 3
  *   coroutines eventually execute the action body.
  *
- * NOTE: The concurrent test uses `runBlocking` (NOT `runTest`) because real ZooKeeper
+ * NOTE: The concurrent test uses `runSuspendIO` (NOT `runTest`) because real ZooKeeper
  * network I/O does not cooperate with the test virtual-time scheduler used by `runTest`.
  */
 class SuspendSingleLeaderTest : AbstractLeaderZookeeperTest() {
 
     @Test
-    fun `runIfLeader returns done for a single suspending caller`() = runTest {
+    fun `runIfLeader returns done for a single suspending caller`() = runSuspendIO {
         val elector = newSuspendElector()
 
         val result = elector.runIfLeader(randomLockName("t3-single")) { "done" }
@@ -37,7 +36,7 @@ class SuspendSingleLeaderTest : AbstractLeaderZookeeperTest() {
     }
 
     @Test
-    fun `peakConcurrent never exceeds 1 across 8 concurrent coroutines`(): Unit = runBlocking {
+    fun `peakConcurrent never exceeds 1 across 8 concurrent coroutines`(): Unit = runSuspendIO {
         val lockName = randomLockName("t3-concurrent")
         // Shared single suspend elector created ONCE outside the worker block.
         val elector = newSuspendElector()

--- a/spring-data/mongodb-coroutines/src/test/kotlin/io/bluetape4k/workshop/mongodb/domain/CoroutineRepositoryTest.kt
+++ b/spring-data/mongodb-coroutines/src/test/kotlin/io/bluetape4k/workshop/mongodb/domain/CoroutineRepositoryTest.kt
@@ -8,7 +8,6 @@ import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.reactor.awaitSingleOrNull
-import kotlinx.coroutines.runBlocking
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldHaveSize
 import io.bluetape4k.assertions.shouldNotBeNull
@@ -26,10 +25,8 @@ class CoroutineRepositoryTest @Autowired constructor(
     companion object: KLoggingChannel()
 
     @BeforeEach
-    fun beforeEach() {
-        runBlocking {
-            operations.dropCollection<Person>().awaitSingleOrNull()
-        }
+    fun beforeEach() = runSuspendIO {
+        operations.dropCollection<Person>().awaitSingleOrNull()
     }
 
     @Test

--- a/spring-data/mongodb-transactions/src/test/kotlin/io/bluetape4k/workshop/mongodb/coroutine/CoroutineManagedTransitionServiceTest.kt
+++ b/spring-data/mongodb-transactions/src/test/kotlin/io/bluetape4k/workshop/mongodb/coroutine/CoroutineManagedTransitionServiceTest.kt
@@ -3,6 +3,7 @@ package io.bluetape4k.workshop.mongodb.coroutine
 import com.mongodb.client.model.Filters
 import com.mongodb.client.model.Projections
 import com.mongodb.reactivestreams.client.MongoClient
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.warn
@@ -14,8 +15,6 @@ import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.reactive.asFlow
 import kotlinx.coroutines.reactive.awaitFirst
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.runTest
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldNotBeNull
 import org.bson.Document
@@ -70,10 +69,8 @@ class CoroutineManagedTransitionServiceTest: AbstractMongodbTest() {
     private val repository: CoroutineProcessRepository = uninitialized()
 
     @BeforeEach
-    fun beforeEach() {
-        runBlocking {
-            repository.deleteAll()
-        }
+    fun beforeEach() = runSuspendIO {
+        repository.deleteAll()
     }
 
     @Test
@@ -84,7 +81,7 @@ class CoroutineManagedTransitionServiceTest: AbstractMongodbTest() {
     }
 
     @Test
-    fun `coroutine transaction commit and rollback`() = runTest {
+    fun `coroutine transaction commit and rollback`() = runSuspendIO {
         repeat(10) {
             val process = managedTransitionService.newProcess()
             try {

--- a/spring-data/r2dbc-examples/src/test/kotlin/io/bluetape4k/workshop/r2dbc/basics/CustomerRepositoryIntegrationTest.kt
+++ b/spring-data/r2dbc-examples/src/test/kotlin/io/bluetape4k/workshop/r2dbc/basics/CustomerRepositoryIntegrationTest.kt
@@ -1,12 +1,11 @@
 package io.bluetape4k.workshop.r2dbc.basics
 
 import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.reactor.awaitSingle
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.runTest
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldNotBeNull
 import org.junit.jupiter.api.BeforeEach
@@ -23,19 +22,17 @@ class CustomerRepositoryIntegrationTest(
     companion object: KLoggingChannel()
 
     @BeforeEach
-    fun beforeEach() {
-        runBlocking {
-            val statements = listOf(
-                "DROP TABLE IF EXISTS customer;",
-                "CREATE TABLE customer (id SERIAL PRIMARY KEY, firstname VARCHAR(100) NOT NULL, lastname VARCHAR(100) NOT NULL);",
-            )
+    fun beforeEach() = runSuspendIO {
+        val statements = listOf(
+            "DROP TABLE IF EXISTS customer;",
+            "CREATE TABLE customer (id SERIAL PRIMARY KEY, firstname VARCHAR(100) NOT NULL, lastname VARCHAR(100) NOT NULL);",
+        )
 
-            statements.forEach {
-                database.sql(it)
-                    .fetch()
-                    .rowsUpdated()
-                    .awaitSingle()
-            }
+        statements.forEach {
+            database.sql(it)
+                .fetch()
+                .rowsUpdated()
+                .awaitSingle()
         }
     }
 
@@ -45,7 +42,7 @@ class CustomerRepositoryIntegrationTest(
     }
 
     @Test
-    fun `execute find all`() = runTest {
+    fun `execute find all`() = runSuspendIO {
         val dave = Customer("Dave", "Matthews")
         val carter = Customer("Carter", "Beauford")
 
@@ -57,7 +54,7 @@ class CustomerRepositoryIntegrationTest(
     }
 
     @Test
-    fun `execute annotated query`() = runTest {
+    fun `execute annotated query`() = runSuspendIO {
         val dave = Customer("Dave", "Matthews")
         val carter = Customer("Carter", "Beauford")
 

--- a/spring-data/r2dbc-examples/src/test/kotlin/io/bluetape4k/workshop/r2dbc/basics/TransactionalServiceIntegrationTest.kt
+++ b/spring-data/r2dbc-examples/src/test/kotlin/io/bluetape4k/workshop/r2dbc/basics/TransactionalServiceIntegrationTest.kt
@@ -1,10 +1,9 @@
 package io.bluetape4k.workshop.r2dbc.basics
 
 import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.reactor.awaitSingle
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.runTest
 import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldNotBeNull
@@ -24,25 +23,23 @@ class TransactionalServiceIntegrationTest @Autowired constructor(
     companion object: KLoggingChannel()
 
     @BeforeEach
-    fun beforeEach() {
-        runBlocking {
-            val statements = listOf(
-                "DROP TABLE IF EXISTS customer;",
-                """
-                CREATE TABLE customer (
-                    id SERIAL PRIMARY KEY, 
-                    firstname VARCHAR(100) NOT NULL, 
-                    lastname VARCHAR(100) NOT NULL
-                );
-                """.trimIndent(),
-            )
+    fun beforeEach() = runSuspendIO {
+        val statements = listOf(
+            "DROP TABLE IF EXISTS customer;",
+            """
+            CREATE TABLE customer (
+                id SERIAL PRIMARY KEY,
+                firstname VARCHAR(100) NOT NULL,
+                lastname VARCHAR(100) NOT NULL
+            );
+            """.trimIndent(),
+        )
 
-            statements.forEach {
-                database.sql(it)
-                    .fetch()
-                    .rowsUpdated()
-                    .awaitSingle()
-            }
+        statements.forEach {
+            database.sql(it)
+                .fetch()
+                .rowsUpdated()
+                .awaitSingle()
         }
     }
 
@@ -52,7 +49,7 @@ class TransactionalServiceIntegrationTest @Autowired constructor(
     }
 
     @Test
-    fun `exception triggers rollback`() = runTest {
+    fun `exception triggers rollback`() = runSuspendIO {
 
         // Dave 저장 시 예외가 발생하여 Rollback 하게 된다.
         assertFailsWith<IllegalStateException> {
@@ -63,7 +60,7 @@ class TransactionalServiceIntegrationTest @Autowired constructor(
     }
 
     @Test
-    fun `insert data transactionally`() = runTest {
+    fun `insert data transactionally`() = runSuspendIO {
         // 저장된다.
         service.save(Customer("Carter", "Beauford")).hasId.shouldBeTrue()
 

--- a/spring-data/r2dbc-examples/src/test/kotlin/io/bluetape4k/workshop/r2dbc/queryexample/PersonRepositoryIntegrationTest.kt
+++ b/spring-data/r2dbc-examples/src/test/kotlin/io/bluetape4k/workshop/r2dbc/queryexample/PersonRepositoryIntegrationTest.kt
@@ -7,8 +7,7 @@ import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.reactive.asFlow
 import kotlinx.coroutines.reactor.awaitSingle
 import kotlinx.coroutines.reactor.awaitSingleOrNull
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.runTest
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldContainSame
 import io.bluetape4k.assertions.shouldNotBeNull
@@ -36,31 +35,29 @@ class PersonRepositoryIntegrationTest @Autowired constructor(
     private lateinit var hank: Person
 
     @BeforeEach
-    fun beforeEach() {
-        runBlocking {
-            val statements = listOf(
-                "DROP TABLE IF EXISTS person;",
-                """
-                CREATE TABLE person (
-                    id SERIAL PRIMARY KEY, 
-                    firstname VARCHAR(100) NOT NULL, 
-                    lastname VARCHAR(100) NOT NULL, 
-                    age INTEGER NOT NULL
-                );""".trimIndent()
-            )
+    fun beforeEach() = runSuspendIO {
+        val statements = listOf(
+            "DROP TABLE IF EXISTS person;",
+            """
+            CREATE TABLE person (
+                id SERIAL PRIMARY KEY,
+                firstname VARCHAR(100) NOT NULL,
+                lastname VARCHAR(100) NOT NULL,
+                age INTEGER NOT NULL
+            );""".trimIndent()
+        )
 
-            skyler = Person("Skyler", "White", 45)
-            walter = Person("Walter", "White", 50)
-            flynn = Person("Walter Jr. (Flynn)", "White", 17)
-            marie = Person("Marie", "Schrader", 38)
-            hank = Person("Hank", "Schrader", 43)
+        skyler = Person("Skyler", "White", 45)
+        walter = Person("Walter", "White", 50)
+        flynn = Person("Walter Jr. (Flynn)", "White", 17)
+        marie = Person("Marie", "Schrader", 38)
+        hank = Person("Hank", "Schrader", 43)
 
-            statements.forEach { stmt ->
-                client.sql(stmt).fetch().rowsUpdated().awaitSingleOrNull()
-            }
-
-            repository.saveAll(listOf(skyler, walter, flynn, marie, hank)).asFlow().collect()
+        statements.forEach { stmt ->
+            client.sql(stmt).fetch().rowsUpdated().awaitSingleOrNull()
         }
+
+        repository.saveAll(listOf(skyler, walter, flynn, marie, hank)).asFlow().collect()
     }
 
     @Test
@@ -70,7 +67,7 @@ class PersonRepositoryIntegrationTest @Autowired constructor(
     }
 
     @Test
-    fun `count by simple example`() = runTest {
+    fun `count by simple example`() = runSuspendIO {
 
         // Kotlin 클래스에 대해서 non-null 때문에 Example 만드는 것은 이렇게 Example에 지정할 속성명을 특정해주는 [ExampleMatcher]를 사용해야 한다!!!
         val matcher = Person::class
@@ -85,7 +82,7 @@ class PersonRepositoryIntegrationTest @Autowired constructor(
     }
 
     @Test
-    fun `ignore properties and match by age`() = runTest {
+    fun `ignore properties and match by age`() = runSuspendIO {
         // Kotlin 클래스에 대해서 non-null 때문에 Example 만드는 것은 이렇게 Example에 지정할 속성명을 특정해주는 [ExampleMatcher]를 사용해야 한다!!!
         val matcher = Person::class
             .buildExampleMatcher(Person::age.name)
@@ -98,7 +95,7 @@ class PersonRepositoryIntegrationTest @Autowired constructor(
     }
 
     @Test
-    fun `match starting strings ignore case`() = runTest {
+    fun `match starting strings ignore case`() = runSuspendIO {
         // Kotlin 클래스에 대해서 non-null 때문에 Example 만드는 것은 이렇게 Example에 지정할 속성명을 특정해주는 [ExampleMatcher]를 사용해야 한다!!!
         val matcher = Person::class
             .buildExampleMatcher(Person::firstname.name, Person::lastname.name)
@@ -112,7 +109,7 @@ class PersonRepositoryIntegrationTest @Autowired constructor(
     }
 
     @Test
-    fun `configuring matchers using lambdas`() = runTest {
+    fun `configuring matchers using lambdas`() = runSuspendIO {
         // Kotlin 클래스에 대해서 non-null 때문에 Example 만드는 것은 이렇게 Example에 지정할 속성명을 특정해주는 [ExampleMatcher]를 사용해야 한다!!!
         val matcher = ExampleMatcher.matching()
             .withIgnorePaths(Person::age.name)
@@ -126,7 +123,7 @@ class PersonRepositoryIntegrationTest @Autowired constructor(
     }
 
     @Test
-    fun `value transformer`() = runTest {
+    fun `value transformer`() = runSuspendIO {
         // Kotlin 클래스에 대해서 non-null 때문에 Example 만드는 것은 이렇게 Example에 지정할 속성명을 특정해주는 [ExampleMatcher]를 사용해야 한다!!!
         val matcher = Person::class
             .buildExampleMatcher(Person::lastname.name, Person::age.name)

--- a/spring-data/redis-examples/src/test/kotlin/io/bluetape4k/workshop/redis/reactive/commands/ReactiveKeyCommandsTest.kt
+++ b/spring-data/redis-examples/src/test/kotlin/io/bluetape4k/workshop/redis/reactive/commands/ReactiveKeyCommandsTest.kt
@@ -21,7 +21,6 @@ import kotlinx.coroutines.reactive.asFlow
 import kotlinx.coroutines.reactive.awaitLast
 import kotlinx.coroutines.reactor.asFlux
 import kotlinx.coroutines.reactor.awaitSingle
-import kotlinx.coroutines.runBlocking
 import io.bluetape4k.assertions.shouldBeEqualTo
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Disabled
@@ -66,10 +65,8 @@ class ReactiveKeyCommandsTest(
     }
 
     @BeforeEach
-    fun beforeEach() {
-        runBlocking {
-            connection.serverCommands().flushAll().awaitSingle()
-        }
+    fun beforeEach() = runSuspendIO {
+        connection.serverCommands().flushAll().awaitSingle()
     }
 
     @Disabled("Lettuce 7.x 에서는 keys 를 패턴으로 찾기가 안된다")

--- a/spring-data/redis-examples/src/test/kotlin/io/bluetape4k/workshop/redis/reactive/operations/JacksonJsonTest.kt
+++ b/spring-data/redis-examples/src/test/kotlin/io/bluetape4k/workshop/redis/reactive/operations/JacksonJsonTest.kt
@@ -10,7 +10,7 @@ import io.bluetape4k.workshop.redis.reactive.model.EmailAddress
 import io.bluetape4k.workshop.redis.reactive.model.Person
 import kotlinx.coroutines.reactive.awaitSingle
 import kotlinx.coroutines.reactor.awaitSingle
-import kotlinx.coroutines.runBlocking
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeInstanceOf
 import io.bluetape4k.assertions.shouldBeTrue
@@ -28,13 +28,11 @@ class JacksonJsonTest @Autowired constructor(
     companion object: KLoggingChannel()
 
     @BeforeEach
-    fun beforeEach() {
-        runBlocking {
-            // TODO: ReactiveRedisOperations 에 대해 `executeSuspending` 함수를 만들자
-            genericOperations.execute { connection ->
-                connection.serverCommands().flushAll()
-            }.awaitSingle() shouldBeEqualTo "OK"
-        }
+    fun beforeEach() = runSuspendIO {
+        // TODO: ReactiveRedisOperations 에 대해 `executeSuspending` 함수를 만들자
+        genericOperations.execute { connection ->
+            connection.serverCommands().flushAll()
+        }.awaitSingle() shouldBeEqualTo "OK"
     }
 
     @Test

--- a/spring-data/redis-examples/src/test/kotlin/io/bluetape4k/workshop/redis/reactive/operations/ListOperationsTest.kt
+++ b/spring-data/redis-examples/src/test/kotlin/io/bluetape4k/workshop/redis/reactive/operations/ListOperationsTest.kt
@@ -7,7 +7,6 @@ import io.bluetape4k.workshop.redis.reactive.AbstractReactiveRedisTest
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.reactive.awaitSingle
 import kotlinx.coroutines.reactor.awaitSingleOrNull
-import kotlinx.coroutines.runBlocking
 import io.bluetape4k.assertions.shouldBeEqualTo
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -25,12 +24,10 @@ class ListOperationsTest(
     }
 
     @BeforeEach
-    fun beforeEach() {
-        runBlocking {
-            operations.execute { conn ->
-                conn.serverCommands().flushDb()
-            }.awaitSingle() shouldBeEqualTo "OK"
-        }
+    fun beforeEach() = runSuspendIO {
+        operations.execute { conn ->
+            conn.serverCommands().flushDb()
+        }.awaitSingle() shouldBeEqualTo "OK"
     }
 
     /**

--- a/spring-data/redis-examples/src/test/kotlin/io/bluetape4k/workshop/redis/reactive/operations/ValueOperationsTest.kt
+++ b/spring-data/redis-examples/src/test/kotlin/io/bluetape4k/workshop/redis/reactive/operations/ValueOperationsTest.kt
@@ -7,7 +7,6 @@ import io.bluetape4k.workshop.redis.reactive.AbstractReactiveRedisTest
 import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.reactive.awaitSingle
 import kotlinx.coroutines.reactor.awaitSingleOrNull
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.time.delay
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeLessOrEqualTo
@@ -31,13 +30,11 @@ class ValueOperationsTest(
     private var valueCreationCount by valueCreationCounter
 
     @BeforeEach
-    fun beforeEach() {
-        runBlocking {
-            // TODO: ReactiveRedisOperations 에 대해 `executeSuspending` 함수를 만들자 
-            operations.execute { connection ->
-                connection.serverCommands().flushAll()
-            }.awaitSingle() shouldBeEqualTo "OK"
-        }
+    fun beforeEach() = runSuspendIO {
+        // TODO: ReactiveRedisOperations 에 대해 `executeSuspending` 함수를 만들자
+        operations.execute { connection ->
+            connection.serverCommands().flushAll()
+        }.awaitSingle() shouldBeEqualTo "OK"
         valueCreationCount = 0
     }
 

--- a/spring-data/redis-examples/src/test/kotlin/io/bluetape4k/workshop/redis/stream/reactive/ReactiveStreamApiTest.kt
+++ b/spring-data/redis-examples/src/test/kotlin/io/bluetape4k/workshop/redis/stream/reactive/ReactiveStreamApiTest.kt
@@ -10,7 +10,6 @@ import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.reactive.asFlow
 import kotlinx.coroutines.reactive.awaitFirstOrNull
 import kotlinx.coroutines.reactor.awaitSingle
-import kotlinx.coroutines.runBlocking
 import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeTrue
@@ -42,10 +41,8 @@ class ReactiveStreamApiTest(
     private val streamOps: ReactiveStreamOperations<String, String, String> = template.opsForStream()
 
     @BeforeEach
-    fun beforeEach() {
-        runBlocking {
-            template.connectionFactory.reactiveConnection.serverCommands().flushAll().awaitSingle()
-        }
+    fun beforeEach() = runSuspendIO {
+        template.connectionFactory.reactiveConnection.serverCommands().flushAll().awaitSingle()
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Replace ad hoc unique string generation in leader tests with `Base58.randomString(8)`.
- Move IO-backed coroutine tests from `runTest`/`runBlocking` toward `runSuspendIO`.
- Use bluetape4k Testcontainers helpers in Redis failure coverage and remove raw JUnit timeout assertion usage.

## Why
Workshop examples should demonstrate the bluetape4k stack instead of reimplementing helper patterns already provided by bluetape4k-* modules.

## Validation
- `rg` scan found no raw `GenericContainer`, JUnit/AssertJ/Kluent/kotlin.test assertion imports, `assertThrows`, or `UUID.randomUUID()` in Kotlin sources.
- `git diff --check`
- `./gradlew :exposed-webflux-r2dbc:test :leader-leader-election:test :leader-leader-zookeeper:test :spring-data-r2dbc-examples:test :spring-data-mongodb-coroutines:test :spring-data-mongodb-transactions:test :spring-data-redis-examples:test`
- `./gradlew :spring-data-r2dbc-examples:test`
- `./gradlew build`

## Notes
- Redis tests still emit Lettuce shutdown warnings during context teardown, but Gradle reports the tests as passing.
- IntelliJ MCP diagnostics were unavailable in this session, so Gradle and repository scans were used as fallback evidence.
