### PR TITLE
test: strengthen observability result assertions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -296,6 +296,7 @@ subprojects {
 
         // JUnit 5
         testImplementation(rootLibs.bluetape4k.junit5)
+        testImplementation(rootLibs.bluetape4k.assertions)
         testImplementation(rootLibs.junit.jupiter.lib)
         testRuntimeOnly(rootLibs.junit.platform.engine)
 

--- a/observability/observability-advanced/src/test/kotlin/io/bluetape4k/workshop/observability/advanced/controller/UserControllerTest.kt
+++ b/observability/observability-advanced/src/test/kotlin/io/bluetape4k/workshop/observability/advanced/controller/UserControllerTest.kt
@@ -1,6 +1,8 @@
 package io.bluetape4k.workshop.observability.advanced.controller
 
 import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldNotBeNull
 import io.bluetape4k.workshop.observability.advanced.AbstractAdvancedTest
 import io.bluetape4k.workshop.observability.advanced.TestObservationConfig
 import io.bluetape4k.workshop.observability.advanced.model.User
@@ -9,7 +11,6 @@ import io.bluetape4k.workshop.observability.advanced.repository.UserRepository
 import io.micrometer.observation.tck.TestObservationRegistry
 import io.micrometer.observation.tck.TestObservationRegistryAssert
 import org.junit.jupiter.api.AfterEach
-import io.bluetape4k.assertions.shouldNotBeNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -79,7 +80,7 @@ class UserControllerTest : AbstractAdvancedTest() {
             .returnResult()
             .responseBody
 
-        body.shouldNotBeNull()
+        body.shouldNotBeNull() shouldBeEqualTo newUser
         TestObservationRegistryAssert.assertThat(testRegistry)
             .hasObservationWithNameEqualTo("user.db.find")
             .that().hasBeenStarted().hasBeenStopped()

--- a/observability/observability-advanced/src/test/kotlin/io/bluetape4k/workshop/observability/advanced/service/UserServiceTest.kt
+++ b/observability/observability-advanced/src/test/kotlin/io/bluetape4k/workshop/observability/advanced/service/UserServiceTest.kt
@@ -1,6 +1,8 @@
 package io.bluetape4k.workshop.observability.advanced.service
 
 import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.workshop.observability.advanced.AbstractAdvancedTest
 import io.bluetape4k.workshop.observability.advanced.TestObservationConfig
 import io.bluetape4k.workshop.observability.advanced.model.User
@@ -10,8 +12,6 @@ import io.micrometer.observation.tck.ObservationContextAssert
 import io.micrometer.observation.tck.TestObservationRegistry
 import io.micrometer.observation.tck.TestObservationRegistryAssert
 import org.junit.jupiter.api.AfterEach
-import io.bluetape4k.assertions.shouldBeNull
-import io.bluetape4k.assertions.shouldNotBeNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -54,7 +54,7 @@ class UserServiceTest : AbstractAdvancedTest() {
 
         val result = userService.getById(testUser.id)
 
-        result.shouldNotBeNull()
+        result shouldBeEqualTo testUser
         TestObservationRegistryAssert.assertThat(testRegistry)
             .hasObservationWithNameEqualTo("user.service.get")
             .that().hasBeenStarted().hasBeenStopped()
@@ -79,7 +79,7 @@ class UserServiceTest : AbstractAdvancedTest() {
 
         val result = userService.getById(testUser.id)
 
-        result.shouldNotBeNull()
+        result shouldBeEqualTo testUser
         TestObservationRegistryAssert.assertThat(testRegistry)
             .hasObservationWithNameEqualTo("user.service.get")
             .that().hasBeenStarted().hasBeenStopped()
@@ -106,7 +106,7 @@ class UserServiceTest : AbstractAdvancedTest() {
     fun `create - produces user service create and user db save observations`() = runSuspendIO {
         val result = userService.create(testUser)
 
-        result.shouldNotBeNull()
+        result shouldBeEqualTo testUser
         TestObservationRegistryAssert.assertThat(testRegistry)
             .hasObservationWithNameEqualTo("user.service.create")
             .that().hasBeenStarted().hasBeenStopped()
@@ -126,7 +126,7 @@ class UserServiceTest : AbstractAdvancedTest() {
         val result = userService.getById(testUser.id)
 
         // DB fallback succeeds and result is non-null
-        result.shouldNotBeNull()
+        result shouldBeEqualTo testUser
         TestObservationRegistryAssert.assertThat(testRegistry)
             .hasObservationWithNameEqualTo("user.service.get")
             .that().hasBeenStarted().hasBeenStopped()

--- a/observability/observability-basic/src/test/kotlin/io/bluetape4k/workshop/observability/basic/service/OrderServiceTest.kt
+++ b/observability/observability-basic/src/test/kotlin/io/bluetape4k/workshop/observability/basic/service/OrderServiceTest.kt
@@ -1,8 +1,11 @@
 package io.bluetape4k.workshop.observability.basic.service
 
 import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.workshop.observability.basic.AbstractBasicTest
 import io.bluetape4k.workshop.observability.basic.TestObservationConfig
+import io.bluetape4k.workshop.observability.basic.model.Order
 import io.micrometer.observation.tck.TestObservationRegistry
 import io.micrometer.observation.tck.TestObservationRegistryAssert
 import kotlinx.coroutines.CancellationException
@@ -10,8 +13,6 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.supervisorScope
 import mockwebserver3.MockResponse
-import io.bluetape4k.assertions.shouldBeNull
-import io.bluetape4k.assertions.shouldNotBeNull
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -46,7 +47,12 @@ class OrderServiceTest : AbstractBasicTest() {
 
         val result = orderService.getOrder(42L)
 
-        result.shouldNotBeNull()
+        result shouldBeEqualTo Order(
+            id = 42L,
+            itemId = 42L,
+            quantity = 1,
+            inventoryAvailable = 10,
+        )
         TestObservationRegistryAssert.assertThat(testRegistry)
             .hasObservationWithNameEqualTo("order.service.fetch")
             .that()


### PR DESCRIPTION
## Summary
- Strengthen observability tests by asserting returned domain objects with `bluetape4k-assertions`.
- Keep Micrometer TCK assertions for span lifecycle, error, count, and parent-context checks.

## Issue
- Closes #225

## Stacked on
- #230

## Verification
- `./gradlew :observability-basic:testClasses :observability-advanced:testClasses`
- `./gradlew :observability-basic:test :observability-advanced:test`
  - `observability-basic`: 6 passing
  - `observability-advanced`: 8 passing

## Notes
- Full repository test suite was not run.
