### PR TITLE
Align Redis and Spring Data tests with IO helpers

### DIFF
--- a/io/okio-examples/src/test/kotlin/io/bluetape4k/okio/PipeTest.kt
+++ b/io/okio-examples/src/test/kotlin/io/bluetape4k/okio/PipeTest.kt
@@ -22,7 +22,7 @@ import io.bluetape4k.assertions.shouldBeTrue
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.fail
+import io.bluetape4k.assertions.fail
 import java.io.InterruptedIOException
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit

--- a/io/okio-examples/src/test/kotlin/io/bluetape4k/okio/WaitUntilNotifiedTest.kt
+++ b/io/okio-examples/src/test/kotlin/io/bluetape4k/okio/WaitUntilNotifiedTest.kt
@@ -14,7 +14,7 @@ import org.junit.jupiter.params.provider.MethodSource
 import java.io.InterruptedIOException
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
-import kotlin.test.DefaultAsserter.fail
+import io.bluetape4k.assertions.fail
 
 class WaitUntilNotifiedTest: AbstractOkioTest() {
 

--- a/io/okio-examples/src/test/kotlin/io/bluetape4k/okio/coroutines/SuspendedSocketTest.kt
+++ b/io/okio-examples/src/test/kotlin/io/bluetape4k/okio/coroutines/SuspendedSocketTest.kt
@@ -20,7 +20,7 @@ import java.nio.channels.ServerSocketChannel
 import java.nio.channels.SocketChannel
 import java.util.concurrent.TimeUnit
 import io.bluetape4k.assertions.assertFailsWith
-import kotlin.test.junit5.JUnit5Asserter.fail
+import io.bluetape4k.assertions.fail
 
 class SuspendedSocketTest: AbstractOkioTest() {
 

--- a/redis/cluster-demo/src/test/kotlin/io/bluetape4k/workshop/redis/cluster/basic/Bluetape4kLettuceUsageTest.kt
+++ b/redis/cluster-demo/src/test/kotlin/io/bluetape4k/workshop/redis/cluster/basic/Bluetape4kLettuceUsageTest.kt
@@ -6,13 +6,13 @@ import io.bluetape4k.redis.lettuce.awaitSuspending
 import io.bluetape4k.redis.lettuce.codec.LettuceLongCodec
 import io.bluetape4k.testcontainers.storage.RedisServer
 import io.bluetape4k.workshop.redis.cluster.AbstractRedisClusterTest
-import kotlinx.coroutines.test.runTest
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import org.junit.jupiter.api.Test
 
 class Bluetape4kLettuceUsageTest: AbstractRedisClusterTest() {
 
     @Test
-    fun `bluetape4k lettuce client supports typed async round trip`() = runTest {
+    fun `bluetape4k lettuce client supports typed async round trip`() = runSuspendIO {
         val redis = RedisServer.Launcher.redis
         val client = LettuceClients.clientOf(redis.url)
 

--- a/redis/distributed-lock/src/test/kotlin/io/bluetape4k/workshop/lock/AbstractDistributedLockTest.kt
+++ b/redis/distributed-lock/src/test/kotlin/io/bluetape4k/workshop/lock/AbstractDistributedLockTest.kt
@@ -2,15 +2,15 @@ package io.bluetape4k.workshop.lock
 
 import io.bluetape4k.codec.Base58
 import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.redis.redisson.redissonClient
 import io.bluetape4k.testcontainers.storage.RedisServer
+import io.bluetape4k.utils.ShutdownQueue
 import io.bluetape4k.workshop.lock.domain.InventoryStore
 import io.bluetape4k.workshop.lock.fenced.FencedResources
 import io.bluetape4k.workshop.lock.service.FencedInventoryService
 import io.bluetape4k.workshop.lock.service.LockedInventoryService
 import io.bluetape4k.workshop.lock.service.SuspendingFencedInventoryService
 import io.bluetape4k.workshop.lock.service.UnsafeInventoryService
-import io.bluetape4k.redis.redisson.redissonClient
-import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.TestInstance
 import org.redisson.api.RedissonClient
@@ -26,6 +26,8 @@ abstract class AbstractDistributedLockTest {
     protected val redisson: RedissonClient by lazy {
         redissonClient {
             useSingleServer().setAddress(redisUrl)
+        }.also {
+            ShutdownQueue.register { runCatching { it.shutdown() } }
         }
     }
 
@@ -45,11 +47,6 @@ abstract class AbstractDistributedLockTest {
     fun resetState() {
         store.resetAll()
         fencedResources.resetAll()
-    }
-
-    @AfterAll
-    fun shutdown() {
-        runCatching { redisson.shutdown() }
     }
 
     protected fun randomName(prefix: String = "test") = "$prefix-${Base58.randomString(8)}"

--- a/redis/redisson-examples/src/test/kotlin/io/bluetape4k/workshop/redisson/collections/BoundedBlockingQueueExamples.kt
+++ b/redis/redisson-examples/src/test/kotlin/io/bluetape4k/workshop/redisson/collections/BoundedBlockingQueueExamples.kt
@@ -5,7 +5,7 @@ import io.bluetape4k.workshop.redisson.AbstractRedissonTest
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.future.await
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.test.runTest
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import kotlinx.coroutines.yield
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeFalse
@@ -27,7 +27,7 @@ class BoundedBlockingQueueExamples: AbstractRedissonTest() {
     }
 
     @Test
-    fun `크기 제한이 있는 Queue 사용`() = runTest {
+    fun `크기 제한이 있는 Queue 사용`() = runSuspendIO {
         val queue = redisson.getBoundedBlockingQueue<Int>(randomName())
         queue.trySetCapacity(ITEM_SIZE).shouldBeTrue()
 

--- a/redis/redisson-examples/src/test/kotlin/io/bluetape4k/workshop/redisson/collections/ListMultimapCacheExamples.kt
+++ b/redis/redisson-examples/src/test/kotlin/io/bluetape4k/workshop/redisson/collections/ListMultimapCacheExamples.kt
@@ -4,7 +4,7 @@ import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
 import io.bluetape4k.workshop.redisson.AbstractRedissonTest
 import kotlinx.coroutines.future.await
-import kotlinx.coroutines.test.runTest
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeTrue
 import org.junit.jupiter.api.Test
@@ -35,7 +35,7 @@ class ListMultimapCacheExamples: AbstractRedissonTest() {
     }
 
     @Test
-    fun `use RListMultimapCache`() = runTest {
+    fun `use RListMultimapCache`() = runSuspendIO {
         val mmapName = randomName()
         val mmap = redisson.getListMultimapCache<String, Int>(mmapName)
         addSampleData(mmap)

--- a/redis/redisson-examples/src/test/kotlin/io/bluetape4k/workshop/redisson/collections/LocalCachedMapExamples.kt
+++ b/redis/redisson-examples/src/test/kotlin/io/bluetape4k/workshop/redisson/collections/LocalCachedMapExamples.kt
@@ -5,7 +5,7 @@ import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.redis.redisson.cache.localCachedMap
 import io.bluetape4k.workshop.redisson.AbstractRedissonTest
 import kotlinx.coroutines.future.await
-import kotlinx.coroutines.test.runTest
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeGreaterThan
@@ -28,7 +28,7 @@ class LocalCachedMapExamples: AbstractRedissonTest() {
     companion object: KLoggingChannel()
 
     @Test
-    fun `simple local cached map`() = runTest {
+    fun `simple local cached map`() = runSuspendIO {
         // Local cache 설정
         val cachedMapName = "local:${Base58.randomString(8)}"
         val cachedMap: RLocalCachedMap<String, Int> = localCachedMap(cachedMapName, redisson) {

--- a/redis/redisson-examples/src/test/kotlin/io/bluetape4k/workshop/redisson/collections/LocalCachedMapTest.kt
+++ b/redis/redisson-examples/src/test/kotlin/io/bluetape4k/workshop/redisson/collections/LocalCachedMapTest.kt
@@ -6,7 +6,7 @@ import io.bluetape4k.logging.debug
 import io.bluetape4k.workshop.redisson.AbstractRedissonTest
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.future.await
-import kotlinx.coroutines.test.runTest
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeNull
@@ -90,7 +90,7 @@ class LocalCachedMapTest: AbstractRedissonTest() {
     }
 
     @Test
-    fun `frontCache1 에 cache item을 추가하면 frontCache2에 추가됩니다`() = runTest {
+    fun `frontCache1 에 cache item을 추가하면 frontCache2에 추가됩니다`() = runSuspendIO {
         val keyToAdd = randomName()
 
         log.debug { "front cache1: put key=$keyToAdd" }
@@ -103,7 +103,7 @@ class LocalCachedMapTest: AbstractRedissonTest() {
     }
 
     @Test
-    fun `frontCache1의 cache item을 삭제하면 frontCache2에서도 삭제됩니다`() = runTest {
+    fun `frontCache1의 cache item을 삭제하면 frontCache2에서도 삭제됩니다`() = runSuspendIO {
         val keyToRemove = randomName()
 
         log.debug { "front cache1: put $keyToRemove" }
@@ -122,7 +122,7 @@ class LocalCachedMapTest: AbstractRedissonTest() {
     }
 
     @Test
-    fun `backCache에 cache item을 추가하면 frontCache 에 반영된다`() = runTest {
+    fun `backCache에 cache item을 추가하면 frontCache 에 반영된다`() = runSuspendIO {
         val key = randomName()
 
         // 초기에 frontCache에 존재하지 않는다.
@@ -155,7 +155,7 @@ class LocalCachedMapTest: AbstractRedissonTest() {
      */
     @Disabled("PRO 버전에서만 지원합니다.")
     @Test
-    fun `frontCache1의 cache item을 expire 되면 frontCache2에서도 삭제됩니다`() = runTest(timeout = 30.seconds) {
+    fun `frontCache1의 cache item을 expire 되면 frontCache2에서도 삭제됩니다`() = runSuspendIO(timeout = 30.seconds) {
         val keyToEvict = randomName()
 
         log.debug { "front cache1: put $keyToEvict" }

--- a/redis/redisson-examples/src/test/kotlin/io/bluetape4k/workshop/redisson/collections/QueueExamples.kt
+++ b/redis/redisson-examples/src/test/kotlin/io/bluetape4k/workshop/redisson/collections/QueueExamples.kt
@@ -6,7 +6,7 @@ import io.bluetape4k.workshop.redisson.AbstractRedissonTest
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.future.await
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.test.runTest
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeTrue
 import org.junit.jupiter.api.Test
@@ -22,7 +22,7 @@ class QueueExamples: AbstractRedissonTest() {
     companion object: KLoggingChannel()
 
     @Test
-    fun `queue usage`() = runTest {
+    fun `queue usage`() = runSuspendIO {
         val queue = redisson.getQueue<Int>(randomName())
         val queue2 = redisson.getQueue<Int>(randomName())
 

--- a/redis/redisson-examples/src/test/kotlin/io/bluetape4k/workshop/redisson/collections/ScoredSortedSetExamples.kt
+++ b/redis/redisson-examples/src/test/kotlin/io/bluetape4k/workshop/redisson/collections/ScoredSortedSetExamples.kt
@@ -3,7 +3,7 @@ package io.bluetape4k.workshop.redisson.collections
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.workshop.redisson.AbstractRedissonTest
 import kotlinx.coroutines.future.await
-import kotlinx.coroutines.test.runTest
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeTrue
 import org.junit.jupiter.api.Test
@@ -46,7 +46,7 @@ class ScoredSortedSetExamples: AbstractRedissonTest() {
     }
 
     @Test
-    fun `RScoredSortedSet 을 이용하여 Score로 정렬된 Set을 사용한다`() = runTest {
+    fun `RScoredSortedSet 을 이용하여 Score로 정렬된 Set을 사용한다`() = runSuspendIO {
         val zset = getSampleScoredSortedSet(randomName())
 
         // ScoredSortedSet의 크기는 6이다
@@ -65,7 +65,7 @@ class ScoredSortedSetExamples: AbstractRedissonTest() {
     }
 
     @Test
-    fun `Score 를 변경하여, 자동으로 정렬되도록 한다`() = runTest {
+    fun `Score 를 변경하여, 자동으로 정렬되도록 한다`() = runSuspendIO {
         val zset = getSampleScoredSortedSet(randomName())
 
         // "B" 요소의 Score를 15.0 증가시킨다 (20.0 -> 35.0)

--- a/redis/redisson-examples/src/test/kotlin/io/bluetape4k/workshop/redisson/collections/SetMultimapCacheExamples.kt
+++ b/redis/redisson-examples/src/test/kotlin/io/bluetape4k/workshop/redisson/collections/SetMultimapCacheExamples.kt
@@ -4,7 +4,7 @@ import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
 import io.bluetape4k.workshop.redisson.AbstractRedissonTest
 import kotlinx.coroutines.future.await
-import kotlinx.coroutines.test.runTest
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeTrue
 import org.junit.jupiter.api.Test
@@ -35,7 +35,7 @@ class SetMultimapCacheExamples: AbstractRedissonTest() {
     }
 
     @Test
-    fun `use RSetMultimapCache`() = runTest {
+    fun `use RSetMultimapCache`() = runSuspendIO {
         val mmapName = randomName()
         val mmap = redisson.getSetMultimapCache<String, Int>(mmapName)
         addSampleData(mmapName)

--- a/redis/redisson-examples/src/test/kotlin/io/bluetape4k/workshop/redisson/collections/SortedSetExamples.kt
+++ b/redis/redisson-examples/src/test/kotlin/io/bluetape4k/workshop/redisson/collections/SortedSetExamples.kt
@@ -3,7 +3,7 @@ package io.bluetape4k.workshop.redisson.collections
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.workshop.redisson.AbstractRedissonTest
 import kotlinx.coroutines.future.await
-import kotlinx.coroutines.test.runTest
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeTrue
 import org.junit.jupiter.api.Test
@@ -27,7 +27,7 @@ class SortedSetExamples: AbstractRedissonTest() {
     }
 
     @Test
-    fun `정렬된 SET 사용 예`() = runTest {
+    fun `정렬된 SET 사용 예`() = runSuspendIO {
         val zset = getSortedSet(randomName())
 
         // 오름차순으로 정렬됨

--- a/redis/redisson-examples/src/test/kotlin/io/bluetape4k/workshop/redisson/locks/CountDownLatchExamples.kt
+++ b/redis/redisson-examples/src/test/kotlin/io/bluetape4k/workshop/redisson/locks/CountDownLatchExamples.kt
@@ -6,7 +6,7 @@ import io.bluetape4k.workshop.redisson.AbstractRedissonTest
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.future.await
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.test.runTest
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import org.junit.jupiter.api.Test
 import kotlin.random.Random
 
@@ -25,7 +25,7 @@ class CountDownLatchExamples: AbstractRedissonTest() {
     companion object: KLoggingChannel()
 
     @Test
-    fun `분산 CountDownLatch 사용`() = runTest {
+    fun `분산 CountDownLatch 사용`() = runSuspendIO {
         val latchName = randomName()
 
         val latch = redisson.getCountDownLatch(latchName)

--- a/redis/redisson-examples/src/test/kotlin/io/bluetape4k/workshop/redisson/locks/LockExamples.kt
+++ b/redis/redisson-examples/src/test/kotlin/io/bluetape4k/workshop/redisson/locks/LockExamples.kt
@@ -11,7 +11,7 @@ import io.bluetape4k.workshop.redisson.AbstractRedissonTest
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.future.await
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.test.runTest
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeGreaterOrEqualTo
@@ -171,7 +171,7 @@ class LockExamples: AbstractRedissonTest() {
     }
 
     @RepeatedTest(REPEAT_SIZE)
-    fun `Multi Job 환경에서 락 획득 및 해제`() = runTest {
+    fun `Multi Job 환경에서 락 획득 및 해제`() = runSuspendIO {
         val lock = redisson.getLock(randomName())
         val lockCounter = AtomicInteger(0)
 

--- a/redis/redisson-examples/src/test/kotlin/io/bluetape4k/workshop/redisson/locks/PermitExpirableSemaphoreExamples.kt
+++ b/redis/redisson-examples/src/test/kotlin/io/bluetape4k/workshop/redisson/locks/PermitExpirableSemaphoreExamples.kt
@@ -5,7 +5,7 @@ import io.bluetape4k.logging.debug
 import io.bluetape4k.workshop.redisson.AbstractRedissonTest
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.future.await
-import kotlinx.coroutines.test.runTest
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import org.junit.jupiter.api.Test
 import java.util.concurrent.TimeUnit
 
@@ -60,7 +60,7 @@ class PermitExpirableSemaphoreExamples: AbstractRedissonTest() {
     }
 
     @Test
-    fun `basic async usage for PermitExpirableSemaphore`() = runTest {
+    fun `basic async usage for PermitExpirableSemaphore`() = runSuspendIO {
         val semaphoreName = randomName()
         val semaphore = redisson.getPermitExpirableSemaphore(semaphoreName)
 

--- a/redis/redisson-examples/src/test/kotlin/io/bluetape4k/workshop/redisson/locks/SpinLockExamples.kt
+++ b/redis/redisson-examples/src/test/kotlin/io/bluetape4k/workshop/redisson/locks/SpinLockExamples.kt
@@ -4,7 +4,7 @@ import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
 import io.bluetape4k.workshop.redisson.AbstractRedissonTest
 import kotlinx.coroutines.future.await
-import kotlinx.coroutines.test.runTest
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.assertions.shouldBeTrue
 import org.junit.jupiter.api.Test
 import java.util.concurrent.TimeUnit
@@ -55,7 +55,7 @@ class SpinLockExamples: AbstractRedissonTest() {
     }
 
     @Test
-    fun `basic async usage of SpinLock`() = runTest {
+    fun `basic async usage of SpinLock`() = runSuspendIO {
         val lockName = randomName()
         val lock = redisson.getSpinLock(lockName)
         var locked = false

--- a/redis/redisson-examples/src/test/kotlin/io/bluetape4k/workshop/redisson/objects/BucketExamples.kt
+++ b/redis/redisson-examples/src/test/kotlin/io/bluetape4k/workshop/redisson/objects/BucketExamples.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.future.await
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.test.runTest
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeGreaterThan
@@ -40,7 +40,7 @@ class BucketExamples: AbstractRedissonTest() {
     companion object: KLoggingChannel()
 
     @Test
-    fun `use bucket`() = runTest {
+    fun `use bucket`() = runSuspendIO {
         val bucket: RBucket<String> = redisson.getBucket(randomName(), RedissonCodecs.String)
 
         // bucket에 object를 설정한다
@@ -74,7 +74,7 @@ class BucketExamples: AbstractRedissonTest() {
     }
 
     @Test
-    fun `use bucket in coroutines`() = runTest {
+    fun `use bucket in coroutines`() = runSuspendIO {
         val bucket: RBucket<String> = redisson.getBucket(randomName())
 
         // bucket에 object를 설정한다
@@ -94,7 +94,7 @@ class BucketExamples: AbstractRedissonTest() {
     }
 
     @Test
-    fun `multiple buckets example`() = runTest {
+    fun `multiple buckets example`() = runSuspendIO {
         val buckets = redisson.buckets
 
         val bucketName1 = randomName()
@@ -173,7 +173,7 @@ class BucketExamples: AbstractRedissonTest() {
      * - `A`: Alias for g$lshzxe, so that the "AKE" string means all the events.
      */
     @Test
-    fun `RBucket에 Listener 추가하기`() = runTest {
+    fun `RBucket에 Listener 추가하기`() = runSuspendIO {
         // NOTE: BeforeAll 함수에서 `CONFIG SET notify-keyspace-events AKE` 를 실행합니다.
 
         val bucket = redisson.getBucket<String>(randomName())

--- a/redis/redisson-examples/src/test/kotlin/io/bluetape4k/workshop/redisson/objects/IdGeneratorExamples.kt
+++ b/redis/redisson-examples/src/test/kotlin/io/bluetape4k/workshop/redisson/objects/IdGeneratorExamples.kt
@@ -3,7 +3,7 @@ package io.bluetape4k.workshop.redisson.objects
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.workshop.redisson.AbstractRedissonTest
 import kotlinx.coroutines.future.await
-import kotlinx.coroutines.test.runTest
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.assertions.shouldHaveSize
 import org.junit.jupiter.api.Test
 
@@ -34,7 +34,7 @@ class IdGeneratorExamples: AbstractRedissonTest() {
 
 
     @Test
-    fun `generate identifier asynchronous`() = runTest {
+    fun `generate identifier asynchronous`() = runSuspendIO {
         val generator = redisson.getIdGenerator(randomName())
 
         // 초기값=42, 할당 갯수 5,000개를 미리 할당합니다. (이미 초기화 되어 있다면, False를 반환하고 무시됨)

--- a/redis/redisson-examples/src/test/kotlin/io/bluetape4k/workshop/redisson/objects/ReliableTopicExamples.kt
+++ b/redis/redisson-examples/src/test/kotlin/io/bluetape4k/workshop/redisson/objects/ReliableTopicExamples.kt
@@ -5,7 +5,7 @@ import io.bluetape4k.logging.debug
 import io.bluetape4k.workshop.redisson.AbstractRedissonTest
 import kotlinx.coroutines.future.await
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.test.runTest
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import kotlinx.coroutines.yield
 import org.awaitility.kotlin.await
 import org.awaitility.kotlin.until
@@ -33,7 +33,7 @@ class ReliableTopicExamples: AbstractRedissonTest() {
     companion object: KLoggingChannel()
 
     @Test
-    fun `자동 재구독이 되는 Topic`() = runTest {
+    fun `자동 재구독이 되는 Topic`() = runSuspendIO {
         val topicName = randomName()
         val topic = redisson.getReliableTopic(topicName)
         val listenCounter = AtomicInteger(0)

--- a/spring-data/elasticsearch-webflux/src/test/kotlin/io/bluetape4k/workshop/elasticsearch/controller/BookControllerTest.kt
+++ b/spring-data/elasticsearch-webflux/src/test/kotlin/io/bluetape4k/workshop/elasticsearch/controller/BookControllerTest.kt
@@ -13,7 +13,7 @@ import io.bluetape4k.workshop.shared.web.httpGet
 import io.bluetape4k.workshop.shared.web.httpPost
 import io.bluetape4k.workshop.shared.web.httpPut
 import kotlinx.coroutines.reactive.awaitSingle
-import kotlinx.coroutines.test.runTest
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeGreaterOrEqualTo
 import io.bluetape4k.assertions.shouldHaveSize
@@ -69,7 +69,7 @@ class BookControllerTest(
     }
 
     @Test
-    fun `find book with not exists isbn`() = runTest {
+    fun `find book with not exists isbn`() = runSuspendIO {
         insertRandomBooks(3)
 
         client.httpGet("$BOOK_PATH/not-exists")

--- a/spring-data/elasticsearch-webflux/src/test/kotlin/io/bluetape4k/workshop/elasticsearch/domain/service/DefaultBookServiceTest.kt
+++ b/spring-data/elasticsearch-webflux/src/test/kotlin/io/bluetape4k/workshop/elasticsearch/domain/service/DefaultBookServiceTest.kt
@@ -9,7 +9,7 @@ import io.bluetape4k.workshop.elasticsearch.domain.exception.BookNotFoundExcepti
 import io.bluetape4k.workshop.elasticsearch.domain.exception.DuplicatedIsbnException
 import io.bluetape4k.workshop.elasticsearch.domain.model.Book
 import io.bluetape4k.workshop.elasticsearch.domain.repository.BookRepository
-import kotlinx.coroutines.test.runTest
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeGreaterOrEqualTo
@@ -100,7 +100,7 @@ class DefaultBookServiceTest(
     }
 
     @Test
-    fun `create book with duplicate isbnm, throw exception`() = runTest {
+    fun `create book with duplicate isbnm, throw exception`() = runSuspendIO {
         val saved = service.create(createBook())
         saved.id.shouldNotBeNull()
         refreshBookIndex()

--- a/spring-data/elasticsearch/src/test/kotlin/io/bluetape4k/workshop/elasticsearch/repository/ReactiveElasticsearchOperationsTest.kt
+++ b/spring-data/elasticsearch/src/test/kotlin/io/bluetape4k/workshop/elasticsearch/repository/ReactiveElasticsearchOperationsTest.kt
@@ -6,7 +6,7 @@ import io.bluetape4k.workshop.elasticsearch.AbstractElasticsearchTest
 import io.bluetape4k.workshop.elasticsearch.model.Conference
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.reactive.asFlow
-import kotlinx.coroutines.test.runTest
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.assertions.shouldBeGreaterOrEqualTo
 import io.bluetape4k.assertions.shouldContain
 import io.bluetape4k.assertions.shouldHaveSize
@@ -27,7 +27,7 @@ class ReactiveElasticsearchOperationsTest(
     companion object: KLogging()
 
     @Test
-    fun `search by expected date and keyword`() = runTest {
+    fun `search by expected date and keyword`() = runSuspendIO {
         val expectedDate = "2014-10-29"
         val expectedWord = "java"
 
@@ -50,7 +50,7 @@ class ReactiveElasticsearchOperationsTest(
     }
 
     @Test
-    fun `search by geo spatial`() = runTest {
+    fun `search by geo spatial`() = runSuspendIO {
         val startLocation = GeoPoint(50.0646501, 19.9449799)
         val range = "530km" // 300mi
         val query = CriteriaQuery(Criteria(Conference::location.name).within(startLocation, range))

--- a/spring-data/elasticsearch/src/test/kotlin/io/bluetape4k/workshop/elasticsearch/repository/ReactiveElasticsearchRepositoryTest.kt
+++ b/spring-data/elasticsearch/src/test/kotlin/io/bluetape4k/workshop/elasticsearch/repository/ReactiveElasticsearchRepositoryTest.kt
@@ -5,7 +5,7 @@ import io.bluetape4k.logging.debug
 import io.bluetape4k.workshop.elasticsearch.AbstractElasticsearchTest
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.reactive.asFlow
-import kotlinx.coroutines.test.runTest
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.assertions.shouldBeGreaterOrEqualTo
 import io.bluetape4k.assertions.shouldContain
 import io.bluetape4k.assertions.shouldHaveSize
@@ -22,7 +22,7 @@ class ReactiveElasticsearchRepositoryTest(
     companion object: KLogging()
 
     @Test
-    fun `search all conference`() = runTest {
+    fun `search all conference`() = runSuspendIO {
         val conferences = repository.findAll().asFlow().toList()
 
         conferences.size shouldBeGreaterOrEqualTo 5
@@ -32,7 +32,7 @@ class ReactiveElasticsearchRepositoryTest(
     }
 
     @Test
-    fun `search by expected keywoard and date by repository`() = runTest {
+    fun `search by expected keywoard and date by repository`() = runSuspendIO {
         val expectedDate = "2014-10-29"
         val expectedWord = "java"
 
@@ -50,7 +50,7 @@ class ReactiveElasticsearchRepositoryTest(
     }
 
     @Test
-    fun `search by geo spatial`() = runTest {
+    fun `search by geo spatial`() = runSuspendIO {
         val startLocation = GeoPoint(50.0646501, 19.9449799)
         val range = "530km" // 300mi
 

--- a/spring-data/mongodb-coroutines/src/test/kotlin/io/bluetape4k/workshop/mongodb/domain/FlowAndCoroutineTest.kt
+++ b/spring-data/mongodb-coroutines/src/test/kotlin/io/bluetape4k/workshop/mongodb/domain/FlowAndCoroutineTest.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.reactive.asFlow
 import kotlinx.coroutines.reactive.awaitSingle
 import kotlinx.coroutines.reactor.awaitSingle
 import kotlinx.coroutines.reactor.awaitSingleOrNull
-import kotlinx.coroutines.test.runTest
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.assertions.shouldBeEqualTo
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -30,7 +30,7 @@ class FlowAndCoroutineTest(
     companion object: KLoggingChannel()
 
     @BeforeEach
-    fun beforeEach() = runTest {
+    fun beforeEach() = runSuspendIO {
         operations.dropCollection<Person>().awaitSingleOrNull()
     }
 

--- a/spring-data/mongodb-coroutines/src/test/kotlin/io/bluetape4k/workshop/mongodb/reactive/AbstractReactiveMongoTest.kt
+++ b/spring-data/mongodb-coroutines/src/test/kotlin/io/bluetape4k/workshop/mongodb/reactive/AbstractReactiveMongoTest.kt
@@ -3,12 +3,11 @@ package io.bluetape4k.workshop.mongodb.reactive
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.workshop.mongodb.AbstractMongodbTest
 import io.bluetape4k.workshop.mongodb.domain.Person
-import kotlinx.coroutines.Dispatchers
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.reactive.asFlow
 import kotlinx.coroutines.reactive.awaitSingle
 import kotlinx.coroutines.reactor.awaitSingle
-import kotlinx.coroutines.runBlocking
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldHaveSize
 import org.junit.jupiter.api.BeforeEach
@@ -28,7 +27,7 @@ abstract class AbstractReactiveMongoTest(
 
     @BeforeEach
     fun beforeEach() {
-        runBlocking(Dispatchers.IO) {
+        runSuspendIO {
             // NOTE: [@Tailable] 을 지원하려면 Collection이 capped 인 놈만 가능합니다.
             //
             val collectionOptions = CollectionOptions.empty()

--- a/spring-data/mongodb-coroutines/src/test/kotlin/io/bluetape4k/workshop/mongodb/reactive/PersonCoroutineRepositoryTest.kt
+++ b/spring-data/mongodb-coroutines/src/test/kotlin/io/bluetape4k/workshop/mongodb/reactive/PersonCoroutineRepositoryTest.kt
@@ -14,7 +14,7 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.reactor.mono
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.runTest
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldNotBeNull
 import org.awaitility.kotlin.await
@@ -33,7 +33,7 @@ class PersonCoroutineRepositoryTest @Autowired constructor(
     companion object: KLoggingChannel()
 
     @Test
-    fun `insert and count`() = runTest {
+    fun `insert and count`() = runSuspendIO {
         val prevCount = repository.count()
         println("prevCount=$prevCount")
 
@@ -47,12 +47,12 @@ class PersonCoroutineRepositoryTest @Autowired constructor(
     }
 
     @Test
-    fun `perform conversion before result processing`() = runTest {
+    fun `perform conversion before result processing`() = runSuspendIO {
         repository.findAll().log("#1").count() shouldBeEqualTo 4
     }
 
     @Test
-    fun `stream data with tailable cursor`() = runTest {
+    fun `stream data with tailable cursor`() = runSuspendIO {
         val prevCount = repository.count().toInt()
 
         val queue = ConcurrentLinkedQueue<Person>()
@@ -87,7 +87,7 @@ class PersonCoroutineRepositoryTest @Autowired constructor(
      * NOTE: bluetape4k-coroutines 의 [PublishSubject] 를 이용하여 해결했습니다.
      */
     @Test
-    fun `stream data with tailable cursor with PublishSubject`() = runTest(timeout = 10.seconds) {
+    fun `stream data with tailable cursor with PublishSubject`() = runSuspendIO(timeout = 10.seconds) {
         val prevCount = repository.count().toInt()
 
         val queue = ConcurrentLinkedQueue<Person>()
@@ -127,25 +127,25 @@ class PersonCoroutineRepositoryTest @Autowired constructor(
     }
 
     @Test
-    fun `query data with query derivation`() = runTest {
+    fun `query data with query derivation`() = runSuspendIO {
         val people = repository.findByLastname("White").log("person")
         people.count() shouldBeEqualTo 2
     }
 
     @Test
-    fun `query data with string query`() = runTest {
+    fun `query data with string query`() = runSuspendIO {
         val person = repository.findByFirstnameAndLastname("Walter", "White")
         person.shouldNotBeNull()
     }
 
     @Test
-    fun `query data with deferred query deviation`() = runTest {
+    fun `query data with deferred query deviation`() = runSuspendIO {
         val people = repository.findByLastname(mono { "White" }).log("person")
         people.count() shouldBeEqualTo 2
     }
 
     @Test
-    fun `query data with mixed deferred query deviation`() = runTest {
+    fun `query data with mixed deferred query deviation`() = runSuspendIO {
         val person = repository.findByFirstnameAndLastname(mono { "Walter" }, "White")
         person.shouldNotBeNull()
     }

--- a/spring-data/r2dbc-coroutines/src/test/kotlin/io/bluetape4k/workshop/r2dbc/domain/CommentRepositoryTest.kt
+++ b/spring-data/r2dbc-coroutines/src/test/kotlin/io/bluetape4k/workshop/r2dbc/domain/CommentRepositoryTest.kt
@@ -3,7 +3,7 @@ package io.bluetape4k.workshop.r2dbc.domain
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.workshop.r2dbc.AbstractR2dbcApplicationTest
 import kotlinx.coroutines.flow.toList
-import kotlinx.coroutines.test.runTest
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.assertions.shouldBeEmpty
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeGreaterOrEqualTo
@@ -21,31 +21,31 @@ class CommentRepositoryTest(
     companion object: KLoggingChannel()
 
     @Test
-    fun `find comments by post id`() = runTest {
+    fun `find comments by post id`() = runSuspendIO {
         val comments = commentRepository.findAllByPostId(1L).toList()
         comments.shouldNotBeEmpty()
         comments.size shouldBeGreaterOrEqualTo 2
     }
 
     @Test
-    fun `find comments by non-existing post id`() = runTest {
+    fun `find comments by non-existing post id`() = runSuspendIO {
         val comments = commentRepository.findAllByPostId(-1L).toList()
         comments.shouldBeEmpty()
     }
 
     @Test
-    fun `count of comments by post id`() = runTest {
+    fun `count of comments by post id`() = runSuspendIO {
         val count = commentRepository.countByPostId(1L)
         count shouldBeGreaterOrEqualTo 2L
     }
 
     @Test
-    fun `count of comments by non-existing post id`() = runTest {
+    fun `count of comments by non-existing post id`() = runSuspendIO {
         commentRepository.countByPostId(-1L) shouldBeEqualTo 0L
     }
 
     @Test
-    fun `insert new comment`() = runTest {
+    fun `insert new comment`() = runSuspendIO {
         val oldCommentSize = commentRepository.countByPostId(2L)
 
         val newComment = createComment(2L)

--- a/spring-data/r2dbc-coroutines/src/test/kotlin/io/bluetape4k/workshop/r2dbc/domain/MemberRepositoryTest.kt
+++ b/spring-data/r2dbc-coroutines/src/test/kotlin/io/bluetape4k/workshop/r2dbc/domain/MemberRepositoryTest.kt
@@ -2,7 +2,7 @@ package io.bluetape4k.workshop.r2dbc.domain
 
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.workshop.r2dbc.AbstractR2dbcApplicationTest
-import kotlinx.coroutines.test.runTest
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldNotBeNull
 import org.junit.jupiter.api.Disabled
@@ -22,7 +22,7 @@ class MemberRepositoryTest(
     }
 
     @Test
-    fun `save and get member`() = runTest {
+    fun `save and get member`() = runSuspendIO {
         val member = Member(name = "John Doe", age = 30, email = "john@example.com")
 
         val savedMember = memberRepository.save(member)

--- a/spring-data/r2dbc-coroutines/src/test/kotlin/io/bluetape4k/workshop/r2dbc/domain/PostRepositoryTest.kt
+++ b/spring-data/r2dbc-coroutines/src/test/kotlin/io/bluetape4k/workshop/r2dbc/domain/PostRepositoryTest.kt
@@ -4,7 +4,7 @@ import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
 import io.bluetape4k.workshop.r2dbc.AbstractR2dbcApplicationTest
 import kotlinx.coroutines.flow.toList
-import kotlinx.coroutines.test.runTest
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.assertions.shouldNotBeEmpty
@@ -26,7 +26,7 @@ class PostRepositoryTest(
     }
 
     @Test
-    fun `find all posts`() = runTest {
+    fun `find all posts`() = runSuspendIO {
         val posts = postRepository.findAll().toList()
         posts.forEach { post ->
             log.debug { "post=$post" }
@@ -35,30 +35,30 @@ class PostRepositoryTest(
     }
 
     @Test
-    fun `find one post by id`() = runTest {
+    fun `find one post by id`() = runSuspendIO {
         val post = postRepository.findOneById(1L)
         post.id shouldBeEqualTo 1L
         log.debug { "post=$post" }
     }
 
     @Test
-    fun `find one post by id - not exists`() = runTest {
+    fun `find one post by id - not exists`() = runSuspendIO {
         postRepository.findOneByIdOrNull(-1L).shouldBeNull()
     }
 
     @Test
-    fun `find first by id`() = runTest {
+    fun `find first by id`() = runSuspendIO {
         val post = postRepository.findFirstById(1L)
         post.id shouldBeEqualTo 1L
     }
 
     @Test
-    fun `find first by id - not exists`() = runTest {
+    fun `find first by id - not exists`() = runSuspendIO {
         postRepository.findFirstByIdOrNull(-1L).shouldBeNull()
     }
 
     @Test
-    fun `insert new post`() = runTest {
+    fun `insert new post`() = runSuspendIO {
         val oldCount = postRepository.count()
 
         val newPost = createPost()

--- a/spring-data/r2dbc-examples/src/test/kotlin/io/bluetape4k/workshop/r2dbc/entitycallback/CustomerRepositoryIntegrationTest.kt
+++ b/spring-data/r2dbc-examples/src/test/kotlin/io/bluetape4k/workshop/r2dbc/entitycallback/CustomerRepositoryIntegrationTest.kt
@@ -1,7 +1,7 @@
 package io.bluetape4k.workshop.r2dbc.entitycallback
 
 import io.bluetape4k.logging.coroutines.KLoggingChannel
-import kotlinx.coroutines.test.runTest
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldNotBeNull
@@ -24,7 +24,7 @@ class CustomerRepositoryIntegrationTest(
     }
 
     @Test
-    fun `generates id on insert`() = runTest {
+    fun `generates id on insert`() = runSuspendIO {
         val dave = Customer("Dave", "Matthews")
 
         val saved = repository.save(dave)

--- a/spring-data/redis-examples/src/test/kotlin/io/bluetape4k/workshop/redis/reactive/ReactiveRedisConfiguration.kt
+++ b/spring-data/redis-examples/src/test/kotlin/io/bluetape4k/workshop/redis/reactive/ReactiveRedisConfiguration.kt
@@ -2,13 +2,13 @@ package io.bluetape4k.workshop.redis.reactive
 
 
 import io.bluetape4k.junit5.faker.Fakers
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.support.uninitialized
 import io.bluetape4k.testcontainers.storage.RedisServer
 import io.bluetape4k.workshop.redis.reactive.model.Person
 import jakarta.annotation.PreDestroy
 import kotlinx.coroutines.reactor.awaitSingleOrNull
-import kotlinx.coroutines.runBlocking
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.context.annotation.Bean
@@ -86,7 +86,7 @@ class ReactiveRedisConfiguration {
 
     @PreDestroy
     fun flushTestDb() {
-        runBlocking {
+        runSuspendIO {
             reactiveRedisConnectionFactory.reactiveConnection.serverCommands().flushDb().awaitSingleOrNull()
         }
     }


### PR DESCRIPTION
## Summary
- Replace virtual-time `runTest` with bluetape4k `runSuspendIO` in Redis, Redisson, MongoDB, R2DBC, Elasticsearch, and related IO-backed tests.
- Use `ShutdownQueue` for the distributed-lock Redisson client lifecycle.
- Normalize Okio fail assertions to `io.bluetape4k.assertions.fail`.

## Evidence
- Audited workshop modules against bluetape4k-junit5, bluetape4k-assertions, bluetape4k-testcontainers, and Redis/Mongo/R2DBC sibling test patterns.
- Compile verification: `./gradlew compileTestKotlin`
- Whitespace check: `git diff --check`
- Pattern scan: no remaining `runTest` in `spring-data`, `redis`, or `io/okio-examples` test sources; no mixed Kotlin/JUnit fail imports in touched Okio tests.

## Notes
- Left `src/main` `runBlocking(Dispatchers.IO)` bridge initializers unchanged because `runSuspendIO` belongs to JUnit test infrastructure.
- Did not bulk-convert short-lived Okio `close()` calls to `closeSafe` because those tests verify explicit close behavior.
