### PR TITLE
refactor: replace leftover println examples

### DIFF
--- a/kotlin/coroutines/src/test/kotlin/io/bluetape4k/workshop/coroutines/flow/FlowLifecycleExamples.kt
+++ b/kotlin/coroutines/src/test/kotlin/io/bluetape4k/workshop/coroutines/flow/FlowLifecycleExamples.kt
@@ -17,11 +17,13 @@ import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onEmpty
 import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withContext
 import io.bluetape4k.assertions.shouldBeEqualTo
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import java.util.concurrent.CopyOnWriteArrayList
 import kotlin.coroutines.coroutineContext
 
 class FlowLifecycleExamples {
@@ -65,14 +67,18 @@ class FlowLifecycleExamples {
 
     @Test
     fun `onEmpty - call on not existing element`() = runTest {
-        flow<List<Int>> { delay(1000) }
+        val emitted = flow<List<Int>> { delay(1000) }
             .onEmpty { emit(emptyList()) }
-            .collect { println(it) }
+            .toList()
+
+        emitted shouldBeEqualTo listOf(emptyList())
 
         // Same action
-        flow<List<Int>> { delay(1000) }
-            .onEmpty { println(emptyList<Int>()) }
-            .collect()
+        val fallback = flow<List<Int>> { delay(1000) }
+            .onEmpty { emit(emptyList()) }
+            .toList()
+
+        fallback shouldBeEqualTo listOf(emptyList())
     }
 
     @Test
@@ -82,9 +88,16 @@ class FlowLifecycleExamples {
             emit(2)
             throw RuntimeException("Boom!")
         }
-        flow.onEach { println("Get $it") }
-            .catch { println("Catch $it") }   // cache는 예외만 받는다. catch 는 flow 가 종료되기 전에 호출된다
+
+        val values = mutableListOf<Int>()
+        val errors = mutableListOf<String?>()
+
+        flow.onEach { values += it }
+            .catch { errors += it.message }   // cache는 예외만 받는다. catch 는 flow 가 종료되기 전에 호출된다
             .collect()
+
+        values shouldBeEqualTo listOf(1, 2)
+        errors shouldBeEqualTo listOf("Boom!")
     }
 
 
@@ -103,44 +116,55 @@ class FlowLifecycleExamples {
             val users = usersFlow()
 
             // collect 작업을 Name1 에서 수행
-            withContext(CoroutineName("Coroutine Name1")) {
-                users.collect { println(it) }
+            val name1Users = withContext(CoroutineName("Coroutine Name1")) {
+                users.toList()
             }
+            name1Users shouldBeEqualTo listOf("User0 in Coroutine Name1", "User1 in Coroutine Name1")
 
             // collect 작업을 Name20 에서 수행
-            withContext(CoroutineName("Coroutine Name2")) {
-                users.collect { println(it) }
+            val name2Users = withContext(CoroutineName("Coroutine Name2")) {
+                users.toList()
             }
+            name2Users shouldBeEqualTo listOf("User0 in Coroutine Name2", "User1 in Coroutine Name2")
 
             // collect 작업을 Name3 에서 수행
-            users
+            val name3Users = users
                 .flowOn(CoroutineName("Coroutine Name3"))
-                .collect { println(it) }
+                .toList()
+
+            name3Users shouldBeEqualTo listOf("User0 in Coroutine Name3", "User1 in Coroutine Name3")
         }
 
-        private suspend fun present(place: String, message: String) {
+        private suspend fun present(place: String, message: String): String {
             val name = coroutineContext[CoroutineName]?.name
-            println("[$name] $message on $place")
+            return "[$name] $message on $place"
         }
 
-        private fun messageFlow(): Flow<String> = flow {
-            present("flow builder", "Message")
+        private fun messageFlow(trace: MutableList<String>): Flow<String> = flow {
+            trace += present("flow builder", "Message")
             emit("Message")
         }
 
         @Test
         fun `flowOn with different context`() = runTest {
-            val messages = messageFlow()
+            val trace = CopyOnWriteArrayList<String>()
+            val messages = messageFlow(trace)
 
             // NOTE: flowOn will work only for the functions upstream the flow.
             //
             withContext(CoroutineName("N1")) {
                 messages
                     .flowOn(CoroutineName("N3"))            // N3 Message on flow builder
-                    .onEach { present("onEach", it) }       // N2 Message on onEach
+                    .onEach { trace += present("onEach", it) }       // N2 Message on onEach
                     .flowOn(CoroutineName("N2"))            //
-                    .collect { present("collect", it) }     // N1 Message on collect
+                    .collect { trace += present("collect", it) }     // N1 Message on collect
             }
+
+            trace.toList() shouldBeEqualTo listOf(
+                "[N3] Message on flow builder",
+                "[N2] Message on onEach",
+                "[N1] Message on collect",
+            )
         }
     }
 

--- a/kotlin/coroutines/src/test/kotlin/io/bluetape4k/workshop/coroutines/flow/FlowOperatorExamples.kt
+++ b/kotlin/coroutines/src/test/kotlin/io/bluetape4k/workshop/coroutines/flow/FlowOperatorExamples.kt
@@ -175,13 +175,11 @@ class FlowOperatorExamples {
         fun flowFrom(elem: String) = flowOf(1, 2, 3)
             .onEach {
                 delay(10)
-                println("delay 10, $it")
             }
             .map { "${it}_${elem}" }
 
         val result = flowOf("A", "B", "C")
             .flatMapMerge(concurrency = 2) { flowFrom(it) }
-            .onEach { print("$it, ") }
             .toList()
 
         result shouldBeEqualTo listOf("1_A", "1_B", "2_A", "2_B", "3_A", "3_B", "1_C", "2_C", "3_C")
@@ -201,7 +199,6 @@ class FlowOperatorExamples {
          */
         val result = flowOf("A", "B", "C").log("chars")
             .flatMapLatest { flowFrom(it) }         // 각 flow의 마지막 요소들만 선택
-            .onEach { println(it) }
             .toList()
 
         result shouldBeEqualTo listOf("1_C", "2_C", "3_C")

--- a/kotlin/coroutines/src/test/kotlin/io/bluetape4k/workshop/coroutines/guide/CoroutineContextExamples.kt
+++ b/kotlin/coroutines/src/test/kotlin/io/bluetape4k/workshop/coroutines/guide/CoroutineContextExamples.kt
@@ -15,8 +15,10 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
+import io.bluetape4k.assertions.shouldBeEqualTo
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.random.Random
 
 class CoroutineContextExamples {
@@ -93,26 +95,32 @@ class CoroutineContextExamples {
 
         @Test
         fun `run many coroutines`() = runTest {
+            val completedCounter = AtomicInteger(0)
             val jobs = List(jobSize) {
                 launch(Dispatchers.IO) {
                     delay(1000)
-                    print(".")
+                    completedCounter.incrementAndGet()
                 }
             }
             jobs.joinAll()
+
+            completedCounter.get() shouldBeEqualTo jobSize
         }
 
         @Test
         fun `run many coroutines with coroutineScope`() = runTest {
+            val completedCounter = AtomicInteger(0)
             coroutineScope {
                 val jobs = List(jobSize) {
                     launch(Dispatchers.IO) {
                         delay(1000)
-                        print(".")
+                        completedCounter.incrementAndGet()
                     }
                 }
                 jobs.joinAll()
             }
+
+            completedCounter.get() shouldBeEqualTo jobSize
         }
     }
 }

--- a/redis/redisson-examples/src/test/kotlin/io/bluetape4k/workshop/redisson/objects/TopicExamples.kt
+++ b/redis/redisson-examples/src/test/kotlin/io/bluetape4k/workshop/redisson/objects/TopicExamples.kt
@@ -32,14 +32,12 @@ class TopicExamples: AbstractRedissonTest() {
 
         // topic 예 listener를 등록합니다.
         // listener id 를 반환한다.
-        val listenerId1 = topic.addListenerAsync(String::class.java) { channel, msg ->
-            println("Listener1: channel[$channel] received: $msg")
+        val listenerId1 = topic.addListenerAsync(String::class.java) { _, _ ->
             receivedCounter.incrementAndGet()
         }.await()
 
         // topic 예 listener를 등록합니다.
-        val listenerId2 = topic.addListenerAsync(String::class.java) { channel, msg ->
-            println("Listener2: channel[$channel] received: $msg")
+        val listenerId2 = topic.addListenerAsync(String::class.java) { _, _ ->
             receivedCounter.incrementAndGet()
         }.await()
 
@@ -74,14 +72,12 @@ class TopicExamples: AbstractRedissonTest() {
 
         // topic 예 listener를 등록합니다.
         // listener id 를 반환한다.
-        val listenerId1 = topic1.addListenerAsync(String::class.java) { channel, msg ->
-            println("Listener1: channel[$channel] received: $msg")
+        val listenerId1 = topic1.addListenerAsync(String::class.java) { _, _ ->
             receivedCounter.incrementAndGet()
         }.await()
 
         // topic 예 listener를 등록합니다.
-        val listenerId2 = topic2.addListenerAsync(String::class.java) { channel, msg ->
-            println("Listener2: channel[$channel] received: $msg")
+        val listenerId2 = topic2.addListenerAsync(String::class.java) { _, _ ->
             receivedCounter.incrementAndGet()
         }.await()
 

--- a/vertx/coroutines/src/main/kotlin/io/bluetape4k/workshop/movierating/Main.kt
+++ b/vertx/coroutines/src/main/kotlin/io/bluetape4k/workshop/movierating/Main.kt
@@ -1,16 +1,20 @@
 package io.bluetape4k.workshop.movierating
 
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.info
+import io.bluetape4k.logging.warn
 import io.vertx.core.Vertx
 import io.vertx.kotlin.coroutines.coAwait
+
+private object Main: KLogging()
 
 suspend fun main() {
     val vertx = Vertx.vertx()
 
     try {
         val result = vertx.deployVerticle(MovieRatingVerticle()).coAwait()
-        println("Application started. $result")
+        Main.log.info { "Application started. $result" }
     } catch (e: Throwable) {
-        println("Could not start application.")
-        e.printStackTrace()
+        Main.log.warn(e) { "Could not start application." }
     }
 }

--- a/virtualthreads/rules/src/test/kotlin/io/bluetape4k/workshop/virtualthread/part1/Example1_PlatformAndVirtualThread.kt
+++ b/virtualthreads/rules/src/test/kotlin/io/bluetape4k/workshop/virtualthread/part1/Example1_PlatformAndVirtualThread.kt
@@ -20,7 +20,7 @@ class Example1_PlatformAndVirtualThread: AbstractVirtualThreadTest() {
     @Test
     fun `Platform thread를 생성자로 생성하기`() {
         val thread = Thread {
-            println("Platform Thread")
+            log.debug { "Platform Thread" }
         }
         thread.start()
         thread.join()

--- a/virtualthreads/rules/src/test/kotlin/io/bluetape4k/workshop/virtualthread/part1/Example2_PlatformAndVirtualThreadBuilder.kt
+++ b/virtualthreads/rules/src/test/kotlin/io/bluetape4k/workshop/virtualthread/part1/Example2_PlatformAndVirtualThreadBuilder.kt
@@ -1,6 +1,7 @@
 package io.bluetape4k.workshop.virtualthread.part1
 
 import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.error
 import io.bluetape4k.workshop.virtualThreads.AbstractVirtualThreadTest
 import io.bluetape4k.assertions.shouldBeEqualTo
@@ -21,14 +22,14 @@ class Example2_PlatformAndVirtualThreadBuilder: AbstractVirtualThreadTest() {
             .name("platform-thread")
             .inheritInheritableThreadLocals(false)
             .uncaughtExceptionHandler { thread, ex ->
-                print("Thread[$thread] failed with exception: $ex")
+                log.error(ex) { "Thread[$thread] failed with exception." }
             }
 
-        print("Builder class=${builder.javaClass.name}")
+        log.debug { "Builder class=${builder.javaClass.name}" }
         builder.javaClass.name shouldBeEqualTo "java.lang.ThreadBuilders\$PlatformThreadBuilder"
 
         val thread = builder.unstarted {
-            print("Platform Thread")
+            log.debug { "Platform Thread" }
         }
 
         thread.javaClass.name shouldBeEqualTo "java.lang.Thread"
@@ -46,11 +47,11 @@ class Example2_PlatformAndVirtualThreadBuilder: AbstractVirtualThreadTest() {
                 log.error(ex) { "Thread[$thread] failed with exception." }
             }
 
-        println("Builder class=${builder.javaClass.name}")
+        log.debug { "Builder class=${builder.javaClass.name}" }
         builder.javaClass.name shouldBeEqualTo "java.lang.ThreadBuilders\$VirtualThreadBuilder"
 
         val thread = builder.unstarted {
-            println("Unstarted Virtual Thread")
+            log.debug { "Unstarted Virtual Thread" }
         }
         thread.javaClass.name shouldBeEqualTo "java.lang.VirtualThread"
         thread.name shouldBeEqualTo "virtual-thread"

--- a/virtualthreads/rules/src/test/kotlin/io/bluetape4k/workshop/virtualthread/part1/Example3_CreateStartedAndUnstartedVirtualThread.kt
+++ b/virtualthreads/rules/src/test/kotlin/io/bluetape4k/workshop/virtualthread/part1/Example3_CreateStartedAndUnstartedVirtualThread.kt
@@ -1,6 +1,7 @@
 package io.bluetape4k.workshop.virtualthread.part1
 
 import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.logging.debug
 import io.bluetape4k.workshop.virtualThreads.AbstractVirtualThreadTest
 import io.bluetape4k.assertions.shouldBeEqualTo
 import org.junit.jupiter.api.Test
@@ -15,7 +16,7 @@ class Example3_CreateStartedAndUnstartedVirtualThread: AbstractVirtualThreadTest
 
         val thread = builder.start {
             Thread.sleep(1000)
-            println("Virtual thread running")
+            log.debug { "Virtual thread running" }
         }
         thread.state shouldBeEqualTo Thread.State.RUNNABLE
         thread.join()
@@ -26,7 +27,7 @@ class Example3_CreateStartedAndUnstartedVirtualThread: AbstractVirtualThreadTest
         val builder = Thread.ofVirtual()
 
         val thread = builder.unstarted {
-            println("Virtual thread running")
+            log.debug { "Virtual thread running" }
         }
         thread.state shouldBeEqualTo Thread.State.NEW
         thread.start()

--- a/virtualthreads/rules/src/test/kotlin/io/bluetape4k/workshop/virtualthread/part1/Example4_VirtualThreadFactory.kt
+++ b/virtualthreads/rules/src/test/kotlin/io/bluetape4k/workshop/virtualthread/part1/Example4_VirtualThreadFactory.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.launch
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeTrue
 import org.junit.jupiter.api.Test
+import java.util.concurrent.atomic.AtomicInteger
 
 class Example4_VirtualThreadFactory: AbstractVirtualThreadTest() {
 
@@ -46,27 +47,33 @@ class Example4_VirtualThreadFactory: AbstractVirtualThreadTest() {
     @Test
     fun `대량의 Blocking 코드를 Virtual Thread로 실행하기`() {
         // Virtual Thread 는 Coroutines 와 달리 Blocking 코드를 실행할 때도 사용할 수 있습니다.
+        val executedCounter = AtomicInteger(0)
         val threads = List(100_000) {
             Thread.ofVirtual().unstarted {
                 Thread.sleep(1000)
-                print(".")
+                executedCounter.incrementAndGet()
             }
         }
 
         threads.forEach { it.start() }
         threads.forEach { it.join() }
+
+        executedCounter.get() shouldBeEqualTo 100_000
     }
 
     @Test
     fun `대량의 Blocking 코드를 Coroutines 로 실행하기`() = runSuspendTest {
         // Coroutines 는 대량의 작업을 실행할 때 더 효율적입니다.
+        val executedCounter = AtomicInteger(0)
         val jobs = List(100_000) {
             launch(Dispatchers.VT) {
                 Thread.sleep(1000)
-                print(".")
+                executedCounter.incrementAndGet()
             }
         }
 
         jobs.joinAll()
+
+        executedCounter.get() shouldBeEqualTo 100_000
     }
 }

--- a/virtualthreads/rules/src/test/kotlin/io/bluetape4k/workshop/virtualthread/part1/Example5_VirtualThreadPerTaskExecutor.kt
+++ b/virtualthreads/rules/src/test/kotlin/io/bluetape4k/workshop/virtualthread/part1/Example5_VirtualThreadPerTaskExecutor.kt
@@ -21,7 +21,7 @@ class Example5_VirtualThreadPerTaskExecutor: AbstractVirtualThreadTest() {
 
             val future = executor.submit {
                 Thread.sleep(100)
-                println("Run in ${Thread.currentThread()}")
+                log.info { "Run in ${Thread.currentThread()}" }
                 Thread.currentThread().name.shouldBeEmpty()
             }
             future.get()

--- a/virtualthreads/rules/src/test/kotlin/io/bluetape4k/workshop/virtualthread/part3/CoroutineWithVirtualThread.kt
+++ b/virtualthreads/rules/src/test/kotlin/io/bluetape4k/workshop/virtualthread/part3/CoroutineWithVirtualThread.kt
@@ -8,7 +8,9 @@ import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withContext
+import io.bluetape4k.assertions.shouldBeEqualTo
 import org.junit.jupiter.api.RepeatedTest
+import java.util.concurrent.atomic.AtomicInteger
 
 /**
  * 동기 코드를 Coroutines 환경에서 `Executors.newVirtualThreadPerTaskExecutor()` 를 이용해서 비동기로 실행할 수 있습니다.
@@ -21,23 +23,26 @@ class CoroutineWithVirtualThread: AbstractVirtualThreadTest() {
 
     @RepeatedTest(REPEAT_SIZE)
     fun `동기 코드를 Virtual Thread 를 사용하는 Coroutine Context 에서 실행하기`() = runTest {
+        val executedCounter = AtomicInteger(0)
         val jobs = List(100_000) {
             launch {
-                myAsyncCode()
+                myAsyncCode(executedCounter)
             }
         }
         jobs.joinAll()
+
+        executedCounter.get() shouldBeEqualTo 100_000
     }
 
-    private suspend fun myAsyncCode() {
+    private suspend fun myAsyncCode(executedCounter: AtomicInteger) {
         // 동기 코드를 [Dispatchers.VT]를 이용하여 Coroutines 환경에서 실행하기 
         withContext(Dispatchers.VT) {
-            mySyncCode()
+            mySyncCode(executedCounter)
         }
     }
 
-    private fun mySyncCode() {
+    private fun mySyncCode(executedCounter: AtomicInteger) {
         Thread.sleep(1000)
-        print(".")
+        executedCounter.incrementAndGet()
     }
 }

--- a/virtualthreads/rules/src/test/kotlin/io/bluetape4k/workshop/virtualthread/part3/StructuredConcurrencyExamples.kt
+++ b/virtualthreads/rules/src/test/kotlin/io/bluetape4k/workshop/virtualthread/part3/StructuredConcurrencyExamples.kt
@@ -4,6 +4,7 @@ import io.bluetape4k.concurrent.virtualthread.StructuredSubtask
 import io.bluetape4k.concurrent.virtualthread.structuredTaskScopeAll
 import io.bluetape4k.concurrent.virtualthread.structuredTaskScopeAny
 import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.logging.debug
 import io.bluetape4k.workshop.virtualThreads.AbstractVirtualThreadTest
 import io.bluetape4k.assertions.shouldBeEqualTo
 import org.junit.jupiter.api.Test
@@ -18,24 +19,24 @@ class StructuredConcurrencyExamples: AbstractVirtualThreadTest() {
     data class Dish(val pasta: Pasta, val sauce: Sauce)
 
     fun preparePasta(): Pasta {
-        println("prepare Pasta")
+        log.debug { "prepare Pasta" }
         return Pasta()
     }
 
     fun makeSaurce(): Sauce {
-        println("make Sauce")
+        log.debug { "make Sauce" }
         return Sauce()
     }
 
     fun serveDish(dish: Dish) {
-        println("😍 hear you are, $dish")
+        log.debug { "hear you are, $dish" }
     }
 
     /**
      * 비동기 코드를 병렬로 실행하고, 모든 작업이 성공적으로 완료되면 결과를 반환합니다.
      */
     fun prepareDish(): Dish = structuredTaskScopeAll { scope ->
-        println("prepare Dish ...")
+        log.debug { "prepare Dish ..." }
         val pasta: StructuredSubtask<Pasta> = scope.fork {
             Thread.sleep(100)
             preparePasta()
@@ -51,18 +52,19 @@ class StructuredConcurrencyExamples: AbstractVirtualThreadTest() {
         pasta.state() shouldBeEqualTo StructuredTaskScope.Subtask.State.SUCCESS
         sauce.state() shouldBeEqualTo StructuredTaskScope.Subtask.State.SUCCESS
 
-        println("complete Dish")
+        log.debug { "complete Dish" }
         Dish(pasta.get(), sauce.get())
     }
 
-    fun cookPasta() {
+    fun cookPasta(): Dish {
         val dish = prepareDish()
         serveDish(dish)
+        return dish
     }
 
     @Test
     fun `Structured Task Scope 안에서 병렬 작업`() {
-        cookPasta()
+        cookPasta() shouldBeEqualTo Dish(Pasta(), Sauce())
     }
 
 
@@ -94,6 +96,6 @@ class StructuredConcurrencyExamples: AbstractVirtualThreadTest() {
 
             scope.result { RuntimeException(it) }
         }
-        println("pasta: $pasta")
+        pasta shouldBeEqualTo Pasta()
     }
 }


### PR DESCRIPTION
## Summary
- replace flow and coroutine example console output with direct bluetape4k assertions
- remove Redisson listener printlns and keep delivery checks on counters
- route Vert.x startup output and virtual-thread educational messages through bluetape4k logging

Closes #227.

## Verification
- ./gradlew :kotlin-coroutines:test :virtualthreads-rules:test :vertx-coroutines:compileKotlin
- ./gradlew :redis-redisson-examples:test --tests "io.bluetape4k.workshop.redisson.objects.TopicExamples"
- ./gradlew :kotlin-coroutines:test --tests "io.bluetape4k.workshop.coroutines.flow.FlowLifecycleExamples"
- ./gradlew detekt