### PR TITLE
build: consume June dependency catalog

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,23 +10,23 @@ kotlinx-coroutines = "1.11.0"  # https://mvnrepository.com/artifact/org.jetbrain
 kotlinx-serialization = "1.11.0"  # https://mvnrepository.com/artifact/org.jetbrains.kotlinx/kotlinx-serialization-bom
 kotlinx-atomicfu = "0.32.1"  # https://mvnrepository.com/artifact/org.jetbrains.kotlinx/atomicfu
 
-spring-boot4 = "4.0.6"  # https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-dependencies
+spring-boot4 = "4.1.0"  # https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-dependencies
 spring-cloud = "2025.1.2"  # https://mvnrepository.com/artifact/org.springframework.cloud/spring-cloud-dependencies
 spring-integration = "7.1.0"  # https://mvnrepository.com/artifact/org.springframework.integration/spring-integration-bom
 spring-modulith = "2.1.0"  # https://mvnrepository.com/artifact/org.springframework.modulith/spring-modulith-bom
 
-reactor-bom = "2025.0.5"  # https://mvnrepository.com/artifact/io.projectreactor/reactor-bom
+reactor-bom = "2025.0.6"  # https://mvnrepository.com/artifact/io.projectreactor/reactor-bom
 resilience4j = "2.4.0"  # https://mvnrepository.com/artifact/io.github.resilience4j/resilience4j-bom
 netty = "4.2.15.Final"  # https://mvnrepository.com/artifact/io.netty/netty-bom
 
-aws2 = "2.46.0"  # https://mvnrepository.com/artifact/software.amazon.awssdk/bom
+aws2 = "2.46.17"  # https://mvnrepository.com/artifact/software.amazon.awssdk/bom
 aws2-crt = "0.45.3"  # https://mvnrepository.com/artifact/software.amazon.awssdk.crt/aws-crt
-aws-kotlin = "1.6.80"  # https://mvnrepository.com/artifact/aws.sdk.kotlin/aws-core
+aws-kotlin = "1.6.102"  # https://mvnrepository.com/artifact/aws.sdk.kotlin/aws-core
 aws-spring-cloud = "4.0.2"  # https://mvnrepository.com/artifact/io.awspring.cloud/spring-cloud-aws-s3
 
 grpc = "1.81.0"  # https://mvnrepository.com/artifact/io.grpc/grpc-bom
 grpc-kotlin = "1.5.0"  # https://mvnrepository.com/artifact/io.grpc/grpc-kotlin-stub
-protobuf = "4.35.0"  # https://mvnrepository.com/artifact/com.google.protobuf/protobuf-bom
+protobuf = "4.35.1"  # https://mvnrepository.com/artifact/com.google.protobuf/protobuf-bom
 grpc-google-common-protos = "2.71.0"  # https://mvnrepository.com/artifact/com.google.api.grpc/grpc-google-common-protos
 avro = "1.12.1"  # https://mvnrepository.com/artifact/org.apache.avro/avro
 
@@ -38,17 +38,17 @@ okhttp3 = "5.4.0"  # https://mvnrepository.com/artifact/com.squareup.okhttp3/okh
 okio = "3.17.0"  # https://mvnrepository.com/artifact/com.squareup.okio/okio
 asynchttpclient = "3.0.9"  # https://mvnrepository.com/artifact/org.asynchttpclient/async-http-client
 
-jackson = "2.21.4"  # https://mvnrepository.com/artifact/com.fasterxml.jackson/jackson-bom
+jackson = "2.22.0"  # https://mvnrepository.com/artifact/com.fasterxml.jackson/jackson-bom
 jackson-annotations = "2.21"  # https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-annotations
-jackson3 = "3.1.4"  # https://mvnrepository.com/artifact/tools.jackson/jackson-bom
+jackson3 = "3.2.0"  # https://mvnrepository.com/artifact/tools.jackson/jackson-bom
 fastjson2 = "2.0.62"  # https://mvnrepository.com/artifact/com.alibaba.fastjson2/fastjson2
 
 mapstruct = "1.6.3"  # https://mvnrepository.com/artifact/org.mapstruct/mapstruct
 reflectasm = "1.11.9"  # https://mvnrepository.com/artifact/com.esotericsoftware/reflectasm
 
 mongo-driver = "5.8.0"  # https://mvnrepository.com/artifact/org.mongodb/mongodb-driver-sync
-lettuce = "6.8.2.RELEASE"  # https://mvnrepository.com/artifact/io.lettuce/lettuce-core
-redisson = "4.4.0"  # https://mvnrepository.com/artifact/org.redisson/redisson
+lettuce = "7.6.0.RELEASE"  # https://mvnrepository.com/artifact/io.lettuce/lettuce-core
+redisson = "4.6.1"  # https://mvnrepository.com/artifact/org.redisson/redisson
 lz4 = "1.11.0"  # https://mvnrepository.com/artifact/at.yawk.lz4/lz4-java
 
 hibernate = "7.4.2.Final"  # https://mvnrepository.com/artifact/org.hibernate.orm/hibernate-core
@@ -65,7 +65,7 @@ mysql-connector-j = "9.7.0"  # https://mvnrepository.com/artifact/com.mysql/mysq
 mariadb-java-client = "3.5.9"  # https://mvnrepository.com/artifact/org.mariadb.jdbc/mariadb-java-client
 postgresql = "42.7.11"  # https://mvnrepository.com/artifact/org.postgresql/postgresql
 h2-v2 = "2.4.240"  # https://mvnrepository.com/artifact/com.h2database/h2
-agroal = "3.1.2"  # https://mvnrepository.com/artifact/io.agroal/agroal-pool
+agroal = "3.2"  # https://mvnrepository.com/artifact/io.agroal/agroal-pool
 
 slf4j = "2.0.18"  # https://mvnrepository.com/artifact/org.slf4j/slf4j-api
 logback = "1.5.34"  # https://mvnrepository.com/artifact/ch.qos.logback/logback-classic
@@ -93,13 +93,13 @@ cassandra = "4.19.3"  # https://mvnrepository.com/artifact/org.apache.cassandra/
 elasticsearch = "9.4.2"  # https://mvnrepository.com/artifact/org.elasticsearch.client/elasticsearch-rest-client
 
 kafka = "4.2.0"  # https://mvnrepository.com/artifact/org.apache.kafka/kafka-clients
-spring-kafka4 = "4.0.5"  # https://mvnrepository.com/artifact/org.springframework.kafka/spring-kafka
+spring-kafka4 = "4.1.0"  # https://mvnrepository.com/artifact/org.springframework.kafka/spring-kafka
 
 bucket4j = "8.19.0"  # https://mvnrepository.com/artifact/com.bucket4j/bucket4j_jdk17-caffeine
 ktor = "3.5.0"  # https://mvnrepository.com/artifact/io.ktor/ktor-server-core
-vertx = "5.0.12"  # https://mvnrepository.com/artifact/io.vertx/vertx-core
+vertx = "5.1.3"  # https://mvnrepository.com/artifact/io.vertx/vertx-core
 
-timefold-solver = "2.1.0"   # https://mvnrepository.com/artifact/ai.timefold.solver/timefold-solver-bom
+timefold-solver = "2.2.0"   # https://mvnrepository.com/artifact/ai.timefold.solver/timefold-solver-bom
 
 eclipse-collections = "13.0.0"  # https://mvnrepository.com/artifact/org.eclipse.collections/eclipse-collections
 jctools = "4.0.6"  # https://mvnrepository.com/artifact/org.jctools/jctools-core
@@ -125,15 +125,15 @@ random-beans = "3.9.0"  # https://mvnrepository.com/artifact/io.github.benas/ran
 springdoc-openapi = "3.0.3"  # https://mvnrepository.com/artifact/org.springdoc/springdoc-openapi-starter-webmvc-api
 problem = "0.29.1"  # https://mvnrepository.com/artifact/org.zalando/problem-spring-webflux
 
-scrimage = "4.6.0"  # https://mvnrepository.com/artifact/com.sksamuel.scrimage/scrimage-core
-gatling = "3.15.0"  # https://mvnrepository.com/artifact/io.gatling/gatling-app
+scrimage = "4.6.5"  # https://mvnrepository.com/artifact/com.sksamuel.scrimage/scrimage-core
+gatling = "3.15.1"  # https://mvnrepository.com/artifact/io.gatling/gatling-app
 
 # Plugin versions
 detekt = "1.23.8"  # https://mvnrepository.com/artifact/io.gitlab.arturbosch.detekt/detekt-gradle-plugin
 dependency-management = "1.1.7"  # https://mvnrepository.com/artifact/io.spring.gradle/dependency-management-plugin
 dokka = "2.2.0"  # https://mvnrepository.com/artifact/org.jetbrains.dokka/dokka-gradle-plugin
 test-logger = "4.0.0"  # https://mvnrepository.com/artifact/com.adarshr/gradle-test-logger-plugin
-shadow = "9.4.1"  # https://mvnrepository.com/artifact/com.gradleup.shadow/shadow-gradle-plugin
+shadow = "9.4.2"  # https://mvnrepository.com/artifact/com.gradleup.shadow/shadow-gradle-plugin
 graalvm-native = "1.1.1"  # https://mvnrepository.com/artifact/org.graalvm.buildtools/native-gradle-plugin
 docker-compose = "0.17.21"  # https://mvnrepository.com/artifact/com.avast.gradle/gradle-docker-compose-plugin
 protobuf-plugin = "0.10.0"  # https://mvnrepository.com/artifact/com.google.protobuf/protobuf-gradle-plugin
@@ -307,7 +307,7 @@ commons-csv = { module = "org.apache.commons:commons-csv", version = "1.14.1" } 
 commons-exec = { module = "org.apache.commons:commons-exec", version = "1.6.0" }  # https://mvnrepository.com/artifact/org.apache.commons/commons-exec
 commons-io = { module = "commons-io:commons-io", version = "2.22.0" }  # https://mvnrepository.com/artifact/commons-io/commons-io
 commons-lang3 = { module = "org.apache.commons:commons-lang3", version = "3.20.0" }  # https://mvnrepository.com/artifact/org.apache.commons/commons-lang3
-commons-logging = { module = "commons-logging:commons-logging", version = "1.3.6" }  # https://mvnrepository.com/artifact/commons-logging/commons-logging
+commons-logging = { module = "commons-logging:commons-logging", version = "1.4.0" }  # https://mvnrepository.com/artifact/commons-logging/commons-logging
 commons-math3 = { module = "org.apache.commons:commons-math3", version = "3.6.1" }  # https://mvnrepository.com/artifact/org.apache.commons/commons-math3
 commons-pool2 = { module = "org.apache.commons:commons-pool2", version = "2.13.1" }  # https://mvnrepository.com/artifact/org.apache.commons/commons-pool2
 commons-text = { module = "org.apache.commons:commons-text", version = "1.15.0" }  # https://mvnrepository.com/artifact/org.apache.commons/commons-text
@@ -319,7 +319,7 @@ guava = { module = "com.google.guava:guava", version = "33.6.0-jre" }  # https:/
 # Serialization
 kryo = { module = "com.esotericsoftware:kryo", version = "5.6.2" }  # https://mvnrepository.com/artifact/com.esotericsoftware/kryo
 kryo5 = { module = "com.esotericsoftware:kryo", version = "5.6.2" }  # https://mvnrepository.com/artifact/com.esotericsoftware/kryo
-fory-kotlin = { module = "org.apache.fory:fory-kotlin", version = "1.0.0" }  # https://mvnrepository.com/artifact/org.apache.fory/fory-kotlin
+fory-kotlin = { module = "org.apache.fory:fory-kotlin", version = "1.3.0" }  # https://mvnrepository.com/artifact/org.apache.fory/fory-kotlin
 
 # Spring Boot
 spring-boot4-dependencies = { module = "org.springframework.boot:spring-boot-dependencies", version.ref = "spring-boot4" }
@@ -529,7 +529,7 @@ jackson3-module-blackbird = { module = "tools.jackson.module:jackson-module-blac
 # Compression
 snappy-java = { module = "org.xerial.snappy:snappy-java", version = "1.1.10.8" }  # https://mvnrepository.com/artifact/org.xerial.snappy/snappy-java
 lz4-java = { module = "at.yawk.lz4:lz4-java", version.ref = "lz4" }
-zstd-jni = { module = "com.github.luben:zstd-jni", version = "1.5.7-9" }  # https://mvnrepository.com/artifact/com.github.luben/zstd-jni
+zstd-jni = { module = "com.github.luben:zstd-jni", version = "1.5.7-11" }  # https://mvnrepository.com/artifact/com.github.luben/zstd-jni
 
 # Reactor
 reactor-core = { module = "io.projectreactor:reactor-core" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -79,9 +79,9 @@ micrometer-tracing = "1.7.0"  # https://mvnrepository.com/artifact/io.micrometer
 micrometer-context-propagation = "1.2.1"  # https://mvnrepository.com/artifact/io.micrometer/context-propagation
 
 opentelemetry = "1.63.0"  # https://mvnrepository.com/artifact/io.opentelemetry/opentelemetry-bom
-opentelemetry-alpha = "1.64.0-alpha-SNAPSHOT"  # https://mvnrepository.com/artifact/io.opentelemetry/opentelemetry-bom-alpha
-opentelemetry-java-agent = "2.27.0"  # https://mvnrepository.com/artifact/io.opentelemetry.javaagent/opentelemetry-javaagent
-opentelemetry-instrumentation-alpha = "2.29.0-alpha-SNAPSHOT"  # https://mvnrepository.com/artifact/io.opentelemetry.instrumentation/opentelemetry-instrumentation-bom-alpha
+opentelemetry-alpha = "1.63.0-alpha"  # https://mvnrepository.com/artifact/io.opentelemetry/opentelemetry-bom-alpha
+opentelemetry-java-agent = "2.29.0"  # https://mvnrepository.com/artifact/io.opentelemetry.javaagent/opentelemetry-javaagent
+opentelemetry-instrumentation-alpha = "2.29.0-alpha"  # https://mvnrepository.com/artifact/io.opentelemetry.instrumentation/opentelemetry-instrumentation-bom-alpha
 
 caffeine = "3.2.4"  # https://mvnrepository.com/artifact/com.github.ben-manes.caffeine/caffeine
 ehcache = "3.12.0"  # https://mvnrepository.com/artifact/org.ehcache/ehcache

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,7 +39,7 @@ okio = "3.17.0"  # https://mvnrepository.com/artifact/com.squareup.okio/okio
 asynchttpclient = "3.0.9"  # https://mvnrepository.com/artifact/org.asynchttpclient/async-http-client
 
 jackson = "2.22.0"  # https://mvnrepository.com/artifact/com.fasterxml.jackson/jackson-bom
-jackson-annotations = "2.21"  # https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-annotations
+jackson-annotations = "2.22"  # https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-annotations
 jackson3 = "3.2.0"  # https://mvnrepository.com/artifact/tools.jackson/jackson-bom
 fastjson2 = "2.0.62"  # https://mvnrepository.com/artifact/com.alibaba.fastjson2/fastjson2
 


### PR DESCRIPTION
## Summary
- Pins this repository to `catalog/2026-06-25-05` from `bluetape4k-dependencies`.
- Aligns centrally governed shared dependency versions with the June 25 catalog train.
- Includes local API adaptations where the upgraded dependency set changed or removed APIs.

## DoD Status
- [x] Catalog reference points at immutable `catalog/2026-06-25-05` where this repository supports catalog refs.
- [x] Shared version catalog is aligned with `bluetape4k-dependencies`.
- [x] Deprecated or removed API usages that blocked compile were replaced.
- [x] `git diff --check` passed.
- [x] Compile-level verification was run for this catalog train.
- [ ] Full repository test suite was not run.
