### PR TITLE
docs: point AWS architecture READMEs at compliant diagrams

### DIFF
--- a/aws/README.ko.md
+++ b/aws/README.ko.md
@@ -12,7 +12,7 @@
 
 모듈은 샘플 진입점 또는 테스트 픽스처, bluetape4k 확장 계층, 예제가 사용하는 런타임 의존성으로 구성됩니다. README와 코드를 비교할 때는 `io.bluetape4k.workshop.aws` 패키지 아래의 구현을 기준으로 삼습니다.
 
-![AWS Demo 아키텍처 다이어그램](../docs/images/readme-diagrams/aws-storage-abstraction-architecture-01.png)
+![AWS Demo 아키텍처 다이어그램](../docs/images/readme-diagrams/aws-storage-abstraction-readme-architecture-01.png)
 
 ## 흐름 다이어그램
 

--- a/aws/README.md
+++ b/aws/README.md
@@ -12,7 +12,7 @@ This example exercises **AWS Demo** as a runnable AWS integration workshop slice
 
 The module is organized around the sample entry point or test fixture, the bluetape4k extension layer, and the runtime dependency used by the example. Keep the package under `io.bluetape4k.workshop.aws` as the source of truth when comparing this README with the code.
 
-![AWS Demo architecture diagram](../docs/images/readme-diagrams/aws-storage-abstraction-architecture-01.png)
+![AWS Demo architecture diagram](../docs/images/readme-diagrams/aws-storage-abstraction-readme-architecture-01.png)
 
 ## Flow Diagram
 

--- a/aws/storage-abstraction/README.ko.md
+++ b/aws/storage-abstraction/README.ko.md
@@ -12,7 +12,7 @@
 
 모듈은 샘플 진입점 또는 테스트 픽스처, bluetape4k 확장 계층, 예제가 사용하는 런타임 의존성으로 구성됩니다. README와 코드를 비교할 때는 `io.bluetape4k.workshop.aws` 패키지 아래의 구현을 기준으로 삼습니다.
 
-![Storage Abstraction Workshop 아키텍처 다이어그램](../../docs/images/readme-diagrams/aws-storage-abstraction-architecture-01.png)
+![Storage Abstraction Workshop 아키텍처 다이어그램](../../docs/images/readme-diagrams/aws-storage-abstraction-readme-architecture-01.png)
 
 ## 흐름 다이어그램
 

--- a/aws/storage-abstraction/README.md
+++ b/aws/storage-abstraction/README.md
@@ -24,7 +24,7 @@ AWS S3, and S3 pre-signed URL backends via Spring Profile — without changing a
 
 ![Storage Abstraction Workshop Graphviz architecture diagram](../../docs/images/readme-diagrams/aws-storage-abstraction-readme-architecture-01.png)
 
-![storage abstraction Architecture diagram](../../docs/images/readme-diagrams/aws-storage-abstraction-architecture-01.png)
+![storage abstraction Architecture diagram](../../docs/images/readme-diagrams/aws-storage-abstraction-readme-architecture-01.png)
 
 ## Key Features
 

--- a/docs/lessons/2026-06-03-workshop-example-readme-localization.md
+++ b/docs/lessons/2026-06-03-workshop-example-readme-localization.md
@@ -58,3 +58,8 @@
 `build.gradle.kts`, 리소스를 evidence로 삼아 entry/API/service/domain/repository/runtime
 관계를 구성한다. Graphviz는 layout/routing evidence로만 사용하고, 최종 SVG/PNG는
 별도 generator가 작성한다.
+
+Architecture 섹션을 보강할 때 첫 overview 이미지만 새 자산으로 바꾸면 기존 상세
+architecture 이미지가 예전 font stack을 계속 노출할 수 있다. README 이미지 링크
+검증은 섹션의 모든 architecture 이미지가 `Architects Daughter`/`Comic Mono` 기반
+SVG/PNG 쌍을 참조하는지까지 확인해야 한다.


### PR DESCRIPTION
## Summary
- Point AWS root and storage-abstraction README architecture images at the compliant `aws-storage-abstraction-readme-architecture-01.png` asset.
- Keep the generated Graphviz-backed AWS architecture diagram as the rendered README asset instead of the older pre-batch image.
- Record the follow-up lesson that every architecture image in a README section must be checked, not only the first overview image.

## Verification
- AWS architecture README image scan: `refs=8 failures=0`.
- Old `aws-storage-abstraction-architecture-01.png` references in affected README files: `0`.
- `xmllint --noout docs/images/readme-diagrams/aws-readme-architecture-01.svg docs/images/readme-diagrams/aws-storage-abstraction-readme-architecture-01.svg`.
- `git diff --check`.

## Scope note
- This fixes the reported stale AWS architecture image reference. Legacy flow/sequence images that still use older font stacks remain a separate diagram migration batch.