### PR TITLE
Align workshop with Kotlin 2.4 catalog train

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ repo-specific layout, commands, domain rules, and local exceptions.
 
 Backend examples using bluetape4k libraries.
 
-- Kotlin 2.3.21
+- Kotlin 2.4.0
 - Java 21
 - Spring Boot 4.0.6
 - bluetape4k 1.7.0

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,10 +2,10 @@
 # Gradle Version Catalog — migrated from buildSrc/src/main/kotlin/Libs.kt
 
 [versions]
-bluetape4k-dependencies-version = "1.1.3"  # https://mvnrepository.com/artifact/io.github.bluetape4k/bluetape4k-dependencies
+bluetape4k-dependencies-version = "1.2.0"  # https://mvnrepository.com/artifact/io.github.bluetape4k/bluetape4k-dependencies
 # bluetape4k-graph version is managed by bluetape4k-dependencies BOM (currently 0.4.1)
 
-kotlin = "2.3.21"  # https://mvnrepository.com/artifact/org.jetbrains.kotlin/kotlin-bom
+kotlin = "2.4.0"  # https://mvnrepository.com/artifact/org.jetbrains.kotlin/kotlin-bom
 kotlinx-coroutines = "1.11.0"  # https://mvnrepository.com/artifact/org.jetbrains.kotlinx/kotlinx-coroutines-bom
 kotlinx-serialization = "1.11.0"  # https://mvnrepository.com/artifact/org.jetbrains.kotlinx/kotlinx-serialization-bom
 kotlinx-atomicfu = "0.32.1"  # https://mvnrepository.com/artifact/org.jetbrains.kotlinx/atomicfu


### PR DESCRIPTION
## Summary
- Move `bluetape4k-workshop` to Kotlin `2.4.0`.
- Move the workshop consumer BOM alias to `bluetape4k-dependencies` `1.2.0`, matching the current Kotlin 2.4 catalog train.
- Update repo-local guidance so the documented Kotlin baseline is not stale.

## Validation
- `./gradlew help --no-daemon`
- `./gradlew :shared:compileKotlin --no-daemon`
- `git diff --check`
- Targeted workspace scan for stale `kotlin = "2.3.21"`, `bluetape4k-dependencies-version = "1.1.3"`, and old catalog refs.

## Notes
- Repos already on Kotlin `2.4.0` and `catalog/2026-06-09-01` were skipped.
- `bluetape4k-workshop` does not resolve the checked-out catalog tag directly; it consumes the published `bluetape4k-dependencies` BOM alias, so this PR aligns that consumer path to `1.2.0`.

## DoD Status
- [x] Kotlin version updated to `2.4.0`.
- [x] Workshop consumer BOM alias updated to `bluetape4k-dependencies` `1.2.0`.
- [x] Repo guidance updated to the Kotlin `2.4.0` baseline.
- [x] Gradle configuration smoke passed.
- [x] `shared` Kotlin compile passed.
- [ ] Full workshop build and Testcontainers-backed modules not run.
