### PR TITLE
fix: stabilize r2dbc webflux schema initialization

### DIFF
--- a/spring-data/r2dbc-webflux-exposed/src/main/kotlin/io/bluetape4k/workshop/exposed/r2dbc/domain/schema/SchemaInitializer.kt
+++ b/spring-data/r2dbc-webflux-exposed/src/main/kotlin/io/bluetape4k/workshop/exposed/r2dbc/domain/schema/SchemaInitializer.kt
@@ -23,6 +23,10 @@ class SchemaInitializer(private val database: R2dbcDatabase): ApplicationListene
     override fun onApplicationEvent(event: ApplicationReadyEvent) {
         log.info { "샘플 데이터 추가" }
 
+        initializeSchema()
+    }
+
+    fun initializeSchema() {
         runBlocking(Dispatchers.IO) {
             suspendTransaction(db = database) {
                 createSchema()

--- a/spring-data/r2dbc-webflux-exposed/src/test/kotlin/io/bluetape4k/workshop/exposed/r2dbc/AbstractWebfluxR2dbcExposedApplicationTest.kt
+++ b/spring-data/r2dbc-webflux-exposed/src/test/kotlin/io/bluetape4k/workshop/exposed/r2dbc/AbstractWebfluxR2dbcExposedApplicationTest.kt
@@ -5,6 +5,8 @@ import io.bluetape4k.junit5.faker.Fakers
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.support.uninitialized
 import io.bluetape4k.workshop.exposed.r2dbc.domain.model.UserRecord
+import io.bluetape4k.workshop.exposed.r2dbc.domain.schema.SchemaInitializer
+import org.junit.jupiter.api.BeforeEach
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.context.ApplicationContext
@@ -35,8 +37,16 @@ abstract class AbstractWebfluxR2dbcExposedApplicationTest {
     @Autowired
     protected val context: ApplicationContext = uninitialized()
 
+    @Autowired
+    private val schemaInitializer: SchemaInitializer = uninitialized()
+
     protected val webTestClient: WebTestClient by lazy {
         WebTestClient.bindToApplicationContext(context).build()
+    }
+
+    @BeforeEach
+    fun ensureSchema() {
+        schemaInitializer.initializeSchema()
     }
 
     protected fun createUser(id: Int? = null): UserRecord =


### PR DESCRIPTION
## Summary
- Reuse SchemaInitializer from tests so cached Spring contexts can recreate the users table after repository harness cleanup.
- Ensure the Spring WebFlux/R2DBC integration test base initializes schema before each test.

## Verification
- ./gradlew :spring-data-r2dbc-webflux-exposed:cleanTest :spring-data-r2dbc-webflux-exposed:test --no-build-cache --max-workers=1 --console=plain
- ./gradlew detekt --console=plain

Closes #239