### PR TITLE
fix: frame observability mock error responses

### DIFF
--- a/observability/observability-basic/src/test/kotlin/io/bluetape4k/workshop/observability/basic/AbstractBasicTest.kt
+++ b/observability/observability-basic/src/test/kotlin/io/bluetape4k/workshop/observability/basic/AbstractBasicTest.kt
@@ -49,6 +49,7 @@ abstract class AbstractBasicTest {
                 setFailFast(
                     MockResponse.Builder()
                         .code(503)
+                        .body("")
                         .build()
                 )
             }

--- a/observability/observability-basic/src/test/kotlin/io/bluetape4k/workshop/observability/basic/service/OrderServiceTest.kt
+++ b/observability/observability-basic/src/test/kotlin/io/bluetape4k/workshop/observability/basic/service/OrderServiceTest.kt
@@ -65,6 +65,7 @@ class OrderServiceTest : AbstractBasicTest() {
         mockServer.enqueue(
             MockResponse.Builder()
                 .code(404)
+                .body("")
                 .build()
         )
 
@@ -83,6 +84,7 @@ class OrderServiceTest : AbstractBasicTest() {
         mockServer.enqueue(
             MockResponse.Builder()
                 .code(500)
+                .body("")
                 .build()
         )
 


### PR DESCRIPTION
## Summary
- Add explicit empty bodies to MockWebServer 404 and 500 responses used by OrderServiceTest.
- Add explicit empty body to the shared fail-fast 503 response so missing stubs fail quickly with framed responses.

## Evidence
- Nightly full on develop still failed in the same 404 test after #241: https://github.com/bluetape4k/bluetape4k-workshop/actions/runs/26492968848

## Verification
- ./gradlew :observability-basic:cleanTest :observability-basic:test --no-build-cache --max-workers=1 --console=plain
- ./gradlew detekt --console=plain

Closes #238