### PR TITLE
Normalize remaining fail assertions and ZooKeeper IO test

### DIFF
--- a/kotlin/coroutines/src/test/kotlin/io/bluetape4k/workshop/coroutines/flow/FlowBuilderExamples.kt
+++ b/kotlin/coroutines/src/test/kotlin/io/bluetape4k/workshop/coroutines/flow/FlowBuilderExamples.kt
@@ -18,7 +18,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import io.bluetape4k.assertions.shouldBeEqualTo
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.fail
+import io.bluetape4k.assertions.fail
 import java.util.concurrent.atomic.AtomicInteger
 
 class FlowBuilderExamples {

--- a/leader/leader-zookeeper/src/test/kotlin/io/bluetape4k/workshop/leader/zookeeper/ExtensionFunctionTest.kt
+++ b/leader/leader-zookeeper/src/test/kotlin/io/bluetape4k/workshop/leader/zookeeper/ExtensionFunctionTest.kt
@@ -9,7 +9,7 @@ import io.bluetape4k.leader.zookeeper.runAsyncIfLeader
 import io.bluetape4k.leader.zookeeper.runIfLeader
 import io.bluetape4k.leader.zookeeper.runIfLeaderGroup
 import io.bluetape4k.leader.zookeeper.suspendRunIfLeader
-import kotlinx.coroutines.test.runTest
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import org.junit.jupiter.api.Test
 import java.util.concurrent.CompletableFuture
 import kotlin.time.Duration.Companion.milliseconds
@@ -60,7 +60,7 @@ class ExtensionFunctionTest : AbstractLeaderZookeeperTest() {
     }
 
     @Test
-    fun `suspendRunIfLeader extension returns the suspending action result`(): Unit = runTest {
+    fun `suspendRunIfLeader extension returns the suspending action result`(): Unit = runSuspendIO {
         val result = curator.suspendRunIfLeader(
             lockName = randomLockName("t6-suspend"),
             basePath = "/test/ext-suspend",

--- a/spring-boot/stomp-websocket/src/test/kotlin/io/bluetape4k/workshop/stomp/websocket/GreetingIntegrationTest.kt
+++ b/spring-boot/stomp-websocket/src/test/kotlin/io/bluetape4k/workshop/stomp/websocket/GreetingIntegrationTest.kt
@@ -12,7 +12,7 @@ import org.awaitility.kotlin.await
 import org.awaitility.kotlin.until
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.fail
+import io.bluetape4k.assertions.fail
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.web.server.LocalServerPort
@@ -74,7 +74,7 @@ class GreetingIntegrationTest(
         if (failure.get() == null) {
             received.get()!!.content shouldBeEqualTo "Hello, Spring!"
         } else {
-            fail(failure.get())
+            fail(cause = failure.get())
         }
     }
 
@@ -98,7 +98,7 @@ class GreetingIntegrationTest(
         if (failure.get() == null) {
             received.get()!!.content shouldBeEqualTo "Hello, Spring!"
         } else {
-            fail(failure.get())
+            fail(cause = failure.get())
         }
     }
 

--- a/virtualthreads/rules/src/test/kotlin/io/bluetape4k/workshop/virtualthread/part2/Rule2WriteBlockingSynchronousCode.kt
+++ b/virtualthreads/rules/src/test/kotlin/io/bluetape4k/workshop/virtualthread/part2/Rule2WriteBlockingSynchronousCode.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.async
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeInRange
 import org.junit.jupiter.api.RepeatedTest
-import org.junit.jupiter.api.fail
+import io.bluetape4k.assertions.fail
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Executors
 
@@ -51,7 +51,7 @@ class Rule2WriteBlockingSynchronousCode: AbstractVirtualThreadTest() {
                 if (error == null) {
                     grossAmountInUsd.toInt() shouldBeEqualTo 108
                 } else {
-                    fail(error)
+                    fail(cause = error)
                 }
             }
             .get()  // 어쨌든 여기서 Blocking 된다 (Non-Blocking 이 아니다)

--- a/virtualthreads/rules/src/test/kotlin/io/bluetape4k/workshop/virtualthread/part2/Rule5UseThreadLocalVariablesCarefully.kt
+++ b/virtualthreads/rules/src/test/kotlin/io/bluetape4k/workshop/virtualthread/part2/Rule5UseThreadLocalVariablesCarefully.kt
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.condition.EnabledOnJre
 import org.junit.jupiter.api.condition.JRE
-import org.junit.jupiter.api.fail
+import io.bluetape4k.assertions.fail
 
 
 /**
@@ -72,7 +72,7 @@ class Rule5UseThreadLocalVariablesCarefully: AbstractVirtualThreadTest() {
                         scope.join().throwIfFailed()
                     }
                 } catch (e: InterruptedException) {
-                    fail(e)
+                    fail(cause = e)
                 }
             }
 


### PR DESCRIPTION
## Summary
- Normalize remaining mixed JUnit `fail` imports to `io.bluetape4k.assertions.fail`.
- Use `runSuspendIO` for the ZooKeeper-backed suspend leader extension test.

## Evidence
- Compile verification: `./gradlew compileTestKotlin`
- Whitespace check: `git diff --check`
- Pattern scan: no remaining JUnit/Kotlin fail imports in Kotlin tests.

## Notes
- Existing virtual-thread deprecated API warning is unrelated and left as an example concern.
