### PR TITLE
test: normalize remaining workshop test annotations

### DIFF
--- a/gatling/virtualthread-simulation/src/test/kotlin/io/bluetape4k/workshop/gatling/controller/AsyncTaskControllerTest.kt
+++ b/gatling/virtualthread-simulation/src/test/kotlin/io/bluetape4k/workshop/gatling/controller/AsyncTaskControllerTest.kt
@@ -7,8 +7,8 @@ import io.bluetape4k.workshop.gatling.AbstractGatlingTest
 import io.bluetape4k.workshop.shared.web.httpGet
 import kotlinx.coroutines.reactive.awaitSingle
 import io.bluetape4k.assertions.shouldNotBeNull
+import org.junit.jupiter.api.Test
 import org.springframework.test.web.reactive.server.returnResult
-import kotlin.test.Test
 
 class AsyncTaskControllerTest: AbstractGatlingTest() {
 

--- a/gatling/virtualthread-simulation/src/test/kotlin/io/bluetape4k/workshop/gatling/controller/SyncTaskControllerTest.kt
+++ b/gatling/virtualthread-simulation/src/test/kotlin/io/bluetape4k/workshop/gatling/controller/SyncTaskControllerTest.kt
@@ -7,8 +7,8 @@ import io.bluetape4k.workshop.gatling.AbstractGatlingTest
 import io.bluetape4k.workshop.shared.web.httpGet
 import kotlinx.coroutines.reactive.awaitSingle
 import io.bluetape4k.assertions.shouldNotBeNull
+import org.junit.jupiter.api.Test
 import org.springframework.test.web.reactive.server.returnResult
-import kotlin.test.Test
 
 class SyncTaskControllerTest: AbstractGatlingTest() {
 

--- a/io/okio-examples/src/test/kotlin/io/bluetape4k/okio/WriteFileTest.kt
+++ b/io/okio-examples/src/test/kotlin/io/bluetape4k/okio/WriteFileTest.kt
@@ -9,7 +9,7 @@ import okio.buffer
 import okio.sink
 import okio.source
 import org.junit.jupiter.api.BeforeAll
-import kotlin.test.Test
+import org.junit.jupiter.api.Test
 
 @TempFolderTest
 class WriteFileTest {

--- a/shared/src/test/kotlin/io/bluetape4k/workshop/shared/web/RestClientExtensionsTest.kt
+++ b/shared/src/test/kotlin/io/bluetape4k/workshop/shared/web/RestClientExtensionsTest.kt
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.TestMethodOrder
 import org.springframework.web.client.HttpClientErrorException
 import org.springframework.web.client.RestClient
 import org.springframework.web.client.toEntity
-import kotlin.test.Test
+import org.junit.jupiter.api.Test
 import io.bluetape4k.assertions.assertFailsWith
 
 class RestClientExtensionsTest: AbstractSpringTest() {

--- a/shared/src/test/kotlin/io/bluetape4k/workshop/shared/web/WebClientExtensionsTest.kt
+++ b/shared/src/test/kotlin/io/bluetape4k/workshop/shared/web/WebClientExtensionsTest.kt
@@ -11,7 +11,7 @@ import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.WebClientResponseException
 import org.springframework.web.reactive.function.client.awaitBody
 import org.springframework.web.reactive.function.client.awaitBodyOrNull
-import kotlin.test.Test
+import org.junit.jupiter.api.Test
 import io.bluetape4k.assertions.assertFailsWith
 
 class WebClientExtensionsTest: AbstractSpringTest() {

--- a/shared/src/test/kotlin/io/bluetape4k/workshop/shared/web/WebTestClientExtensionsTest.kt
+++ b/shared/src/test/kotlin/io/bluetape4k/workshop/shared/web/WebTestClientExtensionsTest.kt
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.TestMethodOrder
 import org.springframework.http.HttpStatus
 import org.springframework.test.web.reactive.server.WebTestClient
 import org.springframework.test.web.reactive.server.expectBody
-import kotlin.test.Test
+import org.junit.jupiter.api.Test
 
 class WebTestClientExtensionsTest: AbstractSpringTest() {
 

--- a/spring-modulith/events-deep-dive/src/test/kotlin/io/bluetape4k/workshop/spring/modulith/events/b/transactions/OrderEventPublicationTests.kt
+++ b/spring-modulith/events-deep-dive/src/test/kotlin/io/bluetape4k/workshop/spring/modulith/events/b/transactions/OrderEventPublicationTests.kt
@@ -4,7 +4,7 @@ import io.bluetape4k.logging.KLogging
 import io.bluetape4k.workshop.spring.modulith.events.util.IntegrationTest
 import io.bluetape4k.assertions.shouldBeTrue
 import org.springframework.beans.factory.annotation.Autowired
-import kotlin.test.Test
+import org.junit.jupiter.api.Test
 import io.bluetape4k.assertions.assertFailsWith
 
 @IntegrationTest


### PR DESCRIPTION
## Summary
- Replace remaining `kotlin.test.Test` imports in the touched workshop tests with JUnit Jupiter `Test`.
- Keep existing bluetape4k assertion usage and avoid changing behavior.

## Issue
- Closes #224

## Supersedes
- Replaces closed stacked PR #231 after #230 was merged.

## Verification
- `./gradlew :gatling-virtualthread-simulation:testClasses :okio-examples:testClasses :shared:testClasses :spring-modulith-events-deep-dive:testClasses`

## Notes
- Okio API KDoc snippets still mention `assertEquals`; those are documentation examples in production API comments, not executable test assertions in this issue scope.
