### PR TITLE
build: consume catalog 2026-06-02-00

### DIFF
--- a/docs/lessons/2026-06-02-catalog-2026-06-02-00-sync.md
+++ b/docs/lessons/2026-06-02-catalog-2026-06-02-00-sync.md
@@ -1,0 +1,24 @@
+# Catalog 2026-06-02-00 Sync
+
+## Context
+
+`bluetape4k-dependencies` cut `catalog/2026-06-02-00` after the issue #101
+security dependency train.
+
+## Decision
+
+Sync shared version aliases from the central catalog.
+
+## Outcome
+
+Workshop catalog versions now match the source-of-truth dependency catalog.
+
+## Verification
+
+- `scripts/sync-shared-versions.py --workspace /Users/debop/work/bluetape4k --check --summary`
+- `scripts/sync-dependabot-ignores.py --workspace /Users/debop/work/bluetape4k --check --summary`
+
+## Future Guidance
+
+Workshop repositories should consume shared dependency changes through the
+central sync scripts.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,16 +17,16 @@ spring-modulith = "2.0.6"  # https://mvnrepository.com/artifact/org.springframew
 
 reactor-bom = "2025.0.5"  # https://mvnrepository.com/artifact/io.projectreactor/reactor-bom
 resilience4j = "2.4.0"  # https://mvnrepository.com/artifact/io.github.resilience4j/resilience4j-bom
-netty = "4.2.13.Final"  # https://mvnrepository.com/artifact/io.netty/netty-bom
+netty = "4.2.15.Final"  # https://mvnrepository.com/artifact/io.netty/netty-bom
 
-aws2 = "2.44.12"  # https://mvnrepository.com/artifact/software.amazon.awssdk/bom
+aws2 = "2.46.0"  # https://mvnrepository.com/artifact/software.amazon.awssdk/bom
 aws2-crt = "0.45.3"  # https://mvnrepository.com/artifact/software.amazon.awssdk.crt/aws-crt
 aws-kotlin = "1.6.80"  # https://mvnrepository.com/artifact/aws.sdk.kotlin/aws-core
 aws-spring-cloud = "4.0.2"  # https://mvnrepository.com/artifact/io.awspring.cloud/spring-cloud-aws-s3
 
 grpc = "1.81.0"  # https://mvnrepository.com/artifact/io.grpc/grpc-bom
 grpc-kotlin = "1.5.0"  # https://mvnrepository.com/artifact/io.grpc/grpc-kotlin-stub
-protobuf = "4.34.1"  # https://mvnrepository.com/artifact/com.google.protobuf/protobuf-bom
+protobuf = "4.35.0"  # https://mvnrepository.com/artifact/com.google.protobuf/protobuf-bom
 grpc-google-common-protos = "2.71.0"  # https://mvnrepository.com/artifact/com.google.api.grpc/grpc-google-common-protos
 avro = "1.12.1"  # https://mvnrepository.com/artifact/org.apache.avro/avro
 
@@ -38,9 +38,9 @@ okhttp3 = "5.3.2"  # https://mvnrepository.com/artifact/com.squareup.okhttp3/okh
 okio = "3.17.0"  # https://mvnrepository.com/artifact/com.squareup.okio/okio
 asynchttpclient = "3.0.9"  # https://mvnrepository.com/artifact/org.asynchttpclient/async-http-client
 
-jackson = "2.21.3"  # https://mvnrepository.com/artifact/com.fasterxml.jackson/jackson-bom
+jackson = "2.21.4"  # https://mvnrepository.com/artifact/com.fasterxml.jackson/jackson-bom
 jackson-annotations = "2.21"  # https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-annotations
-jackson3 = "3.1.3"  # https://mvnrepository.com/artifact/tools.jackson/jackson-bom
+jackson3 = "3.1.4"  # https://mvnrepository.com/artifact/tools.jackson/jackson-bom
 fastjson2 = "2.0.62"  # https://mvnrepository.com/artifact/com.alibaba.fastjson2/fastjson2
 
 mapstruct = "1.6.3"  # https://mvnrepository.com/artifact/org.mapstruct/mapstruct
@@ -125,7 +125,7 @@ random-beans = "3.9.0"  # https://mvnrepository.com/artifact/io.github.benas/ran
 springdoc-openapi = "3.0.3"  # https://mvnrepository.com/artifact/org.springdoc/springdoc-openapi-starter-webmvc-api
 problem = "0.29.1"  # https://mvnrepository.com/artifact/org.zalando/problem-spring-webflux
 
-scrimage = "4.5.4"  # https://mvnrepository.com/artifact/com.sksamuel.scrimage/scrimage-core
+scrimage = "4.6.0"  # https://mvnrepository.com/artifact/com.sksamuel.scrimage/scrimage-core
 gatling = "3.15.0"  # https://mvnrepository.com/artifact/io.gatling/gatling-app
 
 # Plugin versions


### PR DESCRIPTION
## Summary

Consume the `catalog/2026-06-02-00` dependency catalog cut from `bluetape4k-dependencies` after issue #101.

- Updates synced shared version aliases from the central catalog.
- Updates the default `bt4k` catalog ref where this repository imports the catalog by tag.
- Adds a short lesson so future catalog trains keep the ref bump and alias sync together.

## Verification

- `git diff --check`
- `scripts/sync-shared-versions.py --workspace /Users/debop/work/bluetape4k --check --summary`
- `scripts/sync-dependabot-ignores.py --workspace /Users/debop/work/bluetape4k --check --summary`

## Notes

Full repository CI is expected to validate Gradle resolution after the PR opens.