### PR TITLE
Align workshop IO tests with bluetape4k lifecycles

### DIFF
--- a/graph/knowledge-graph/src/test/kotlin/io/bluetape4k/workshop/graph/knowledge/AbstractKnowledgeGraphSuspendTest.kt
+++ b/graph/knowledge-graph/src/test/kotlin/io/bluetape4k/workshop/graph/knowledge/AbstractKnowledgeGraphSuspendTest.kt
@@ -10,7 +10,7 @@ import io.bluetape4k.workshop.graph.knowledge.seed.KnowledgeGraphSeed
 import io.bluetape4k.workshop.graph.knowledge.seed.seedKnowledgeGraph
 import io.bluetape4k.workshop.graph.knowledge.service.KnowledgeGraphSuspendService
 import kotlinx.coroutines.flow.toList
-import kotlinx.coroutines.test.runTest
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
@@ -35,7 +35,7 @@ abstract class AbstractKnowledgeGraphSuspendTest {
     protected lateinit var seed: KnowledgeGraphSeed
 
     @BeforeEach
-    fun cleanGraph() = runTest {
+    fun cleanGraph() = runSuspendIO {
         ops.dropGraph(graphName)
         service.initialize()
         seed = seedKnowledgeGraph(service)
@@ -46,7 +46,7 @@ abstract class AbstractKnowledgeGraphSuspendTest {
     // ─────────────────────────────────────────────────────────────────────
 
     @Test
-    fun `findMentionedEntities returns entities mentioned by a document`() = runTest {
+    fun `findMentionedEntities returns entities mentioned by a document`() = runSuspendIO {
         val entityIds = service.findMentionedEntities(seed.docKotlinGuide.id).toList()
             .map { it.properties["entityId"] }
 
@@ -55,7 +55,7 @@ abstract class AbstractKnowledgeGraphSuspendTest {
     }
 
     @Test
-    fun `findMentionedEntities for spring guide returns spring and kotlin`() = runTest {
+    fun `findMentionedEntities for spring guide returns spring and kotlin`() = runSuspendIO {
         val entityIds = service.findMentionedEntities(seed.docSpringGuide.id).toList()
             .map { it.properties["entityId"] }
 
@@ -68,7 +68,7 @@ abstract class AbstractKnowledgeGraphSuspendTest {
     // ─────────────────────────────────────────────────────────────────────
 
     @Test
-    fun `findRelatedEntities returns direct neighbours at depth 1`() = runTest {
+    fun `findRelatedEntities returns direct neighbours at depth 1`() = runSuspendIO {
         val entityIds = service.findRelatedEntities(seed.entityKotlin.id, depth = 1).toList()
             .map { it.properties["entityId"] }
 
@@ -78,7 +78,7 @@ abstract class AbstractKnowledgeGraphSuspendTest {
     }
 
     @Test
-    fun `findRelatedEntities at depth 2 includes transitively reachable entities`() = runTest {
+    fun `findRelatedEntities at depth 2 includes transitively reachable entities`() = runSuspendIO {
         val entityIds = service.findRelatedEntities(seed.entityKotlin.id, depth = 2).toList()
             .map { it.properties["entityId"] }
 
@@ -93,7 +93,7 @@ abstract class AbstractKnowledgeGraphSuspendTest {
     // ─────────────────────────────────────────────────────────────────────
 
     @Test
-    fun `findConceptsForEntity returns concept for kotlin entity`() = runTest {
+    fun `findConceptsForEntity returns concept for kotlin entity`() = runSuspendIO {
         val conceptIds = service.findConceptsForEntity(seed.entityKotlin.id).toList()
             .map { it.properties["conceptId"] }
 
@@ -102,7 +102,7 @@ abstract class AbstractKnowledgeGraphSuspendTest {
     }
 
     @Test
-    fun `findConceptsForEntity returns framework concept for spring entity`() = runTest {
+    fun `findConceptsForEntity returns framework concept for spring entity`() = runSuspendIO {
         val conceptIds = service.findConceptsForEntity(seed.entitySpring.id).toList()
             .map { it.properties["conceptId"] }
 
@@ -115,7 +115,7 @@ abstract class AbstractKnowledgeGraphSuspendTest {
     // ─────────────────────────────────────────────────────────────────────
 
     @Test
-    fun `inferRelationshipPaths finds path from kotlin to spring`() = runTest {
+    fun `inferRelationshipPaths finds path from kotlin to spring`() = runSuspendIO {
         val paths = service.inferRelationshipPaths(
             seed.entityKotlin.id,
             seed.entitySpring.id,
@@ -130,7 +130,7 @@ abstract class AbstractKnowledgeGraphSuspendTest {
     }
 
     @Test
-    fun `inferRelationshipPaths respects maxPaths bound`() = runTest {
+    fun `inferRelationshipPaths respects maxPaths bound`() = runSuspendIO {
         val paths = service.inferRelationshipPaths(
             seed.entityKotlin.id,
             seed.entityJvm.id,
@@ -146,7 +146,7 @@ abstract class AbstractKnowledgeGraphSuspendTest {
     // ─────────────────────────────────────────────────────────────────────
 
     @Test
-    fun `classify and findConceptsForEntity round-trip`() = runTest {
+    fun `classify and findConceptsForEntity round-trip`() = runSuspendIO {
         val buildTool = service.addConcept("concept-build-tool", "Build Tool", "infrastructure")
         val gradle = service.addEntity("entity-gradle", "Gradle", "BuildTool")
         service.classify(gradle.id, buildTool.id)
@@ -158,7 +158,7 @@ abstract class AbstractKnowledgeGraphSuspendTest {
     }
 
     @Test
-    fun `mention creates findMentionedEntities link`() = runTest {
+    fun `mention creates findMentionedEntities link`() = runSuspendIO {
         val doc = service.addDocument("doc-gradle-guide", "Gradle User Manual", "docs")
         val gradle = service.addEntity("entity-gradle", "Gradle", "BuildTool")
         service.mention(doc.id, gradle.id, confidence = 90)
@@ -174,7 +174,7 @@ abstract class AbstractKnowledgeGraphSuspendTest {
     // ─────────────────────────────────────────────────────────────────────
 
     @Test
-    fun `addEntity and retrieve via findRelatedEntities`() = runTest {
+    fun `addEntity and retrieve via findRelatedEntities`() = runSuspendIO {
         val gradle = service.addEntity("entity-gradle", "Gradle", "BuildTool")
         service.relateEntities(seed.entityKotlin.id, gradle.id, relationType = "uses")
 
@@ -189,56 +189,56 @@ abstract class AbstractKnowledgeGraphSuspendTest {
     // ─────────────────────────────────────────────────────────────────────
 
     @Test
-    fun `addEntity with blank entityId throws IllegalArgumentException`() = runTest {
+    fun `addEntity with blank entityId throws IllegalArgumentException`() = runSuspendIO {
         assertFailsWith<IllegalArgumentException> {
             service.addEntity("", "Name", "Type")
         }
     }
 
     @Test
-    fun `addConcept with blank conceptId throws IllegalArgumentException`() = runTest {
+    fun `addConcept with blank conceptId throws IllegalArgumentException`() = runSuspendIO {
         assertFailsWith<IllegalArgumentException> {
             service.addConcept("", "Name")
         }
     }
 
     @Test
-    fun `addDocument with blank documentId throws IllegalArgumentException`() = runTest {
+    fun `addDocument with blank documentId throws IllegalArgumentException`() = runSuspendIO {
         assertFailsWith<IllegalArgumentException> {
             service.addDocument("", "Title")
         }
     }
 
     @Test
-    fun `mention with confidence above 100 throws IllegalArgumentException`() = runTest {
+    fun `mention with confidence above 100 throws IllegalArgumentException`() = runSuspendIO {
         assertFailsWith<IllegalArgumentException> {
             service.mention(seed.docKotlinGuide.id, seed.entityKotlin.id, confidence = 101)
         }
     }
 
     @Test
-    fun `mention with negative confidence throws IllegalArgumentException`() = runTest {
+    fun `mention with negative confidence throws IllegalArgumentException`() = runSuspendIO {
         assertFailsWith<IllegalArgumentException> {
             service.mention(seed.docKotlinGuide.id, seed.entityKotlin.id, confidence = -1)
         }
     }
 
     @Test
-    fun `findRelatedEntities with zero depth throws IllegalArgumentException`() = runTest {
+    fun `findRelatedEntities with zero depth throws IllegalArgumentException`() = runSuspendIO {
         assertFailsWith<IllegalArgumentException> {
             service.findRelatedEntities(seed.entityKotlin.id, depth = 0)
         }
     }
 
     @Test
-    fun `inferRelationshipPaths with zero maxDepth throws IllegalArgumentException`() = runTest {
+    fun `inferRelationshipPaths with zero maxDepth throws IllegalArgumentException`() = runSuspendIO {
         assertFailsWith<IllegalArgumentException> {
             service.inferRelationshipPaths(seed.entityKotlin.id, seed.entitySpring.id, maxDepth = 0)
         }
     }
 
     @Test
-    fun `inferRelationshipPaths with zero maxPaths throws IllegalArgumentException`() = runTest {
+    fun `inferRelationshipPaths with zero maxPaths throws IllegalArgumentException`() = runSuspendIO {
         assertFailsWith<IllegalArgumentException> {
             service.inferRelationshipPaths(seed.entityKotlin.id, seed.entitySpring.id, maxPaths = 0)
         }

--- a/graph/recommendation/src/test/kotlin/io/bluetape4k/workshop/graph/recommendation/AbstractRecommendationSuspendTest.kt
+++ b/graph/recommendation/src/test/kotlin/io/bluetape4k/workshop/graph/recommendation/AbstractRecommendationSuspendTest.kt
@@ -19,7 +19,7 @@ import io.bluetape4k.workshop.graph.recommendation.seed.USER_DAVE
 import io.bluetape4k.workshop.graph.recommendation.seed.USER_EVE
 import io.bluetape4k.workshop.graph.recommendation.seed.seedRecommendation
 import io.bluetape4k.workshop.graph.recommendation.service.RecommendationSuspendService
-import kotlinx.coroutines.test.runTest
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
@@ -61,7 +61,7 @@ abstract class AbstractRecommendationSuspendTest {
     protected abstract val service: RecommendationSuspendService
 
     @BeforeEach
-    fun cleanGraph() = runTest {
+    fun cleanGraph() = runSuspendIO {
         ops.dropGraph(graphName)
         service.initialize()
     }
@@ -71,7 +71,7 @@ abstract class AbstractRecommendationSuspendTest {
     // ─────────────────────────────────────────────────────────────────────────
 
     @Test
-    fun `addUser creates User vertex with correct properties`() = runTest {
+    fun `addUser creates User vertex with correct properties`() = runSuspendIO {
         val alice = service.addUser(USER_ALICE, "Alice")
 
         alice.label shouldBeEqualTo "User"
@@ -80,7 +80,7 @@ abstract class AbstractRecommendationSuspendTest {
     }
 
     @Test
-    fun `addUser returns existing vertex on second call (idempotent)`() = runTest {
+    fun `addUser returns existing vertex on second call (idempotent)`() = runSuspendIO {
         val first = service.addUser(USER_ALICE, "Alice")
         val second = service.addUser(USER_ALICE, "Alice")
 
@@ -88,7 +88,7 @@ abstract class AbstractRecommendationSuspendTest {
     }
 
     @Test
-    fun `addProduct creates Product vertex with correct properties`() = runTest {
+    fun `addProduct creates Product vertex with correct properties`() = runSuspendIO {
         val laptop = service.addProduct("laptop", "Laptop", category = "Electronics")
 
         laptop.label shouldBeEqualTo "Product"
@@ -98,7 +98,7 @@ abstract class AbstractRecommendationSuspendTest {
     }
 
     @Test
-    fun `addProduct returns existing vertex on second call (idempotent)`() = runTest {
+    fun `addProduct returns existing vertex on second call (idempotent)`() = runSuspendIO {
         val first = service.addProduct("laptop", "Laptop")
         val second = service.addProduct("laptop", "Laptop")
 
@@ -110,28 +110,28 @@ abstract class AbstractRecommendationSuspendTest {
     // ─────────────────────────────────────────────────────────────────────────
 
     @Test
-    fun `addUser with blank userId throws IllegalArgumentException`() = runTest {
+    fun `addUser with blank userId throws IllegalArgumentException`() = runSuspendIO {
         assertFailsWith<IllegalArgumentException> {
             service.addUser("", "Alice")
         }
     }
 
     @Test
-    fun `addUser with blank name throws IllegalArgumentException`() = runTest {
+    fun `addUser with blank name throws IllegalArgumentException`() = runSuspendIO {
         assertFailsWith<IllegalArgumentException> {
             service.addUser(USER_ALICE, "")
         }
     }
 
     @Test
-    fun `addProduct with blank productId throws IllegalArgumentException`() = runTest {
+    fun `addProduct with blank productId throws IllegalArgumentException`() = runSuspendIO {
         assertFailsWith<IllegalArgumentException> {
             service.addProduct("", "Laptop")
         }
     }
 
     @Test
-    fun `purchase with rating below 0 throws IllegalArgumentException`() = runTest {
+    fun `purchase with rating below 0 throws IllegalArgumentException`() = runSuspendIO {
         val alice = service.addUser(USER_ALICE, "Alice")
         val laptop = service.addProduct("laptop", "Laptop")
 
@@ -141,7 +141,7 @@ abstract class AbstractRecommendationSuspendTest {
     }
 
     @Test
-    fun `purchase with rating above 5 throws IllegalArgumentException`() = runTest {
+    fun `purchase with rating above 5 throws IllegalArgumentException`() = runSuspendIO {
         val alice = service.addUser(USER_ALICE, "Alice")
         val laptop = service.addProduct("laptop", "Laptop")
 
@@ -151,7 +151,7 @@ abstract class AbstractRecommendationSuspendTest {
     }
 
     @Test
-    fun `recommendProducts with limit 0 throws IllegalArgumentException`() = runTest {
+    fun `recommendProducts with limit 0 throws IllegalArgumentException`() = runSuspendIO {
         val alice = service.addUser(USER_ALICE, "Alice")
 
         assertFailsWith<IllegalArgumentException> {
@@ -160,7 +160,7 @@ abstract class AbstractRecommendationSuspendTest {
     }
 
     @Test
-    fun `recommendProducts with limit above MAX throws IllegalArgumentException`() = runTest {
+    fun `recommendProducts with limit above MAX throws IllegalArgumentException`() = runSuspendIO {
         val alice = service.addUser(USER_ALICE, "Alice")
 
         assertFailsWith<IllegalArgumentException> {
@@ -169,7 +169,7 @@ abstract class AbstractRecommendationSuspendTest {
     }
 
     @Test
-    fun `recommendFollows with limit 0 throws IllegalArgumentException`() = runTest {
+    fun `recommendFollows with limit 0 throws IllegalArgumentException`() = runSuspendIO {
         val alice = service.addUser(USER_ALICE, "Alice")
 
         assertFailsWith<IllegalArgumentException> {
@@ -178,7 +178,7 @@ abstract class AbstractRecommendationSuspendTest {
     }
 
     @Test
-    fun `recommendFollows with limit above MAX throws IllegalArgumentException`() = runTest {
+    fun `recommendFollows with limit above MAX throws IllegalArgumentException`() = runSuspendIO {
         val alice = service.addUser(USER_ALICE, "Alice")
 
         assertFailsWith<IllegalArgumentException> {
@@ -187,7 +187,7 @@ abstract class AbstractRecommendationSuspendTest {
     }
 
     @Test
-    fun `follow with same follower and followee throws IllegalArgumentException`() = runTest {
+    fun `follow with same follower and followee throws IllegalArgumentException`() = runSuspendIO {
         val alice = service.addUser(USER_ALICE, "Alice")
 
         assertFailsWith<IllegalArgumentException> {
@@ -200,7 +200,7 @@ abstract class AbstractRecommendationSuspendTest {
     // ─────────────────────────────────────────────────────────────────────────
 
     @Test
-    fun `purchase creates PURCHASED edge without rating`() = runTest {
+    fun `purchase creates PURCHASED edge without rating`() = runSuspendIO {
         val alice = service.addUser(USER_ALICE, "Alice")
         val laptop = service.addProduct("laptop", "Laptop")
         val edge = service.purchase(alice.id, laptop.id)
@@ -211,7 +211,7 @@ abstract class AbstractRecommendationSuspendTest {
     }
 
     @Test
-    fun `purchase creates PURCHASED edge with rating stored as String`() = runTest {
+    fun `purchase creates PURCHASED edge with rating stored as String`() = runSuspendIO {
         val alice = service.addUser(USER_ALICE, "Alice")
         val laptop = service.addProduct("laptop", "Laptop")
         val edge = service.purchase(alice.id, laptop.id, rating = 5)
@@ -220,7 +220,7 @@ abstract class AbstractRecommendationSuspendTest {
     }
 
     @Test
-    fun `purchase creates PURCHASED edge with purchasedAt stored`() = runTest {
+    fun `purchase creates PURCHASED edge with purchasedAt stored`() = runSuspendIO {
         val alice = service.addUser(USER_ALICE, "Alice")
         val laptop = service.addProduct("laptop", "Laptop")
         val edge = service.purchase(alice.id, laptop.id, purchasedAt = "2024-01-15")
@@ -229,7 +229,7 @@ abstract class AbstractRecommendationSuspendTest {
     }
 
     @Test
-    fun `follow creates FOLLOWS edge between two users`() = runTest {
+    fun `follow creates FOLLOWS edge between two users`() = runSuspendIO {
         val alice = service.addUser(USER_ALICE, "Alice")
         val bob = service.addUser(USER_BOB, "Bob")
         val edge = service.follow(alice.id, bob.id)
@@ -243,7 +243,7 @@ abstract class AbstractRecommendationSuspendTest {
     // ─────────────────────────────────────────────────────────────────────────
 
     @Test
-    fun `recommendProducts returns headphones with score 3`() = runTest {
+    fun `recommendProducts returns headphones with score 3`() = runSuspendIO {
         val seed = seedRecommendation(service)
 
         val results = service.recommendProducts(seed.alice.id)
@@ -254,7 +254,7 @@ abstract class AbstractRecommendationSuspendTest {
     }
 
     @Test
-    fun `recommendProducts top result is headphones`() = runTest {
+    fun `recommendProducts top result is headphones`() = runSuspendIO {
         val seed = seedRecommendation(service)
 
         val results = service.recommendProducts(seed.alice.id)
@@ -263,7 +263,7 @@ abstract class AbstractRecommendationSuspendTest {
     }
 
     @Test
-    fun `recommendProducts returns correct descending score ordering`() = runTest {
+    fun `recommendProducts returns correct descending score ordering`() = runSuspendIO {
         val seed = seedRecommendation(service)
 
         val results = service.recommendProducts(seed.alice.id)
@@ -274,7 +274,7 @@ abstract class AbstractRecommendationSuspendTest {
     }
 
     @Test
-    fun `recommendProducts alice own products not in results`() = runTest {
+    fun `recommendProducts alice own products not in results`() = runSuspendIO {
         val seed = seedRecommendation(service)
 
         val results = service.recommendProducts(seed.alice.id)
@@ -286,7 +286,7 @@ abstract class AbstractRecommendationSuspendTest {
     }
 
     @Test
-    fun `recommendProducts user with no purchases returns empty`() = runTest {
+    fun `recommendProducts user with no purchases returns empty`() = runSuspendIO {
         val isolated = service.addUser("isolated", "Isolated User")
 
         val results = service.recommendProducts(isolated.id)
@@ -295,7 +295,7 @@ abstract class AbstractRecommendationSuspendTest {
     }
 
     @Test
-    fun `recommendProducts limit 1 returns only top result`() = runTest {
+    fun `recommendProducts limit 1 returns only top result`() = runSuspendIO {
         val seed = seedRecommendation(service)
 
         val results = service.recommendProducts(seed.alice.id, limit = 1)
@@ -309,7 +309,7 @@ abstract class AbstractRecommendationSuspendTest {
     // ─────────────────────────────────────────────────────────────────────────
 
     @Test
-    fun `recommendFollows returns dave and eve for alice`() = runTest {
+    fun `recommendFollows returns dave and eve for alice`() = runSuspendIO {
         val seed = seedRecommendation(service)
 
         val results = service.recommendFollows(seed.alice.id)
@@ -320,7 +320,7 @@ abstract class AbstractRecommendationSuspendTest {
     }
 
     @Test
-    fun `recommendFollows result is sorted by mutualFollowCount desc then userId asc`() = runTest {
+    fun `recommendFollows result is sorted by mutualFollowCount desc then userId asc`() = runSuspendIO {
         val seed = seedRecommendation(service)
 
         val results = service.recommendFollows(seed.alice.id)
@@ -331,7 +331,7 @@ abstract class AbstractRecommendationSuspendTest {
     }
 
     @Test
-    fun `recommendFollows alice herself not in results`() = runTest {
+    fun `recommendFollows alice herself not in results`() = runSuspendIO {
         val seed = seedRecommendation(service)
 
         val results = service.recommendFollows(seed.alice.id)
@@ -341,7 +341,7 @@ abstract class AbstractRecommendationSuspendTest {
     }
 
     @Test
-    fun `recommendFollows already-followed users not in results`() = runTest {
+    fun `recommendFollows already-followed users not in results`() = runSuspendIO {
         val seed = seedRecommendation(service)
 
         val results = service.recommendFollows(seed.alice.id)
@@ -353,7 +353,7 @@ abstract class AbstractRecommendationSuspendTest {
     }
 
     @Test
-    fun `recommendFollows user with no follows returns empty`() = runTest {
+    fun `recommendFollows user with no follows returns empty`() = runSuspendIO {
         val isolated = service.addUser("isolated", "Isolated User")
 
         val results = service.recommendFollows(isolated.id)
@@ -362,7 +362,7 @@ abstract class AbstractRecommendationSuspendTest {
     }
 
     @Test
-    fun `recommendFollows limit 1 returns only top result`() = runTest {
+    fun `recommendFollows limit 1 returns only top result`() = runSuspendIO {
         val seed = seedRecommendation(service)
 
         val results = service.recommendFollows(seed.alice.id, limit = 1)
@@ -372,7 +372,7 @@ abstract class AbstractRecommendationSuspendTest {
     }
 
     @Test
-    fun `recommendFollows mutual follow count is correct`() = runTest {
+    fun `recommendFollows mutual follow count is correct`() = runSuspendIO {
         val seed = seedRecommendation(service)
 
         val results = service.recommendFollows(seed.alice.id)
@@ -384,7 +384,7 @@ abstract class AbstractRecommendationSuspendTest {
     }
 
     @Test
-    fun `recommendFollows dave intermediary is bob`() = runTest {
+    fun `recommendFollows dave intermediary is bob`() = runSuspendIO {
         val seed = seedRecommendation(service)
 
         val results = service.recommendFollows(seed.alice.id)
@@ -394,7 +394,7 @@ abstract class AbstractRecommendationSuspendTest {
     }
 
     @Test
-    fun `recommendFollows eve intermediary is carol`() = runTest {
+    fun `recommendFollows eve intermediary is carol`() = runSuspendIO {
         val seed = seedRecommendation(service)
 
         val results = service.recommendFollows(seed.alice.id)

--- a/graph/social-network/src/test/kotlin/io/bluetape4k/workshop/graph/social/AbstractSocialNetworkSuspendTest.kt
+++ b/graph/social-network/src/test/kotlin/io/bluetape4k/workshop/graph/social/AbstractSocialNetworkSuspendTest.kt
@@ -16,7 +16,7 @@ import io.bluetape4k.workshop.graph.social.seed.SocialNetworkSeed
 import io.bluetape4k.workshop.graph.social.seed.seedSocialNetwork
 import io.bluetape4k.workshop.graph.social.service.SocialNetworkSuspendService
 import kotlinx.coroutines.flow.toList
-import kotlinx.coroutines.test.runTest
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
@@ -46,7 +46,7 @@ abstract class AbstractSocialNetworkSuspendTest {
     protected abstract val service: SocialNetworkSuspendService
 
     @BeforeEach
-    fun cleanGraph() = runTest {
+    fun cleanGraph() = runSuspendIO {
         ops.dropGraph(graphName)
         service.initialize()
     }
@@ -56,7 +56,7 @@ abstract class AbstractSocialNetworkSuspendTest {
     // ─────────────────────────────────────────────────────────────────────
 
     @Test
-    fun `addPerson creates Person vertex with correct properties`() = runTest {
+    fun `addPerson creates Person vertex with correct properties`() = runSuspendIO {
         val alice = service.addPerson("alice", "Alice Smith", title = "Engineer", location = "Seoul")
 
         alice.label shouldBeEqualTo PersonLabel.label
@@ -67,7 +67,7 @@ abstract class AbstractSocialNetworkSuspendTest {
     }
 
     @Test
-    fun `addPerson returns existing vertex on second call (idempotent)`() = runTest {
+    fun `addPerson returns existing vertex on second call (idempotent)`() = runSuspendIO {
         val first = service.addPerson("alice", "Alice Smith")
         val second = service.addPerson("alice", "Alice Smith")
 
@@ -75,7 +75,7 @@ abstract class AbstractSocialNetworkSuspendTest {
     }
 
     @Test
-    fun `addCompany creates Company vertex with correct properties`() = runTest {
+    fun `addCompany creates Company vertex with correct properties`() = runSuspendIO {
         val acme = service.addCompany("acme", "Acme Corp", industry = "Technology", location = "Seoul")
 
         acme.label shouldBeEqualTo CompanyLabel.label
@@ -85,7 +85,7 @@ abstract class AbstractSocialNetworkSuspendTest {
     }
 
     @Test
-    fun `addCompany returns existing vertex on second call (idempotent)`() = runTest {
+    fun `addCompany returns existing vertex on second call (idempotent)`() = runSuspendIO {
         val first = service.addCompany("acme", "Acme Corp")
         val second = service.addCompany("acme", "Acme Corp")
 
@@ -97,21 +97,21 @@ abstract class AbstractSocialNetworkSuspendTest {
     // ─────────────────────────────────────────────────────────────────────
 
     @Test
-    fun `addPerson with blank personId throws IllegalArgumentException`() = runTest {
+    fun `addPerson with blank personId throws IllegalArgumentException`() = runSuspendIO {
         assertFailsWith<IllegalArgumentException> {
             service.addPerson("", "Alice Smith")
         }
     }
 
     @Test
-    fun `addCompany with blank companyId throws IllegalArgumentException`() = runTest {
+    fun `addCompany with blank companyId throws IllegalArgumentException`() = runSuspendIO {
         assertFailsWith<IllegalArgumentException> {
             service.addCompany("", "Acme Corp")
         }
     }
 
     @Test
-    fun `addWorkExperience with blank role throws IllegalArgumentException`() = runTest {
+    fun `addWorkExperience with blank role throws IllegalArgumentException`() = runSuspendIO {
         val alice = service.addPerson("alice", "Alice Smith")
         val acme = service.addCompany("acme", "Acme Corp")
 
@@ -121,7 +121,7 @@ abstract class AbstractSocialNetworkSuspendTest {
     }
 
     @Test
-    fun `connect with strength below minimum throws IllegalArgumentException`() = runTest {
+    fun `connect with strength below minimum throws IllegalArgumentException`() = runSuspendIO {
         val alice = service.addPerson("alice", "Alice Smith")
         val bob = service.addPerson("bob", "Bob Jones")
 
@@ -131,7 +131,7 @@ abstract class AbstractSocialNetworkSuspendTest {
     }
 
     @Test
-    fun `findAllConnectionPaths with maxDepth exceeding MAX_TRAVERSAL_DEPTH throws IllegalArgumentException`() = runTest {
+    fun `findAllConnectionPaths with maxDepth exceeding MAX_TRAVERSAL_DEPTH throws IllegalArgumentException`() = runSuspendIO {
         val alice = service.addPerson("alice", "Alice Smith")
         val bob = service.addPerson("bob", "Bob Jones")
 
@@ -146,7 +146,7 @@ abstract class AbstractSocialNetworkSuspendTest {
     // ─────────────────────────────────────────────────────────────────────
 
     @Test
-    fun `connect creates bidirectional KNOWS edges`() = runTest {
+    fun `connect creates bidirectional KNOWS edges`() = runSuspendIO {
         val seed: SocialNetworkSeed = seedSocialNetwork(service)
 
         val aliceNeighbors = service.getDirectConnections(seed.alice.id).toList()
@@ -157,7 +157,7 @@ abstract class AbstractSocialNetworkSuspendTest {
     }
 
     @Test
-    fun `connect stores strength as String property`() = runTest {
+    fun `connect stores strength as String property`() = runSuspendIO {
         val alice = service.addPerson("alice", "Alice Smith")
         val bob = service.addPerson("bob", "Bob Jones")
         service.connect(alice.id, bob.id, since = "2024-01-01", strength = 8)
@@ -171,7 +171,7 @@ abstract class AbstractSocialNetworkSuspendTest {
     }
 
     @Test
-    fun `follow creates unidirectional FOLLOWS edge`() = runTest {
+    fun `follow creates unidirectional FOLLOWS edge`() = runSuspendIO {
         val seed = seedSocialNetwork(service)
 
         val aliceNeighbors = service.getDirectConnections(seed.alice.id).toList()
@@ -183,7 +183,7 @@ abstract class AbstractSocialNetworkSuspendTest {
     // ─────────────────────────────────────────────────────────────────────
 
     @Test
-    fun `addWorkExperience creates WORKS_AT edge with correct properties`() = runTest {
+    fun `addWorkExperience creates WORKS_AT edge with correct properties`() = runSuspendIO {
         val alice = service.addPerson("alice", "Alice Smith")
         val acme = service.addCompany("acme", "Acme Corp")
         val edge = service.addWorkExperience(alice.id, acme.id, role = "Engineer", startDate = "2022-03-01", isCurrent = true)
@@ -194,7 +194,7 @@ abstract class AbstractSocialNetworkSuspendTest {
     }
 
     @Test
-    fun `addWorkExperience with isCurrent=false stores false as String`() = runTest {
+    fun `addWorkExperience with isCurrent=false stores false as String`() = runSuspendIO {
         val alice = service.addPerson("alice", "Alice Smith")
         val acme = service.addCompany("acme", "Acme Corp")
         val edge = service.addWorkExperience(alice.id, acme.id, role = "Intern", isCurrent = false)
@@ -207,7 +207,7 @@ abstract class AbstractSocialNetworkSuspendTest {
     // ─────────────────────────────────────────────────────────────────────
 
     @Test
-    fun `getDirectConnections returns 1st-degree KNOWS connections`() = runTest {
+    fun `getDirectConnections returns 1st-degree KNOWS connections`() = runSuspendIO {
         val seed = seedSocialNetwork(service)
 
         val connections = service.getDirectConnections(seed.alice.id).toList()
@@ -218,7 +218,7 @@ abstract class AbstractSocialNetworkSuspendTest {
     }
 
     @Test
-    fun `getDirectConnections result does NOT contain seed vertex`() = runTest {
+    fun `getDirectConnections result does NOT contain seed vertex`() = runSuspendIO {
         val seed = seedSocialNetwork(service)
 
         val connections = service.getDirectConnections(seed.alice.id).toList()
@@ -231,7 +231,7 @@ abstract class AbstractSocialNetworkSuspendTest {
     // ─────────────────────────────────────────────────────────────────────
 
     @Test
-    fun `getConnectionsWithinDegree maxDegree=2 returns up to 2nd-degree connections`() = runTest {
+    fun `getConnectionsWithinDegree maxDegree=2 returns up to 2nd-degree connections`() = runSuspendIO {
         val seed = seedSocialNetwork(service)
 
         val connections = service.getConnectionsWithinDegree(seed.alice.id, maxDegree = 2).toList()
@@ -243,7 +243,7 @@ abstract class AbstractSocialNetworkSuspendTest {
     }
 
     @Test
-    fun `getConnectionsWithinDegree excludes seed vertex`() = runTest {
+    fun `getConnectionsWithinDegree excludes seed vertex`() = runSuspendIO {
         val seed = seedSocialNetwork(service)
 
         val connections = service.getConnectionsWithinDegree(seed.alice.id, maxDegree = 2).toList()
@@ -256,7 +256,7 @@ abstract class AbstractSocialNetworkSuspendTest {
     // ─────────────────────────────────────────────────────────────────────
 
     @Test
-    fun `getNthDegreeConnections degree=1 returns only direct connections`() = runTest {
+    fun `getNthDegreeConnections degree=1 returns only direct connections`() = runSuspendIO {
         val seed = seedSocialNetwork(service)
 
         val firstDegree = service.getNthDegreeConnections(seed.alice.id, degree = 1)
@@ -268,7 +268,7 @@ abstract class AbstractSocialNetworkSuspendTest {
     }
 
     @Test
-    fun `getNthDegreeConnections degree=2 does NOT contain 1st-degree connections`() = runTest {
+    fun `getNthDegreeConnections degree=2 does NOT contain 1st-degree connections`() = runSuspendIO {
         val seed = seedSocialNetwork(service)
 
         val secondDegree = service.getNthDegreeConnections(seed.alice.id, degree = 2)
@@ -280,7 +280,7 @@ abstract class AbstractSocialNetworkSuspendTest {
     }
 
     @Test
-    fun `getNthDegreeConnections degree=2 does NOT contain seed vertex`() = runTest {
+    fun `getNthDegreeConnections degree=2 does NOT contain seed vertex`() = runSuspendIO {
         val seed = seedSocialNetwork(service)
 
         val secondDegree = service.getNthDegreeConnections(seed.alice.id, degree = 2)
@@ -293,7 +293,7 @@ abstract class AbstractSocialNetworkSuspendTest {
     // ─────────────────────────────────────────────────────────────────────
 
     @Test
-    fun `recommendConnections returns FOAF candidates with correct mutualCount`() = runTest {
+    fun `recommendConnections returns FOAF candidates with correct mutualCount`() = runSuspendIO {
         val seed = seedSocialNetwork(service)
 
         val recs = service.recommendConnections(seed.alice.id)
@@ -306,7 +306,7 @@ abstract class AbstractSocialNetworkSuspendTest {
     }
 
     @Test
-    fun `recommendConnections result is sorted by mutualCount desc then personId asc`() = runTest {
+    fun `recommendConnections result is sorted by mutualCount desc then personId asc`() = runSuspendIO {
         val seed = seedSocialNetwork(service)
 
         val recs = service.recommendConnections(seed.alice.id)
@@ -316,7 +316,7 @@ abstract class AbstractSocialNetworkSuspendTest {
     }
 
     @Test
-    fun `recommendConnections excludes existing direct connections`() = runTest {
+    fun `recommendConnections excludes existing direct connections`() = runSuspendIO {
         val seed = seedSocialNetwork(service)
 
         val recs = service.recommendConnections(seed.alice.id)
@@ -326,7 +326,7 @@ abstract class AbstractSocialNetworkSuspendTest {
     }
 
     @Test
-    fun `recommendConnections returns empty for person with no connections`() = runTest {
+    fun `recommendConnections returns empty for person with no connections`() = runSuspendIO {
         val seed = seedSocialNetwork(service)
 
         val recs = service.recommendConnections(seed.eve.id)
@@ -339,7 +339,7 @@ abstract class AbstractSocialNetworkSuspendTest {
     // ─────────────────────────────────────────────────────────────────────
 
     @Test
-    fun `findColleagues returns colleagues at the same company`() = runTest {
+    fun `findColleagues returns colleagues at the same company`() = runSuspendIO {
         val seed = seedSocialNetwork(service)
 
         val colleagues = service.findColleagues(seed.alice.id).toList()
@@ -349,7 +349,7 @@ abstract class AbstractSocialNetworkSuspendTest {
     }
 
     @Test
-    fun `findColleagues excludes the seed person`() = runTest {
+    fun `findColleagues excludes the seed person`() = runSuspendIO {
         val seed = seedSocialNetwork(service)
 
         val colleagues = service.findColleagues(seed.alice.id).toList()
@@ -362,7 +362,7 @@ abstract class AbstractSocialNetworkSuspendTest {
     // ─────────────────────────────────────────────────────────────────────
 
     @Test
-    fun `findConnectionPath returns path of length 1 for directly connected persons`() = runTest {
+    fun `findConnectionPath returns path of length 1 for directly connected persons`() = runSuspendIO {
         val seed = seedSocialNetwork(service)
 
         val path = service.findConnectionPath(seed.alice.id, seed.bob.id)
@@ -373,7 +373,7 @@ abstract class AbstractSocialNetworkSuspendTest {
     }
 
     @Test
-    fun `findConnectionPath returns 2-hop path via intermediary`() = runTest {
+    fun `findConnectionPath returns 2-hop path via intermediary`() = runSuspendIO {
         val seed = seedSocialNetwork(service)
 
         val path = service.findConnectionPath(seed.alice.id, seed.dave.id)
@@ -383,7 +383,7 @@ abstract class AbstractSocialNetworkSuspendTest {
     }
 
     @Test
-    fun `findConnectionPath returns null when no path exists`() = runTest {
+    fun `findConnectionPath returns null when no path exists`() = runSuspendIO {
         val alice = service.addPerson("alice", "Alice Smith")
         val isolated = service.addPerson("isolated", "Isolated Person")
 
@@ -397,7 +397,7 @@ abstract class AbstractSocialNetworkSuspendTest {
     // ─────────────────────────────────────────────────────────────────────
 
     @Test
-    fun `findAllConnectionPaths returns all paths within maxDepth`() = runTest {
+    fun `findAllConnectionPaths returns all paths within maxDepth`() = runSuspendIO {
         val seed = seedSocialNetwork(service)
 
         val paths = service.findAllConnectionPaths(seed.alice.id, seed.dave.id, maxDepth = 3).toList()
@@ -406,7 +406,7 @@ abstract class AbstractSocialNetworkSuspendTest {
     }
 
     @Test
-    fun `findAllConnectionPaths returns empty list for disconnected persons`() = runTest {
+    fun `findAllConnectionPaths returns empty list for disconnected persons`() = runSuspendIO {
         val alice = service.addPerson("alice", "Alice Smith")
         val isolated = service.addPerson("isolated", "Isolated Person")
 
@@ -420,7 +420,7 @@ abstract class AbstractSocialNetworkSuspendTest {
     // ─────────────────────────────────────────────────────────────────────
 
     @Test
-    fun `findMutualConnections returns shared direct connections`() = runTest {
+    fun `findMutualConnections returns shared direct connections`() = runSuspendIO {
         val seed = seedSocialNetwork(service)
 
         val mutual = service.findMutualConnections(seed.alice.id, seed.dave.id)
@@ -429,7 +429,7 @@ abstract class AbstractSocialNetworkSuspendTest {
     }
 
     @Test
-    fun `findMutualConnections returns empty for non-overlapping networks`() = runTest {
+    fun `findMutualConnections returns empty for non-overlapping networks`() = runSuspendIO {
         val seed = seedSocialNetwork(service)
 
         val mutual = service.findMutualConnections(seed.alice.id, seed.eve.id)

--- a/image-processing/advanced-workflow/src/test/kotlin/io/bluetape4k/workshop/imageprocessing/advanced/service/FfmVipsDerivativeProcessorTest.kt
+++ b/image-processing/advanced-workflow/src/test/kotlin/io/bluetape4k/workshop/imageprocessing/advanced/service/FfmVipsDerivativeProcessorTest.kt
@@ -2,7 +2,7 @@ package io.bluetape4k.workshop.imageprocessing.advanced.service
 
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeLessOrEqualTo
-import kotlinx.coroutines.test.runTest
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import org.junit.jupiter.api.Test
 import java.awt.Color
 import java.awt.image.BufferedImage
@@ -12,7 +12,7 @@ import javax.imageio.ImageIO
 class FfmVipsDerivativeProcessorTest : AbstractFfmVipsWorkshopTest() {
 
     @Test
-    fun `processor generates webp variants with bounded dimensions`() = runTest {
+    fun `processor generates webp variants with bounded dimensions`() = runSuspendIO {
         val processor = FfmVipsDerivativeProcessor(
             properties = testProperties(maxInputBytes = 1024 * 1024),
             keyFactory = ImageKeyFactory(),

--- a/leader/leader-election/src/test/kotlin/io/bluetape4k/workshop/leader/AbstractLeaderElectionTest.kt
+++ b/leader/leader-election/src/test/kotlin/io/bluetape4k/workshop/leader/AbstractLeaderElectionTest.kt
@@ -5,7 +5,9 @@ import io.bluetape4k.leader.ListeningLeaderElector
 import io.bluetape4k.leader.lettuce.LettuceLeaderElector
 import io.bluetape4k.leader.lettuce.LettuceSuspendLeaderElector
 import io.bluetape4k.logging.KLogging
+import io.bluetape4k.support.closeSafe
 import io.bluetape4k.testcontainers.storage.RedisServer
+import io.bluetape4k.utils.ShutdownQueue
 import io.lettuce.core.RedisClient
 import io.lettuce.core.api.StatefulRedisConnection
 import io.lettuce.core.codec.StringCodec
@@ -35,6 +37,13 @@ abstract class AbstractLeaderElectionTest {
         /** Redis URL from the running container. */
         val redisUrl: String get() = redis.url
 
+        /** Shared Redis client; individual tests still receive isolated connections. */
+        val client: RedisClient by lazy {
+            RedisClient.create(redisUrl).also {
+                ShutdownQueue.register { runCatching { it.shutdown() } }
+            }
+        }
+
         /** Default options for deterministic testing: fast wait, short lease. */
         val defaultOptions = LeaderElectionOptions(
             waitTime = 100.milliseconds,
@@ -42,9 +51,11 @@ abstract class AbstractLeaderElectionTest {
         )
     }
 
-    /** Opens a fresh [StatefulRedisConnection]. Caller is responsible for closing it. */
+    /** Opens a fresh [StatefulRedisConnection] and registers it for test-suite shutdown. */
     protected fun newConnection(): StatefulRedisConnection<String, String> =
-        RedisClient.create(redisUrl).connect(StringCodec.UTF8)
+        client.connect(StringCodec.UTF8).also {
+            ShutdownQueue.register { it.closeSafe() }
+        }
 
     /** Creates a new [LettuceLeaderElector] with its own connection and the given options. */
     protected fun newElector(

--- a/leader/leader-election/src/test/kotlin/io/bluetape4k/workshop/leader/RedisFailureTest.kt
+++ b/leader/leader-election/src/test/kotlin/io/bluetape4k/workshop/leader/RedisFailureTest.kt
@@ -6,6 +6,7 @@ import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.leader.LeaderElectionOptions
 import io.bluetape4k.leader.lettuce.LettuceLeaderElector
 import io.bluetape4k.logging.*
+import io.bluetape4k.support.closeSafe
 import io.bluetape4k.testcontainers.storage.RedisServer
 import io.lettuce.core.RedisClient
 import io.lettuce.core.codec.StringCodec
@@ -32,21 +33,31 @@ class RedisFailureTest {
     fun `runIfLeader throws exception when Redis is unavailable`() = runSuspendIO(timeout = 10.seconds) {
         // Use a dedicated container — NOT the shared singleton
         val redisContainer = RedisServer(image = RedisServer.IMAGE, tag = "7-alpine").apply { start() }
+        val client = RedisClient.create(redisContainer.url)
 
-        val connection = RedisClient.create(redisContainer.url).connect(StringCodec.UTF8)
-        val options = LeaderElectionOptions(waitTime = 100.milliseconds, leaseTime = 5.seconds)
-        val elector = LettuceLeaderElector(connection, options)
-        val lockName = "test:t6:${Base58.randomString(8)}"
+        try {
+            val connection = client.connect(StringCodec.UTF8)
+            val options = LeaderElectionOptions(waitTime = 100.milliseconds, leaseTime = 5.seconds)
+            val elector = LettuceLeaderElector(connection, options)
+            val lockName = "test:t6:${Base58.randomString(8)}"
 
-        // Stop Redis before attempting lock acquisition
-        redisContainer.stop()
+            try {
+                // Stop Redis before attempting lock acquisition
+                redisContainer.stop()
 
-        // runSuspendIO timeout guards against infinite hang; assertFailsWith verifies Redis failure propagation.
-        assertFailsWith<Exception> {
-            elector.runIfLeader(lockName) { "should-not-execute" }
+                // runSuspendIO timeout guards against infinite hang; assertFailsWith verifies Redis failure propagation.
+                assertFailsWith<Exception> {
+                    elector.runIfLeader(lockName) { "should-not-execute" }
+                }
+
+                log.info { "[T6] Redis failure correctly propagated as exception — no silent hang" }
+            } finally {
+                connection.closeSafe()
+            }
+        } finally {
+            runCatching { client.shutdown() }
+            runCatching { redisContainer.stop() }
         }
-
-        log.info { "[T6] Redis failure correctly propagated as exception — no silent hang" }
     }
 
     companion object : KLogging()


### PR DESCRIPTION
## Summary
- Align container-backed graph suspend tests and the VIPS processor test with bluetape4k coroutine test guidance by using `runSuspendIO` instead of virtual-time `runTest`.
- Reuse a shared Lettuce `RedisClient` in leader election tests and register Redis resources through `ShutdownQueue`/`closeSafe`.

## Evidence
- Reviewed referenced bluetape4k graph/testcontainers and leader patterns, plus workshop module usage.
- Targeted tests: `./gradlew :leader-leader-election:test :graph-social-network:test :graph-recommendation:test :graph-knowledge-graph:test :image-processing-advanced-workflow:test`
- Compile verification: `./gradlew compileTestKotlin`
- Full build also completed successfully: `./gradlew build`
- Whitespace check: `git diff --check`

## Follow-up
- Exposed Spring Boot samples still intentionally use fixed PostgreSQL active profiles; moving them to a multi-dialect `@ParameterizedTest` harness is a larger structural follow-up.
