### PR TITLE
Use IO coroutine runner for HTTP-backed tests

### DIFF
--- a/messaging/kafka-reply/src/test/kotlin/io/bluetape4k/workshop/kafka/PingPongApplicationTest.kt
+++ b/messaging/kafka-reply/src/test/kotlin/io/bluetape4k/workshop/kafka/PingPongApplicationTest.kt
@@ -1,7 +1,7 @@
 package io.bluetape4k.workshop.kafka
 
 import io.bluetape4k.logging.coroutines.KLoggingChannel
-import kotlinx.coroutines.test.runTest
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldContain
 import org.junit.jupiter.api.Disabled
@@ -24,7 +24,7 @@ class PingPongApplicationTest {
 
     @Disabled("KafkaApplication 을 수동으로 실행시켜야 합니다.")
     @Test
-    fun `call ping and then return pong`() = runTest {
+    fun `call ping and then return pong`() = runSuspendIO {
         client.get()
             .uri("/ping")
             .awaitExchange { response ->

--- a/observability/micrometer-tracing-coroutines/src/test/kotlin/io/bluetape4k/workshop/micrometer/service/CoroutineServiceTest.kt
+++ b/observability/micrometer-tracing-coroutines/src/test/kotlin/io/bluetape4k/workshop/micrometer/service/CoroutineServiceTest.kt
@@ -3,7 +3,7 @@ package io.bluetape4k.workshop.micrometer.service
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
 import io.bluetape4k.workshop.micrometer.AbstractTracingTest
-import kotlinx.coroutines.test.runTest
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldNotBeEmpty
 import io.bluetape4k.assertions.shouldNotBeNull
@@ -22,12 +22,12 @@ class CoroutineServiceTest(
     }
 
     @Test
-    fun `get name`() = runTest {
+    fun `get name`() = runSuspendIO {
         service.getName().shouldNotBeEmpty()
     }
 
     @Test
-    fun `get todo by id`() = runTest {
+    fun `get todo by id`() = runSuspendIO {
         val id = 42
 
         val todo = service.getTodo(id)

--- a/observability/micrometer-tracing-coroutines/src/test/kotlin/io/bluetape4k/workshop/micrometer/zipkin/ZipkinServerLaunchTest.kt
+++ b/observability/micrometer-tracing-coroutines/src/test/kotlin/io/bluetape4k/workshop/micrometer/zipkin/ZipkinServerLaunchTest.kt
@@ -5,7 +5,7 @@ import io.bluetape4k.logging.debug
 import io.bluetape4k.testcontainers.infra.ZipkinServer
 import io.bluetape4k.utils.Systemx
 import kotlinx.coroutines.reactor.awaitSingleOrNull
-import kotlinx.coroutines.test.runTest
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldNotBeNull
@@ -24,7 +24,7 @@ class ZipkinServerLaunchTest {
 
     @Disabled("Zipkin 서버 접속 시 예외 발생 : not on SSL/TLS record:")
     @Test
-    fun `launch zipkin server`() = runTest(timeout = 30.seconds) {
+    fun `launch zipkin server`() = runSuspendIO(timeout = 30.seconds) {
         zipkin.start()
         zipkin.isRunning.shouldBeTrue()
 

--- a/shared/src/test/kotlin/io/bluetape4k/workshop/shared/web/WebTestClientExtensionsTest.kt
+++ b/shared/src/test/kotlin/io/bluetape4k/workshop/shared/web/WebTestClientExtensionsTest.kt
@@ -4,7 +4,7 @@ import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
 import io.bluetape4k.support.toUtf8String
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.test.runTest
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.assertions.shouldContain
 import io.bluetape4k.assertions.shouldNotBeNull
 import org.junit.jupiter.api.MethodOrderer
@@ -46,7 +46,7 @@ class WebTestClientExtensionsTest: AbstractSpringTest() {
 
         @Test
         @Order(2)
-        fun `httGet httpbin anything`() = runTest {
+        fun `httGet httpbin anything`() = runSuspendIO {
             val response = client
                 .httpGet("/anything")
                 .expectStatus().is2xxSuccessful

--- a/virtualthreads/spring-mvc-tomcat/src/test/kotlin/io/bluetape4k/workshop/virtualthread/tomcat/controller/MemberControllerTest.kt
+++ b/virtualthreads/spring-mvc-tomcat/src/test/kotlin/io/bluetape4k/workshop/virtualthread/tomcat/controller/MemberControllerTest.kt
@@ -9,7 +9,7 @@ import io.bluetape4k.workshop.virtualthread.tomcat.domain.dto.MemberWithTeamDTO
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.reactive.asFlow
 import kotlinx.coroutines.reactive.awaitSingle
-import kotlinx.coroutines.test.runTest
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldNotBeEmpty
 import io.bluetape4k.assertions.shouldNotBeNull
@@ -21,7 +21,7 @@ class MemberControllerTest: AbstractVirtualThreadMvcTest() {
     companion object: KLoggingChannel()
 
     @Test
-    fun `get all members`() = runTest {
+    fun `get all members`() = runSuspendIO {
         val members = webTestClient
             .get()
             .uri("/member")
@@ -38,7 +38,7 @@ class MemberControllerTest: AbstractVirtualThreadMvcTest() {
     }
 
     @Test
-    fun `get member by id`() = runTest {
+    fun `get member by id`() = runSuspendIO {
         val member = webTestClient
             .get()
             .uri("/member/1")
@@ -51,7 +51,7 @@ class MemberControllerTest: AbstractVirtualThreadMvcTest() {
     }
 
     @Test
-    fun `search member`() = runTest {
+    fun `search member`() = runSuspendIO {
         val condition = MemberSearchCondition(teamName = "teamA", ageGoe = 60)
 
         val members = webTestClient

--- a/virtualthreads/spring-mvc-tomcat/src/test/kotlin/io/bluetape4k/workshop/virtualthread/tomcat/controller/TeamControllerTest.kt
+++ b/virtualthreads/spring-mvc-tomcat/src/test/kotlin/io/bluetape4k/workshop/virtualthread/tomcat/controller/TeamControllerTest.kt
@@ -7,7 +7,7 @@ import io.bluetape4k.workshop.virtualthread.tomcat.domain.dto.TeamDTO
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.reactive.asFlow
 import kotlinx.coroutines.reactive.awaitSingle
-import kotlinx.coroutines.test.runTest
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldNotBeEmpty
 import org.junit.jupiter.api.Test
@@ -18,7 +18,7 @@ class TeamControllerTest: AbstractVirtualThreadMvcTest() {
     companion object: KLoggingChannel()
 
     @Test
-    fun `get all teams`() = runTest {
+    fun `get all teams`() = runSuspendIO {
         val teams = webTestClient
             .get()
             .uri("/team")
@@ -34,7 +34,7 @@ class TeamControllerTest: AbstractVirtualThreadMvcTest() {
     }
 
     @Test
-    fun `get team by id`() = runTest {
+    fun `get team by id`() = runSuspendIO {
         val team = webTestClient
             .get()
             .uri("/team/1")
@@ -47,7 +47,7 @@ class TeamControllerTest: AbstractVirtualThreadMvcTest() {
     }
 
     @Test
-    fun `get team by name`() = runTest {
+    fun `get team by name`() = runSuspendIO {
         val team = webTestClient
             .get()
             .uri("/team/name/teamA")


### PR DESCRIPTION
## Summary
- Use `runSuspendIO` for HTTP-backed suspend tests in Kafka reply, Zipkin launch, shared WebTestClient helpers, observability, and virtual-thread MVC modules.
- Keep pure coroutine lesson and in-memory service/repository tests on `runTest`.

## Evidence
- Audited remaining `runTest` usage and separated pure virtual-time examples from real HTTP/server/Testcontainers IO.
- Compile verification: `./gradlew compileTestKotlin`
- Whitespace check: `git diff --check`

## Notes
- Disabled/manual Kafka and Zipkin tests were not runtime-executed; this PR only aligns their coroutine test runner.
