### PR TITLE
Align cache benchmark strategy semantics

### DIFF
--- a/spring-boot/cache-benchmark/README.ko.md
+++ b/spring-boot/cache-benchmark/README.ko.md
@@ -7,7 +7,7 @@
 - `kotlinx-benchmark`가 JMH 스타일 warmup과 iteration을 제공합니다.
 - H2는 persistence layer를 로컬이고 반복 가능한 상태로 유지합니다.
 - Redis-backed profile은 bluetape4k Testcontainers로 Redis를 시작합니다.
-- Caffeine, Spring Cache Redis, Redisson near cache, manual read/write policy를 같은 연산으로 측정합니다.
+- Caffeine, Spring Cache Redis, Redisson near cache, 그리고 명시적 캐시 전략(읽기/쓰기 전략)을 같은 연산으로 측정합니다.
 
 ## 아키텍처
 
@@ -19,7 +19,14 @@
 
 ![7 Cache Strategy Comparison](../../docs/images/readme-diagrams/cache-benchmark-scenario-01.png)
 
-프로파일은 직접 DB 접근, local cache, shared Redis cache, two-tier near cache, explicit read-through, synchronous write-through, asynchronous write-behind update를 모두 포함합니다.
+프로파일은 직접 DB 접근, local cache, shared Redis cache, two-tier near cache, 명시적 read-through 읽기, cache-aside 쓰기, 동기 write-through 쓰기, 비동기 write-behind update를 모두 포함합니다.
+
+### 전략 의미
+
+- **Read-Through**: `findById`의 캐시 미스는 Repository 조회로 처리한 뒤 캐시에 저장합니다.
+- **Cache-aside 쓰기**: 애플리케이션이 DB 저장 후 캐시를 갱신하는 쓰기 방식입니다.
+- **Write-Through**: 쓰기마다 DB와 캐시를 동기적으로 같이 갱신합니다.
+- **Write-Behind**: 캐시를 먼저 갱신하고 DB 반영은 백그라운드로 지연 수행합니다.
 
 ## 7가지 캐시 프로파일
 
@@ -29,9 +36,9 @@
 | 2 | **Caffeine** | `@Cacheable` local | Per-instance | Low | Lowest (ns) |
 | 3 | **Redis Cache** | `@Cacheable` remote | Shared | Low | Low (µs) |
 | 4 | **Near Cache** | Redisson `RLocalCachedMap` | Eventual | Medium | Mixed |
-| 5 | **Read-Through** | Manual Redis RT | Eventual | Low | Low |
-| 6 | **Write-Through** | Sync Redis + DB | Strong | High | Low |
-| 7 | **Write-Behind** | Async DB flush | Eventual | Lowest | Low |
+| 5 | **Read-Through** | 캐시 미스 시 Read-Through 조회 후 저장 | Eventual | Low | Low |
+| 6 | **Write-Through** | 동기식 Dual-Write | Strong | High | Low |
+| 7 | **Write-Behind** | 캐시 즉시 갱신 + 비동기 DB flush | Eventual | Lowest | Low |
 
 ## 벤치마크 결과
 

--- a/spring-boot/cache-benchmark/README.md
+++ b/spring-boot/cache-benchmark/README.md
@@ -7,7 +7,7 @@ This module benchmarks seven cache strategies behind one `ProductCacheService` c
 - `kotlinx-benchmark` provides JMH-style warmups and iterations.
 - H2 keeps the persistence layer local and repeatable.
 - Redis is started through bluetape4k Testcontainers for Redis-backed profiles.
-- Caffeine, Spring Cache Redis, Redisson near cache, and manual read/write policies are measured with the same operations.
+- Caffeine, Spring Cache Redis, Redisson near cache, and explicit read/write strategy profiles are measured with the same operations.
 
 ## Architecture
 
@@ -19,7 +19,14 @@ Each benchmark profile boots the Spring context with a fresh H2 database URL and
 
 ![7 Cache Strategy Comparison](../../docs/images/readme-diagrams/cache-benchmark-scenario-01.png)
 
-The profiles cover direct database access, local caching, shared Redis caching, two-tier near caching, explicit read-through, synchronous write-through, and asynchronous write-behind updates.
+The profiles cover direct database access, local caching, shared Redis caching, two-tier near caching, explicit read-through reads, explicit cache-aside write management, synchronous write-through writes, and asynchronous write-behind updates.
+
+### Strategy semantics
+
+- **Read-Through**: cache miss on `findById` is handled by repository lookup and then cached.
+- **Cache-aside writes**: application code writes to DB first, then explicitly updates cache for the target profile.
+- **Write-Through**: every write performs synchronized DB + cache updates.
+- **Write-Behind**: writes update cache immediately and flush DB asynchronously.
 
 ## 7 Cache Profiles
 
@@ -29,9 +36,9 @@ The profiles cover direct database access, local caching, shared Redis caching, 
 | 2 | **Caffeine** | `@Cacheable` local | Per-instance | Low | Lowest (ns) |
 | 3 | **Redis Cache** | `@Cacheable` remote | Shared | Low | Low (µs) |
 | 4 | **Near Cache** | Redisson `RLocalCachedMap` | Eventual | Medium | Mixed |
-| 5 | **Read-Through** | Manual Redis RT | Eventual | Low | Low |
-| 6 | **Write-Through** | Sync Redis + DB | Strong | High | Low |
-| 7 | **Write-Behind** | Async DB flush | Eventual | Lowest | Low |
+| 5 | **Read-Through** | Cache-on-miss reads (`read-through`) | Eventual | Low | Low |
+| 6 | **Write-Through** | Synchronous dual-write | Strong | High | Low |
+| 7 | **Write-Behind** | Cache-first writes + async DB flush | Eventual | Lowest | Low |
 
 ## Benchmark Results
 

--- a/spring-boot/cache-benchmark/src/benchmark/kotlin/io/bluetape4k/workshop/cache/benchmark/benchmarks/ReadThroughBenchmark.kt
+++ b/spring-boot/cache-benchmark/src/benchmark/kotlin/io/bluetape4k/workshop/cache/benchmark/benchmarks/ReadThroughBenchmark.kt
@@ -16,9 +16,10 @@ import java.util.concurrent.TimeUnit
 /**
  * Profile 5 — Read-Through Cache.
  *
- * Manual Redis read-through: cache-first; on miss loads from DB and
- * populates the cache. Similar to Profile 3 but the pattern is explicit
- * and key-prefixed for isolation.
+ * Profile 5 — Read-Through Cache.
+ *
+ * Read path: Redis cache-first with explicit DB fallback; cache is populated on miss.
+ * Write path remains application-managed (cache-aside) in this service.
  */
 @State(Scope.Benchmark)
 @BenchmarkMode(Mode.Throughput)

--- a/spring-boot/cache-benchmark/src/benchmark/kotlin/io/bluetape4k/workshop/cache/benchmark/benchmarks/WriteBehindBenchmark.kt
+++ b/spring-boot/cache-benchmark/src/benchmark/kotlin/io/bluetape4k/workshop/cache/benchmark/benchmarks/WriteBehindBenchmark.kt
@@ -17,8 +17,10 @@ import java.util.concurrent.TimeUnit
 /**
  * Profile 7 — Write-Behind Cache.
  *
- * Measures write throughput when the cache is updated synchronously but the DB
- * flush is deferred to a background thread ([@Async]).
+ * Profile 7 — Write-Behind Cache.
+ *
+ * Measures write throughput when cache updates are synchronous but DB flush is
+ * deferred to a background thread ([@Async]) for eventual consistency.
  *
  * Expected: highest write throughput among profiles 6 & 7 (async DB flush),
  * at the cost of eventual consistency.

--- a/spring-boot/cache-benchmark/src/benchmark/kotlin/io/bluetape4k/workshop/cache/benchmark/benchmarks/WriteThroughBenchmark.kt
+++ b/spring-boot/cache-benchmark/src/benchmark/kotlin/io/bluetape4k/workshop/cache/benchmark/benchmarks/WriteThroughBenchmark.kt
@@ -17,8 +17,10 @@ import java.util.concurrent.TimeUnit
 /**
  * Profile 6 — Write-Through Cache.
  *
- * Measures write throughput when both the Redis cache and the DB are updated
- * synchronously on every [save] call.
+ * Profile 6 — Write-Through Cache.
+ *
+ * Measures write throughput when both Redis and DB are updated synchronously
+ * on every [save] call.
  *
  * Also measures read throughput (cache-warmed) to compare with write cost.
  */

--- a/spring-boot/cache-benchmark/src/main/kotlin/io/bluetape4k/workshop/cache/benchmark/service/ReadThroughService.kt
+++ b/spring-boot/cache-benchmark/src/main/kotlin/io/bluetape4k/workshop/cache/benchmark/service/ReadThroughService.kt
@@ -10,12 +10,14 @@ import java.time.Duration
 /**
  * Profile 5 — Read-Through Cache.
  *
- * A manual read-through implementation using Redis:
- * - On cache hit: return cached value (no DB access)
- * - On cache miss: load from DB, populate cache, return value
+ * Read strategy: Redis-backed cache with explicit miss handling.
  *
- * Difference from Profile 3 (Redis Cache): explicit `getOrLoad` logic is visible here,
- * making the read-through pattern explicit and measurable.
+ * - On cache hit: return cached value (no DB access).
+ * - On cache miss: load from DB and populate cache.
+ *
+ * Write strategy: cache-aside / application-managed.
+ * Writes are persisted in the repository first, then reflected in Redis so this
+ * profile is intentionally not a write-through strategy.
  */
 @Service
 class ReadThroughService(

--- a/spring-boot/cache-benchmark/src/main/kotlin/io/bluetape4k/workshop/cache/benchmark/service/WriteBehindService.kt
+++ b/spring-boot/cache-benchmark/src/main/kotlin/io/bluetape4k/workshop/cache/benchmark/service/WriteBehindService.kt
@@ -10,10 +10,10 @@ import java.time.Duration
 /**
  * Profile 7 — Write-Behind Cache.
  *
- * Writes are applied immediately to the Redis cache and asynchronously to the DB.
- * - Reads: cache-first, fall through to DB on miss
- * - Writes (new entity): DB save first to get the generated ID, then populate cache
- * - Writes (update): cache updated immediately, DB flush deferred via [WriteBehindFlusher]
+ * Strategy: cache-first reads and write-behind writes.
+ * - Reads: cache-first, fall through to DB on miss.
+ * - Writes (new entity): DB save first to get the generated ID, then cache the new row.
+ * - Writes (update): update Redis immediately, flush DB asynchronously.
  *
  * ## Why a separate flusher?
  * Spring's `@Async` requires the call to pass through a Spring proxy.

--- a/spring-boot/cache-benchmark/src/main/kotlin/io/bluetape4k/workshop/cache/benchmark/service/WriteThroughService.kt
+++ b/spring-boot/cache-benchmark/src/main/kotlin/io/bluetape4k/workshop/cache/benchmark/service/WriteThroughService.kt
@@ -10,9 +10,11 @@ import java.time.Duration
 /**
  * Profile 6 — Write-Through Cache.
  *
- * Every write is applied synchronously to **both** Redis cache and the DB.
- * - Reads: cache-first, fall through to DB on miss
- * - Writes: synchronous dual-write (cache + DB) — strong consistency, higher write latency
+ * Strategy: true write-through.
+ * Every write is applied synchronously to both Redis cache and DB.
+ *
+ * - Reads: cache-first, then repository on miss.
+ * - Writes: synchronized dual-write (cache + DB) for immediate consistency.
  */
 @Service
 class WriteThroughService(
@@ -37,7 +39,6 @@ class WriteThroughService(
     }
 
     override fun save(product: Product): Product {
-        // Write-through: update DB first, then update cache atomically
         val saved = productRepository.save(product)
         redisTemplate.opsForValue().set(cacheKey(saved.id), saved, TTL)
         return saved

--- a/spring-boot/cache-benchmark/src/test/kotlin/io/bluetape4k/workshop/cache/benchmark/service/ReadThroughServiceTest.kt
+++ b/spring-boot/cache-benchmark/src/test/kotlin/io/bluetape4k/workshop/cache/benchmark/service/ReadThroughServiceTest.kt
@@ -1,11 +1,13 @@
 package io.bluetape4k.workshop.cache.benchmark.service
 
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.workshop.cache.benchmark.AbstractCacheBenchmarkTest
 import io.bluetape4k.workshop.cache.benchmark.domain.Product
 import io.bluetape4k.workshop.cache.benchmark.domain.ProductRepository
+import org.springframework.data.redis.core.RedisTemplate
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import java.math.BigDecimal
@@ -13,6 +15,7 @@ import java.math.BigDecimal
 class ReadThroughServiceTest(
     @Autowired private val service: ReadThroughService,
     @Autowired private val productRepository: ProductRepository,
+    @Autowired private val redisTemplate: RedisTemplate<String, Product>,
 ) : AbstractCacheBenchmarkTest() {
 
     @Test
@@ -34,6 +37,22 @@ class ReadThroughServiceTest(
     @Test
     fun `findById returns null for unknown id`() {
         service.findById(999_999L).shouldBeNull()
+    }
+
+    @Test
+    fun `findById loads from repository on cache miss and populates Redis cache`() {
+        val existing = productRepository.findAll().first()
+        service.evict(existing.id)
+
+        (redisTemplate.hasKey(ReadThroughService.KEY_PREFIX + existing.id)).shouldBeFalse()
+
+        val first = service.findById(existing.id)
+        first shouldBeEqualTo existing
+
+        (redisTemplate.hasKey(ReadThroughService.KEY_PREFIX + existing.id)).shouldBeTrue()
+
+        val second = service.findById(existing.id)
+        second shouldBeEqualTo first
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Clarify `spring-boot/cache-benchmark` cache strategy semantics to distinguish true cache-aside write handling from read-through/read-through-write/write-behind behavior.
- Update service/benchmark comments and README wording in English/Korean so terminology matches `exposed-workshop` chapter 11 strategy models.
- Add a read-through coverage test validating cache miss population and cache hit reuse in `ReadThroughService`.

## Testing
- `./gradlew :spring-boot-cache-benchmark:test --tests "io.bluetape4k.workshop.cache.benchmark.service.ReadThroughServiceTest"`
- `./gradlew :spring-boot-cache-benchmark:test --tests "io.bluetape4k.workshop.cache.benchmark.service.WriteThroughServiceTest" --tests "io.bluetape4k.workshop.cache.benchmark.service.WriteBehindServiceTest"`

## Related Issues
Closes #246

## DoD Status
- [x] Issue context and acceptance criteria validated from #246
- [x] Cache strategy semantics aligned in service, benchmark, and README docs (EN/KO)
- [x] Read-through miss/load behavior test added in `ReadThroughServiceTest`
- [x] Targeted tests executed and passing
- [ ] PR review and merge completed
