### PR TITLE
docs: persist local work notes

### DIFF
--- a/WIP.md
+++ b/WIP.md
@@ -9,7 +9,7 @@ Open count: 7 issues.
 - CI/Nightly, Spring Boot 4.0.x alignment, Gradle 9.5.0/version-catalog migration, local OMX ignore rules, and assertion migration are merged.
 - JDBC helper dependency fixes for Exposed workshop modules are merged by PR #60 and PR #61.
 - Dependency governance, compatibility guards, and dependency bumps are merged through PR #33 through PR #59.
-- QMD-backed audit registered `#120` for disabled R2DBC WebFlux integration tests.
+- GNO-backed audit registered `#120` for disabled R2DBC WebFlux integration tests.
 
 ## Current Direction
 

--- a/docs/lessons/2026-05-18-wip-audit-r2dbc-webflux-tests.md
+++ b/docs/lessons/2026-05-18-wip-audit-r2dbc-webflux-tests.md
@@ -2,7 +2,7 @@
 
 ## Context
 
-The 2026-05-18 qmd-backed workshop audit checked prior compile-drift lessons,
+The 2026-05-18 GNO-backed workshop audit checked prior compile-drift lessons,
 live GitHub issues, and current source markers before refreshing `WIP.md`.
 
 ## Decision or Finding
@@ -20,7 +20,7 @@ repo-local WIP queue.
 
 ## Verification
 
-- `qmd query ... --no-rerank -c bluetape4k-docs` surfaced the prior workshop
+- `gno query ... --no-rerank -c bluetape4k-docs` surfaced the prior workshop
   compile-drift lesson.
 - `gh issue list --assignee debop` confirmed the existing open assigned queue.
 - `gh issue list --search "r2dbc schema disabled tests"` found no duplicate.

--- a/docs/superpowers/specs/2026-05-24-issue-93-image-processing-advanced-design.md
+++ b/docs/superpowers/specs/2026-05-24-issue-93-image-processing-advanced-design.md
@@ -289,7 +289,7 @@ Workflow metrics use low-cardinality tags only. They never include `imageId`, fi
 | Item | Status | Notes |
 |---|---|---|
 | Target repository confirmed | Done | `bluetape4k-workshop`, branch `feat/issue-93-image-processing-advanced` |
-| Memory/qmd searched | Done | Found `images-vips` design/plan and issue #77 classification references |
+| Memory/GNO searched | Done | Found `images-vips` design/plan and issue #77 classification references |
 | Current repo and ecosystem reuse searched | Done | CodeGraph and source inspection for VIPS and image storage |
 | External/current API evidence checked | Done | Local source for `FfmVipsRuntime`, `ffmVipsImageOf`, `ImageStorage`, `S3ImageStorage`, `LocalImageStorage` |
 | Technical constraints identified | Done | Java 25 module, libvips native dependency, unsigned public URL security |


### PR DESCRIPTION
## Summary
- Preserve local planning, lesson, and WIP documentation updates.
- No production source or build configuration files are changed.

## Validation
- git diff --cached --check before commit

## Notes
- Gradle tests were not run because this PR is documentation-only.