### PR TITLE
test: add default bluetape4k assertions dependency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -296,6 +296,7 @@ subprojects {
 
         // JUnit 5
         testImplementation(rootLibs.bluetape4k.junit5)
+        testImplementation(rootLibs.bluetape4k.assertions)
         testImplementation(rootLibs.junit.jupiter.lib)
         testRuntimeOnly(rootLibs.junit.platform.engine)
 


### PR DESCRIPTION
## Summary
- Add `bluetape4k-assertions` as a shared test dependency for all workshop subprojects.
- Follow the existing root-level `bluetape4k-junit5` dependency pattern so assertion migration work does not need repeated per-module dependency edits.

## Issue
- Closes #229

## Verification
- `./gradlew :shared:testClasses`

## Notes
- Full repository test suite was not run; this PR only changes dependency availability.
