### PR TITLE
fix: short-circuit inventory 4xx responses

### DIFF
--- a/observability/observability-basic/src/main/kotlin/io/bluetape4k/workshop/observability/basic/client/InventoryClient.kt
+++ b/observability/observability-basic/src/main/kotlin/io/bluetape4k/workshop/observability/basic/client/InventoryClient.kt
@@ -5,8 +5,9 @@ import io.bluetape4k.workshop.observability.basic.model.Inventory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.awaitExchangeOrNull
 import org.springframework.web.reactive.function.client.awaitBodyOrNull
-import reactor.core.publisher.Mono
+import org.springframework.web.reactive.function.client.createExceptionAndAwait
 
 /**
  * HTTP client for the downstream inventory service.
@@ -37,10 +38,13 @@ class InventoryClient(
     suspend fun fetchInventory(itemId: Long): Inventory? {
         val result = client.get()
             .uri("/inventory/{id}", itemId)
-            .retrieve()
-            .onStatus({ it.is4xxClientError }) { Mono.empty() }
-            .onStatus({ it.is5xxServerError }) { resp -> resp.createException().flatMap { Mono.error(it) } }
-            .awaitBodyOrNull<Inventory>()
+            .awaitExchangeOrNull { response ->
+                when {
+                    response.statusCode().is4xxClientError -> null
+                    response.statusCode().is5xxServerError -> throw response.createExceptionAndAwait()
+                    else -> response.awaitBodyOrNull<Inventory>()
+                }
+            }
         if (result == null) warn { "fetchInventory returned null for itemId=$itemId" }
         return result
     }


### PR DESCRIPTION
## Summary
- Switch InventoryClient from retrieve/onStatus to awaitExchangeOrNull.
- Return null immediately for 4xx responses without reading the error body.
- Preserve 5xx exception propagation with createExceptionAndAwait.

## Evidence
- Nightly still timed out in awaitBodyOrNull after #242: https://github.com/bluetape4k/bluetape4k-workshop/actions/runs/26494500455

## Verification
- ./gradlew :observability-basic:cleanTest :observability-basic:test --no-build-cache --max-workers=1 --console=plain
- ./gradlew detekt --console=plain

Closes #238